### PR TITLE
Added indexer/check.js to run verifications without creating index.json

### DIFF
--- a/indexer/check.js
+++ b/indexer/check.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const child = require('child_process').fork('indexer/indexer.js', ["nosave"]);
+child.on('exit', (code) => {
+    process.exitCode = code;
+});

--- a/indexer/indexer.js
+++ b/indexer/indexer.js
@@ -9,23 +9,36 @@ const crypto = require('crypto');
 const errors = [];
 process.exitCode = 100;
 
+let writeIndexFile = true;
+
+if (process.argv.length === 3) {
+    if (process.argv[2] === "nosave") {
+        writeIndexFile = false;
+    }
+}
+
 let presetFilesArray = [];
 let presetsFolder = new PresetsFolder(settings.presetsDir, settings, presetFilesArray, errors);
 
 //console.log(getUniqueValues(presetFilesArray, "firmwareVersion"));
 
-if (0 === errors.length)
-{
-    const indexContent = new IndexContent(presetFilesArray, settings);
-    const jsonIndexContent = JSON.stringify(indexContent, null, 2);
-    fs.writeFileSync("index.json", jsonIndexContent);
-    console.log("OK: index.json created");
+if (0 === errors.length) {
+    console.log("OK");
 
-    const sum = crypto.createHash('sha256');
-    sum.update(jsonIndexContent);
-    const indexHash = sum.digest('hex');
-    fs.writeFileSync("index_hash.txt", indexHash);
-    console.log("OK: index_hash.txt created");
+    if (writeIndexFile) {
+        const indexContent = new IndexContent(presetFilesArray, settings);
+        const jsonIndexContent = JSON.stringify(indexContent, null, 2);
+        fs.writeFileSync("index.json", jsonIndexContent);
+        console.log("index.json created");
 
-    process.exitCode = 0;
+        const sum = crypto.createHash('sha256');
+        sum.update(jsonIndexContent);
+        const indexHash = sum.digest('hex');
+        fs.writeFileSync("index_hash.txt", indexHash);
+        console.log("index_hash.txt created");
+
+        process.exitCode = 0;
+    }
+} else {
+    console.log("Failed with errors");
 }


### PR DESCRIPTION
usage:
`node indexer/indexer.js` - runs verifications for presets, creates index.json
`node indexer/indexer.js nosave` - just runs verifications
`node indexer/check.js` - just runs verifications, same as `node indexer/indexer.js nosave`

exit code 0 - no errors