### PR TITLE
RC_LINK : update frsky with more options for flight style

### DIFF
--- a/presets/4.3/rc_link/frsky_sbus.txt
+++ b/presets/4.3/rc_link/frsky_sbus.txt
@@ -7,16 +7,17 @@
 # Description: Basic RC link settings for a 111hz / 9ms FrSky Sbus link, with the Rx bound in D16 mode with no more than 8 channels
 # Description: These settings work best when used with a version of OpenTx with good module sync
 # Description: Note: Telemetry requires smartPort (s.Port) and does not convey RSSI (use Lua or analog RSSI)
-# Description: Note: When more than 8 channels are used, manual RC smoothing settings and two point averaging is required
+# Description: Note: When more than 8 channels are bound, manual RC smoothing settings and two point averaging is required
 # Description: Early versions of OpenTx with poor module sync will require two point averaging
 # Description: Cell vs full voltage option affects which value will be sent by telemetry to the handset.  Default is per cell.
 # Description: Units default to metric. Telemetry defaults to non-inverted and half-duple.  Both can be changed with checkbox
 # Description: Other telemetry settings,eg gps format, default latitude and longitude, extra sensors, require manual CLI entries
+# Description: Other options are provided for the intended flying style.
 
 feature RX_SERIAL
 set serialrx_provider = SBUS
 set feedforward_averaging = OFF
-set feedforward_smooth_factor = 20
+set feedforward_smooth_factor = 25
 set feedforward_jitter_reduction = 7
 set frsky_vfas_precision = 1
 
@@ -51,4 +52,30 @@ set tlm_inverted = ON
 set tlm_halfduplex = ON
 # option begin (unchecked) Full duplex telemetry
 set tlm_halfduplex = OFF
+# option end
+
+# if bound in D16 with more than 8 channels - sends duplicates all the time - too slow for racing
+# option begin (unchecked) Bound with >8 channels
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 35
+# option end
+
+# sharper handling for racing:
+# option begin (unchecked) Race
+set feedforward_smooth_factor = 20
+set set feedforward_jitter_reduction = 5
+# option end
+
+# stronger smoothing for HD freestyle (not for racing):
+# option begin (unchecked) HD Freestyle
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 45
+set set feedforward_jitter_reduction = 12
+# option end
+
+# stronger smoothing for Cinematic flying (not for racing):
+# option begin (unchecked) Cinematic
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 60
+set set feedforward_jitter_reduction = 15
 # option end


### PR DESCRIPTION
Includes race, HD freestyle, and cinematic alternatives to general purpose defaults.
Includes an option for people who run more than 8 channel modes, which always sends duplicate data every second packet.  This is not recommended for either racing or freestyle since it is very slow.