### PR TITLE
Added properties: nosearch and discusssion

### DIFF
--- a/indexer/Settings.js
+++ b/indexer/Settings.js
@@ -18,7 +18,7 @@ const PresetCategories = {
     LEDS:           "LEDS",
     MODES:          "MODES",
     RC_SMOOTHING:   "RC_SMOOTHING",
-    FILTERS:         "FILTERS",
+    FILTERS:        "FILTERS",
     RC_LINK:        "RC_LINK",
     BNF:            "BNF",
     OTHER:          "OTHER",
@@ -51,6 +51,8 @@ const settings = {
         description:       {type: MetadataTypes.STRING_ARRAY,     optional: true   },
         include:           {type: MetadataTypes.FILE_PATH_ARRAY,  optional: true   },
         keywords:          {type: MetadataTypes.WORDS_ARRAY,      optional: true   },
+        nosearch:          {type: MetadataTypes.BOOLEAN,          optional: true   },
+        discussion:        {type: MetadataTypes.STRING,           optional: true   },
     }),
 }
 


### PR DESCRIPTION
Adding optional properties:
`# nosearch: true/false`
if set to TRUE then the current preset will be excluded from the user search in the configurator.
Allows to create service presets for including into other presets without confusing end-user.

`# discussion: https://your.link`
Allows adding a link to the discussion of the current preset. For example, it could be a pull request link. (idea by @ctzsnooze )