### PR TITLE
Karate filter array

### DIFF
--- a/presets/4.3/filters/karate_array.txt
+++ b/presets/4.3/filters/karate_array.txt
@@ -1,0 +1,44 @@
+#$ TITLE: the Karate array 
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, karate, race, freesytle, suagrK, CTZsoonze, KarateBrot, 5"
+#$ AUTHOR: sugarK
+#$ DESCRIPTION: the Karate fitler array as developed by @CTZsoonze and @sugarK for 4.3 using @karateBrot's rpm cross fade code.
+#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
+#$ DESCRIPTION: This filtering array will work with most 5" race and freesytle builds that have a solid airframe and motors in good condition. 
+#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK. 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/51
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_dyn_min_hz = 500
+set gyro_lpf1_dyn_max_hz = 1000
+set simplified_gyro_filter = OFF
+set simplified_gyro_filter_multiplier = 140
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 200
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 2
+set rpm_filter_fade_range_hz = 100
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 10
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 100
+
+
+# OPTION BEGIN (UNCHECKED): Dshot300
+set motor_pwm_protocol = Dshot300
+# OPTION END
+
+# OPTION BEGIN (UNCHECKED): Dshot600
+set motor_pwm_protocol = DSHOT600
+# OPTION END


### PR DESCRIPTION
this is the karate filter array. It has had extensive testing over the few months on a wide range of machines both race and freestyle based 5" machines.. Vs 4.2 run with no gyro LPF only rpm and the FFT notch this produces around half the gyro filter phase delay using this setup...  While over personally run it on every thing from my betaFPV65 to my 6" LoRanger 99% of other user testing has been on 5" quads 