### PR TITLE
Create vtx_table_template.txt

### DIFF
--- a/presets/4.3/vtx/vtx_table_template.txt
+++ b/presets/4.3/vtx/vtx_table_template.txt
@@ -2,6 +2,7 @@
 # FirmwareVersion: 4.3
 # Category: VTX
 # Official: false
+# Nosearch: false (set to true for actual VTX table)
 # Keywords: vtx, vtx table
 # Author: first last pilot name 
 # Description: fill this in with description (the below txt must be included in a vtx table and official MUST be set to off for legal reasons)
@@ -10,4 +11,4 @@
 # Description: ----------
 # Description: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets  the user assumes all liability associated  with breaching local regulations 
 
-# add vtx table here 
+# Add vtx table here 


### PR DESCRIPTION
> created a VTX table preset template that includes the legal disclaimer and the setting  Official: false

template looks like this 

```
# Title: Default 4.3 VTX table template
# FirmwareVersion: 4.3
# Category: VTX
# Official: false
# Keywords: vtx, vtx table
# Author: first last pilot name 
# Description: fill this in with description ( the below txt must be included in a vtx table and official MUST be set to off for legal reasons )
#Description: Note this table is as provided by the manufacture
# Description: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes not representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations. 
# Description: ----------
# Description: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and In using these presets  the user assumes all liability associated  with breaching local regulations 

# add vtx table here 


```