### PR TITLE
Skip .* files/folders and non txt files for presets indexing

### DIFF
--- a/indexer/PresetsFolder.js
+++ b/indexer/PresetsFolder.js
@@ -18,14 +18,16 @@ class PresetsFolder
         list.forEach((fileName) => {
             const fullFileName = fullPath + '/' + fileName;
             const stat = fs.statSync(fullFileName);
-            if (stat && stat.isDirectory()) {
-                let subdir = new PresetsFolder(fullFileName, settings, presetFilesArray, errors);
-                subdir.name = fileName;
-                this.subFolders.push(subdir);
-            } else {
-                let presetsFile = new PresetsFile(fullFileName, settings, errors);
-                presetFilesArray.push(presetsFile);
-                this.files.push(presetsFile);
+            if (!fileName.startsWith(".")) {
+                if (stat && stat.isDirectory()) {
+                    let subdir = new PresetsFolder(fullFileName, settings, presetFilesArray, errors);
+                    subdir.name = fileName;
+                    this.subFolders.push(subdir);
+                } else if (fileName.toLowerCase().endsWith(".txt")) {
+                    let presetsFile = new PresetsFile(fullFileName, settings, errors);
+                    presetFilesArray.push(presetsFile);
+                    this.files.push(presetsFile);
+                }
             }
         });
     }


### PR DESCRIPTION
After discussion with @ctzsnooze figured we need to skip .* files and folders while indexing presets.
Also decided to skip all non-txt files to be safe.