### PR TITLE
Updated to use the branch 'main' for default, and automatically trigger a run on a pull request.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
-name: CI - Build only (deploy if master)
+name: CI - Indexer job (deploy if default branch - i.e. main)
 
-on: 
-  push:
-    branches:
-    - '**'
+on: [push, pull_request]
 
 jobs:
   build:
@@ -21,12 +18,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - if: github.ref != 'refs/heads/master' 
-      name: Run the build (only) script
+    - if: github.ref != 'refs/heads/main' 
+      name: Run the checker script
       run: ./scripts/build.sh
 
-    - if: github.ref == 'refs/heads/master' 
-      name: Run the build & deploy script
+    - if: github.ref == 'refs/heads/main' 
+      name: Run the checker, indexer and deployment script
       run: ./scripts/build.sh deploy
       env:
         AWS_DISTRIBUTION_ID: ${{secrets.AWS_DISTRIBUTION_ID}}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,14 +18,19 @@ echo "Bucket:    ${AWS_BUCKET}"
 mkdir -p ${artifacts}
 
 node --version
-node indexer/indexer.js
-
-echo "Copying files to staging location: ${artifacts}"
-cp ./index.json $artifacts
-cp ./index_hash.txt $artifacts 
-cp -r ./presets/* $artifacts
+node indexer/check.js
 
 if [ "${1}" == "deploy" ]; then
+
+  echo "Running indexer"
+  node indexer/indexer.js
+
+  echo "Copying files to staging location: ${artifacts}"
+  cp ./index.json $artifacts
+  cp ./index_hash.txt $artifacts 
+  cp -r ./presets/* $artifacts
+
+  echo "Deploying to AWS S3: ${AWS_BUCKET}"
   aws configure set preview.cloudfront true
   aws s3 sync ${artifacts} s3://${AWS_BUCKET}/presets --delete --region "${AWS_REGION}" --cache-control max-age=345600
   aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --path "/presets/*"


### PR DESCRIPTION
The github action occurs on pull request, and runs the check, and a index (but it goes nowhere). For a merge to main it runs the same, but also deploys all the index files and content to https://api.betaflight.com/presets

So the effect is we no longer need to merge in the `index_hash.json` and `index.json`  because these will simply be deployed to S3 when a merge to `main` occurs. They are then accessible via:
1. https://api.betaflight.com/presets/index.json 
2. https://api.betaflight.com/presets/index_hash.json 

A corresponding change will need to be made to the configurator to look at these new locations rather than the "raw" github storage for the index files. Note that the preset files are also deployed to S3, so they can all be obtained via https://api.betaflight.com/presets