### PR TITLE
RC_LINK - ELRS updated with Options for flight purpose

### DIFF
--- a/presets/4.3/rc_link/elrs_150hz.txt
+++ b/presets/4.3/rc_link/elrs_150hz.txt
@@ -25,8 +25,24 @@ set report_cell_voltage = ON
 set report_cell_voltage = OFF
 #$ OPTION END
 
-# stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
+# sharper handling for racing:
+#$ OPTION BEGIN (UNCHECKED) Race feedforward settings
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 25
+set set feedforward_jitter_reduction = 5
+#$ OPTION END
+
+# stronger smoothing for HD freestyle:
+#$ OPTION BEGIN (UNCHECKED) HD Freestyle feedforward settings
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 45
+set set feedforward_jitter_reduction = 10
+#$ OPTION END
+
+# stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED) Cinematic feedforward settings
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 60
+set set feedforward_jitter_reduction = 14
 #$ OPTION END
+

--- a/presets/4.3/rc_link/elrs_250hz.txt
+++ b/presets/4.3/rc_link/elrs_250hz.txt
@@ -19,14 +19,29 @@ set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 35
 set feedforward_jitter_reduction = 6
 
-# per cell or whole pack voltage readings:
+# per cell or whole pack voltage readings back via telemetry to Tx:
 set report_cell_voltage = ON
-#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings to Tx
 set report_cell_voltage = OFF
 #$ OPTION END
 
-# stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
+# sharper handling for racing:
+#$ OPTION BEGIN (UNCHECKED) Race feedforward settings
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 25
+set set feedforward_jitter_reduction = 5
+#$ OPTION END
+
+# stronger smoothing for HD freestyle (not for racing):
+#$ OPTION BEGIN (UNCHECKED) HD Freestyle feedforward settings
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 50
+set set feedforward_jitter_reduction = 10
+#$ OPTION END
+
+# stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED) Cinematic feedforward settings
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 65
+set set feedforward_jitter_reduction = 12
 #$ OPTION END

--- a/presets/4.3/rc_link/elrs_500hz.txt
+++ b/presets/4.3/rc_link/elrs_500hz.txt
@@ -13,21 +13,35 @@
 feature RX_SERIAL
 set serialrx_provider = CRSF
 
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
-set feedforward_jitter_reduction = 5
-
 # rc smoothing should always be enabled with ELRS
 set rc_smoothing = ON
 
-# per cell or whole pack voltage readings:
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 35
+set feedforward_jitter_reduction = 5
+
+# per cell or whole pack voltage readings back via telemetry to Tx:
 set report_cell_voltage = ON
-#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings to Tx
 set report_cell_voltage = OFF
 #$ OPTION END
 
-# stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
+# sharper handling for racing:
+#$ OPTION BEGIN (UNCHECKED) Race feedforward settings
+set feedforward_smooth_factor = 65
+set set feedforward_jitter_reduction = 4
+#$ OPTION END
+
+# stronger smoothing for HD freestyle:
+#$ OPTION BEGIN (UNCHECKED) HD Freestyle feedforward settings
 set feedforward_averaging = 3_POINT
 set feedforward_smooth_factor = 70
+set set feedforward_jitter_reduction = 9
+#$ OPTION END
+
+# stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED) Cinematic feedforward settings
+set feedforward_averaging = 3_POINT
+set feedforward_smooth_factor = 75
+set set feedforward_jitter_reduction = 12
 #$ OPTION END

--- a/presets/4.3/rc_link/elrs_50hz.txt
+++ b/presets/4.3/rc_link/elrs_50hz.txt
@@ -17,7 +17,7 @@ set rc_smoothing = ON
 
 set feedforward_averaging = OFF
 set feedforward_smooth_factor = 0
-set feedforward_jitter_reduction = 15
+set feedforward_jitter_reduction = 12
 
 # per cell or whole pack voltage readings:
 set report_cell_voltage = ON
@@ -25,7 +25,19 @@ set report_cell_voltage = ON
 set report_cell_voltage = OFF
 #$ OPTION END
 
-# stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
+# sharper handling for racing - note that 50hz is too slow for racing
+#$ OPTION BEGIN (UNCHECKED) Race feedforward settings
+set set feedforward_jitter_reduction = 7
+#$ OPTION END
+
+# stronger smoothing for HD freestyle (not for racing):
+#$ OPTION BEGIN (UNCHECKED) HD Freestyle feedforward settings
+set feedforward_smooth_factor = 25
+set set feedforward_jitter_reduction = 15
+#$ OPTION END
+
+# stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED) Cinematic feedforward settings
 set feedforward_smooth_factor = 50
+set set feedforward_jitter_reduction = 20
 #$ OPTION END


### PR DESCRIPTION
Include options to 'optimise' link behaviour for specific flight applications, eg, Race, HD freestyle, Cinematic.
The default if no option is selected, is suitable for general use.