### PR TITLE
Metaproperty hashtag change

### DIFF
--- a/indexer/PresetsFile.js
+++ b/indexer/PresetsFile.js
@@ -60,8 +60,8 @@ class PresetsFile
 
         for (let line of lines) {
             line = line.trim();
-            if (line.startsWith("#")) {
-                this._processCommentLine(line);
+            if (line.startsWith(this._settings.MetapropertyDirective)) {
+                this._processMetapropertyLine(line);
             }
 
             this._currentLine++;
@@ -70,11 +70,12 @@ class PresetsFile
         delete this._currentLine;
     }
 
-    _processCommentLine(line)
+    _processMetapropertyLine(line)
     {
-        line = line.slice(1).trim(); // (# Title: foo) -> (Title: foo)
+        line = line.slice(this._settings.MetapropertyDirective.length).trim(); // (#$ Title: foo) -> (Title: foo)
         const lowCaseLine = line.toLowerCase();
         let isProperty = false;
+        let isOptionDirective = false;
 
         for (const [property, value] of Object.entries(this._presetsFileMetadata)) {
             const lineBeginning = `${property.toLowerCase()}:`; // "Title:"
@@ -88,6 +89,11 @@ class PresetsFile
 
         if (!isProperty && lowCaseLine.startsWith(this._settings.OptionsDirectives.OPTION_DIRECTIVE)) {
             this._processOptionDirective(line);
+            isOptionDirective = true;
+        }
+
+        if (!isProperty && !isOptionDirective) {
+                this._addError(`line ${this._currentLine}, unknown preset directive: '${line}'`);
         }
     }
 

--- a/indexer/Settings.js
+++ b/indexer/Settings.js
@@ -33,6 +33,8 @@ const OptionsDirectives = {
 }
 
 const settings = {
+    MetapropertyDirective: "#$",
+
     PresetCategories: Object.freeze(PresetCategories),
 
     MetadataTypes: Object.freeze(MetadataTypes),
@@ -44,7 +46,7 @@ const settings = {
 
     presetsFileMetadata: Object.freeze({
         title:             {type: MetadataTypes.STRING,           optional: false  },
-        firmwareVersion:   {type: MetadataTypes.STRING_ARRAY,     optional: false  },
+        firmware_version:  {type: MetadataTypes.STRING_ARRAY,     optional: false  },
         category:          {type: MetadataTypes.PRESET_CATEGORY,  optional: false  },
         official:          {type: MetadataTypes.BOOLEAN,          optional: false  },
         author:            {type: MetadataTypes.STRING,           optional: true   },

--- a/presets/4.3/filters/defaults.txt
+++ b/presets/4.3/filters/defaults.txt
@@ -1,10 +1,10 @@
-# Title: Default 4.3 Filter settings
-# FirmwareVersion: 4.3
-# Category: FILTERS
-# Official: true
-# Keywords: defaults, filter, filters, reset
-# Author: Betaflight
-# Description: Resets Filter settings to 4.3 defaults
+#$ TITLE: Default 4.3 Filter settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, filter, filters, reset
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets Filter settings to 4.3 defaults
 
 set gyro_lpf1_type = PT1
 set gyro_lpf1_static_hz = 250

--- a/presets/4.3/leds/defaults.txt
+++ b/presets/4.3/leds/defaults.txt
@@ -1,11 +1,11 @@
-# Title: Default 4.3 LED settings
-# FirmwareVersion: 4.3
-# Category: LEDS
-# Official: true
-# Keywords: defaults, reset, leds
-# Author: Betaflight
-# Description: Resets LED settings to 4.3 defaults
-# Description: Options: LED, colour or mode_color resets.
+#$ TITLE: Default 4.3 LED settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: LEDS
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, leds
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets LED settings to 4.3 defaults
+#$ DESCRIPTION: Options: LED, colour or mode_color resets.
 
 # led designations
 

--- a/presets/4.3/modes/defaults.txt
+++ b/presets/4.3/modes/defaults.txt
@@ -1,10 +1,10 @@
-# Title: Default 4.3 Modes and Adjustment settings
-# FirmwareVersion: 4.3
-# Category: MODES
-# Official: true
-# Keywords: defaults, reset, mode, modes, adjustments, aux, switch
-# Author: Betaflight
-# Description: Resets modes and adjustment ranges to 4.3 defaults
+#$ TITLE: Default 4.3 Modes and Adjustment settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: MODES
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, mode, modes, adjustments, aux, switch
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets modes and adjustment ranges to 4.3 defaults
 
 # aux switch settings
 

--- a/presets/4.3/osd/defaults.txt
+++ b/presets/4.3/osd/defaults.txt
@@ -1,10 +1,10 @@
-# Title: Default 4.3 OSD settings
-# FirmwareVersion: 4.3
-# Category: OSD
-# Official: true
-# Keywords: defaults, reset, OSD
-# Author: Betaflight
-# Description: Resets the OSD values back to Betaflight 4.3 defaults
+#$ TITLE: Default 4.3 OSD settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OSD
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, OSD
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the OSD values back to Betaflight 4.3 defaults
 
 set osd_units = METRIC
 set osd_warn_arming_disable = ON

--- a/presets/4.3/other/reset_blackbox.txt
+++ b/presets/4.3/other/reset_blackbox.txt
@@ -1,10 +1,10 @@
-# Title: Reset 4.3 Blackbox settings
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset, blackbox, logging, log
-# Author: Betaflight
-# Description: Resets the 4.3 blackbox settings back to defaults
+#$ TITLE: Reset 4.3 Blackbox settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, blackbox, logging, log
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the 4.3 blackbox settings back to defaults
 
 set blackbox_sample_rate = 1/4
 set blackbox_device = SPIFLASH

--- a/presets/4.3/other/reset_camera_control.txt
+++ b/presets/4.3/other/reset_camera_control.txt
@@ -1,10 +1,10 @@
-# Title: Reset Camera Control settings
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset, names, camera, control, camera_control
-# Author: Betaflight
-# Description: Resets the Camera Control settings to 4.3 defaults
+#$ TITLE: Reset Camera Control settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, names, camera, control, camera_control
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the Camera Control settings to 4.3 defaults
 
 set camera_control_mode = HARDWARE_PWM
 set camera_control_ref_voltage = 330

--- a/presets/4.3/other/reset_gps.txt
+++ b/presets/4.3/other/reset_gps.txt
@@ -1,11 +1,11 @@
-# Title: Reset GPS settings
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset, GPS
-# Author: Betaflight
-# Description: Resets the GPS settings to 4.3 defaults
-# Description: Optionally enable GPS feature, default is off
+#$ TITLE: Reset GPS settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, GPS
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the GPS settings to 4.3 defaults
+#$ DESCRIPTION: Optionally enable GPS feature, default is off
 
 set gps_provider = NMEA
 set gps_sbas_mode = NONE
@@ -44,6 +44,6 @@ set gps_rescue_use_mag = ON
 
 feature -GPS
 
-# option begin (unchecked) enable GPS?
+#$ OPTION BEGIN (UNCHECKED) enable GPS?
 feature GPS
-# option end
+#$ OPTION END

--- a/presets/4.3/other/reset_launch_mode.txt
+++ b/presets/4.3/other/reset_launch_mode.txt
@@ -1,10 +1,10 @@
-# Title: Reset Launch Mode settings
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset, names, launch, launch_mode
-# Author: Betaflight
-# Description: Resets the Launch Mode settings to 4.3 defaults
+#$ TITLE: Reset Launch Mode settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, names, launch, launch_mode
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the Launch Mode settings to 4.3 defaults
 
 set launch_control_mode = NORMAL
 set launch_trigger_allow_reset = ON

--- a/presets/4.3/other/reset_names.txt
+++ b/presets/4.3/other/reset_names.txt
@@ -1,10 +1,10 @@
-# Title: Reset 4.3 Names
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset, names, profile
-# Author: Betaflight
-# Description: Resets the craft names and optionally resets profile names
+#$ TITLE: Reset 4.3 Names
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, names, profile
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the craft names and optionally resets profile names
 
 set name = -
 set display_name = -
@@ -13,17 +13,17 @@ set box_user_2_name = -
 set box_user_3_name = -
 set box_user_4_name = -
 
-# option begin (checked) reset profile 1 name?
+#$ OPTION BEGIN (CHECKED) reset profile 1 name?
 profile 1
 set profile_name = -
-# option end
+#$ OPTION END
 
-# option begin (checked) reset profile 1 name?
+#$ OPTION BEGIN (CHECKED) reset profile 1 name?
 profile 2
 set profile_name = -
-# option end
+#$ OPTION END
 
-# option begin (checked) reset profile 1 name?
+#$ OPTION BEGIN (CHECKED) reset profile 1 name?
 profile 3
 set profile_name = -
-# option end
+#$ OPTION END

--- a/presets/4.3/other/reset_servo.txt
+++ b/presets/4.3/other/reset_servo.txt
@@ -1,10 +1,10 @@
-# Title: Reset 4.3 Stats
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset statistics, stats
-# Author: Betaflight
-# Description: Resets the 4.3 servo settings back to defaults
+#$ TITLE: Reset 4.3 Stats
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset statistics, stats
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the 4.3 servo settings back to defaults
 
 # reset servo
 servo 0 1000 2000 1500 100 -1

--- a/presets/4.3/other/reset_stats.txt
+++ b/presets/4.3/other/reset_stats.txt
@@ -1,10 +1,10 @@
-# Title: Reset 4.3 Stats
-# FirmwareVersion: 4.3
-# Category: OTHER
-# Official: true
-# Keywords: defaults, reset statistics, stats
-# Author: Betaflight
-# Description: Resets the saved flight stats values back to zero
+#$ TITLE: Reset 4.3 Stats
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset statistics, stats
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets the saved flight stats values back to zero
 
 set stats_min_armed_time_s = -1
 set stats_total_flights = 0

--- a/presets/4.3/rates/BMSThomas.txt
+++ b/presets/4.3/rates/BMSThomas.txt
@@ -1,11 +1,11 @@
-# Title: BMSThomas racing/freestyle rates
-# FirmwareVersion: 4.3
-# Category: RATES
-# Official: false
-# Keywords: racing
-# Author: Thomas "BMSThomas" Bitmatta
-# Description: Racing and freestyle rates by BMSThomas - MultiGP International Open 2019 champion
-# Description: ACTUAL rates with 720 degrees/sec max
+#$ TITLE: BMSThomas racing/freestyle rates
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RATES
+#$ OFFICIAL: false
+#$ KEYWORDS: racing
+#$ AUTHOR: Thomas "BMSThomas" Bitmatta
+#$ DESCRIPTION: Racing and freestyle rates by BMSThomas - MultiGP International Open 2019 champion
+#$ DESCRIPTION: ACTUAL rates with 720 degrees/sec max
 
 set rates_type = ACTUAL
 set roll_rc_rate = 19

--- a/presets/4.3/rates/defaults.txt
+++ b/presets/4.3/rates/defaults.txt
@@ -1,13 +1,13 @@
-# Title: Default rates
-# FirmwareVersion: 4.3
-# Category: RATES
-# Official: true
-# Keywords: defaults, rates
-# Author: Betaflight
-# Description: Default Betaflight rates
-# Description: Will be applied for the currently selected rate profile
-# Description: TPA values are not included
-# Description: Throttle limit and curve are not included
+#$ TITLE: Default rates
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RATES
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, rates
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Default Betaflight rates
+#$ DESCRIPTION: Will be applied for the currently selected rate profile
+#$ DESCRIPTION: TPA values are not included
+#$ DESCRIPTION: Throttle limit and curve are not included
 
 set rates_type = BETAFLIGHT
 set quickrates_rc_expo = OFF

--- a/presets/4.3/rc_link/Crossfire_150hz_locked _CFV3.txt
+++ b/presets/4.3/rc_link/Crossfire_150hz_locked _CFV3.txt
@@ -1,13 +1,13 @@
-# Title: TBS Crossfire 150hz locked  CFV3
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords:  rc link, TBS, cfv3, 150hz, Crossfire
-# Author: Zak Smiley sugarK
-# Description: setup for TBS Crossfire 150hz locked  CFV3
-# Description: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
-# Description: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-# Description: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
+#$ TITLE: TBS Crossfire 150hz locked  CFV3
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS:  rc link, TBS, cfv3, 150hz, Crossfire
+#$ AUTHOR: Zak Smiley sugarK
+#$ DESCRIPTION: setup for TBS Crossfire 150hz locked  CFV3
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
+#$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
 
 feature RX_SERIAL
 set serialrx_provider = CRSF

--- a/presets/4.3/rc_link/Crossfire_150hz_locked_CFV2.txt
+++ b/presets/4.3/rc_link/Crossfire_150hz_locked_CFV2.txt
@@ -1,13 +1,13 @@
-# Title: TBS Crossfire 150hz locked  CFV2
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: defaults, rc link, tracer, TBS, cfv2, 150hz, Crossfire
-# Author: Zak Smiley sugarK
-# Description: setup for TBS Crossfire 150hz locked  CFV2
-# Description: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
-# Description: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-# Description: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
+#$ TITLE: TBS Crossfire 150hz locked  CFV2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, rc link, tracer, TBS, cfv2, 150hz, Crossfire
+#$ AUTHOR: Zak Smiley sugarK
+#$ DESCRIPTION: setup for TBS Crossfire 150hz locked  CFV2
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
+#$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
 
 feature RX_SERIAL
 set serialrx_provider = CRSF

--- a/presets/4.3/rc_link/Crossfire_50hz_locked_CFV2_CFV3.txt
+++ b/presets/4.3/rc_link/Crossfire_50hz_locked_CFV2_CFV3.txt
@@ -1,13 +1,13 @@
-# Title: TBS Crossfire 50hz locked  CFV2/CFV3
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: defaults, rc link, TBS, cfv2, 50hz, Crossfire
-# Author: Zak Smiley sugarK
-# Description: setup for TBS Crossfire 50hz locked  CFV2
-# Description: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
-# Description: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-# Description: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
+#$ TITLE: TBS Crossfire 50hz locked  CFV2/CFV3
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, rc link, TBS, cfv2, 50hz, Crossfire
+#$ AUTHOR: Zak Smiley sugarK
+#$ DESCRIPTION: setup for TBS Crossfire 50hz locked  CFV2
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
+#$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
 
 feature RX_SERIAL
 set serialrx_provider = CRSF

--- a/presets/4.3/rc_link/Crossfire_dyanmic_rate.txt
+++ b/presets/4.3/rc_link/Crossfire_dyanmic_rate.txt
@@ -1,13 +1,13 @@
-# Title: TBS Crossfire Dynamic rate CFV2/CFV3
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: rc link, TBS, cfv2, 150hz, Crossfire ,dynamic, cfv3
-# Author: Zak Smiley sugarK
-# Description: setup for TBS Crossfire dynamic rate  CFV2/CFV3
-# Description: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
-# Description: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-# Description: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua. Also frankly we DO NOT recommend this TX setting, preferring one or the other of the locked modes as the RC smoothing can only be optimised for one of the frequency modes
+#$ TITLE: TBS Crossfire Dynamic rate CFV2/CFV3
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: rc link, TBS, cfv2, 150hz, Crossfire ,dynamic, cfv3
+#$ AUTHOR: Zak Smiley sugarK
+#$ DESCRIPTION: setup for TBS Crossfire dynamic rate  CFV2/CFV3
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
+#$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua. Also frankly we DO NOT recommend this TX setting, preferring one or the other of the locked modes as the RC smoothing can only be optimised for one of the frequency modes
 
 feature RX_SERIAL
 set serialrx_provider = CRSF

--- a/presets/4.3/rc_link/Tracer_CFV2.txt
+++ b/presets/4.3/rc_link/Tracer_CFV2.txt
@@ -1,13 +1,13 @@
-# Title: TBS Tacer CFV2
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: defaults, rc link, tracer, TBS, cfv2, 250hz
-# Author: Zak Smiley sugarK
-# Description: setup fo the various TBS radio links via CRSF
-# Description: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
-# Description: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-# Description: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
+#$ TITLE: TBS Tacer CFV2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, rc link, tracer, TBS, cfv2, 250hz
+#$ AUTHOR: Zak Smiley sugarK
+#$ DESCRIPTION: setup fo the various TBS radio links via CRSF
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
+#$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
 
 feature RX_SERIAL
 set serialrx_provider = CRSF

--- a/presets/4.3/rc_link/Tracer_CFV3.txt
+++ b/presets/4.3/rc_link/Tracer_CFV3.txt
@@ -1,13 +1,13 @@
-# Title: TBS Tacer CFV3
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: defaults, rc link, tracer, TBS, cfv3, 250hz
-# Author: Zak Smiley sugarK
-# Description: setup for TBS Tacer CFV3
-# Description: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
-# Description: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-# Description: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
+#$ TITLE: TBS Tacer CFV3
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, rc link, tracer, TBS, cfv3, 250hz
+#$ AUTHOR: Zak Smiley sugarK
+#$ DESCRIPTION: setup for TBS Tacer CFV3
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
+#$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua 
 
 feature RX_SERIAL
 set serialrx_provider = CRSF

--- a/presets/4.3/rc_link/defaults.txt
+++ b/presets/4.3/rc_link/defaults.txt
@@ -1,10 +1,10 @@
-# Title: Default 4.3 RC link settings
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: defaults, reset, rc link, rc_link
-# Author: Betaflight
-# Description: Resets all RC Link related parameters to 4.3 defaults
+#$ TITLE: Default 4.3 RC link settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, rc link, rc_link
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets all RC Link related parameters to 4.3 defaults
 # Warning: Resets settings for ALL protocols
 # Note: Does NOT reset serial port settings or Rx Link mode (TAER / AETR etc)
 

--- a/presets/4.3/rc_link/elrs_150hz.txt
+++ b/presets/4.3/rc_link/elrs_150hz.txt
@@ -1,13 +1,13 @@
-# Title: ELRS 150hz
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: ELRS, rc, link, rc_link, 150hz
-# Author: ctzsnooze
-# Description: Basic RC link settings for a 150hz ELRS link via CRSF
-# Description: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
-# Description: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-# Description: The voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option is whole pack
+#$ TITLE: ELRS 150hz
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: ELRS, rc, link, rc_link, 150hz
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Basic RC link settings for a 150hz ELRS link via CRSF
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+#$ DESCRIPTION: The voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option is whole pack
 
 feature RX_SERIAL
 set serialrx_provider = CRSF
@@ -21,12 +21,12 @@ set feedforward_jitter_reduction = 7
 
 # per cell or whole pack voltage readings:
 set report_cell_voltage = ON
-# option begin (unchecked) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
 set report_cell_voltage = OFF
-# option end
+#$ OPTION END
 
 # stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-# option begin (unchecked) Stronger smoothing for HD or cinematic (not for racing)
+#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 60
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_link/elrs_250hz.txt
+++ b/presets/4.3/rc_link/elrs_250hz.txt
@@ -1,13 +1,13 @@
-# Title: ELRS 250hz
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: ELRS, rc, link, 250hz
-# Author: ctzsnooze
-# Description: Basic RC link settings for a 250hz ELRS link via CRSF
-# Description: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
-# Description: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-# Description: Voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option whole pack
+#$ TITLE: ELRS 250hz
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: ELRS, rc, link, 250hz
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Basic RC link settings for a 250hz ELRS link via CRSF
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+#$ DESCRIPTION: Voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option whole pack
 
 feature RX_SERIAL
 set serialrx_provider = CRSF
@@ -21,12 +21,12 @@ set feedforward_jitter_reduction = 6
 
 # per cell or whole pack voltage readings:
 set report_cell_voltage = ON
-# option begin (unchecked) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
 set report_cell_voltage = OFF
-# option end
+#$ OPTION END
 
 # stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-# option begin (unchecked) Stronger smoothing for HD or cinematic (not for racing)
+#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 65
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_link/elrs_500hz.txt
+++ b/presets/4.3/rc_link/elrs_500hz.txt
@@ -1,14 +1,14 @@
-# Title: ELRS 500hz
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: ELRS, rc, link, 500hz
-# Author: ctzsnooze
-# Description: Basic RC link settings for a 500hz ELRS link via CRSF
-# Description: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
-# Description: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-# Description: If a log shows excessive noise in your feedforward trace, most likely there is a Tx firmware issue 
-# Description: The Voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option whole pack
+#$ TITLE: ELRS 500hz
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: ELRS, rc, link, 500hz
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Basic RC link settings for a 500hz ELRS link via CRSF
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+#$ DESCRIPTION: If a log shows excessive noise in your feedforward trace, most likely there is a Tx firmware issue 
+#$ DESCRIPTION: The Voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option whole pack
 
 feature RX_SERIAL
 set serialrx_provider = CRSF
@@ -22,12 +22,12 @@ set rc_smoothing = ON
 
 # per cell or whole pack voltage readings:
 set report_cell_voltage = ON
-# option begin (unchecked) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
 set report_cell_voltage = OFF
-# option end
+#$ OPTION END
 
 # stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-# option begin (unchecked) Stronger smoothing for HD or cinematic (not for racing)
+#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
 set feedforward_averaging = 3_POINT
 set feedforward_smooth_factor = 70
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_link/elrs_50hz.txt
+++ b/presets/4.3/rc_link/elrs_50hz.txt
@@ -1,13 +1,13 @@
-# Title: ELRS 50hz
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: ELRS, rc, link, rc_link, 50hz
-# Author: ctzsnooze
-# Description: Basic RC link settings for a 50hz ELRS link via CRSF
-# Description: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
-# Description: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-# Description: The voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option is whole pack
+#$ TITLE: ELRS 50hz
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: ELRS, rc, link, rc_link, 50hz
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Basic RC link settings for a 50hz ELRS link via CRSF
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+#$ DESCRIPTION: The voltage option is for OpenTx telemetry back to the transmitter, default is per cell, option is whole pack
 
 feature RX_SERIAL
 set serialrx_provider = CRSF
@@ -21,11 +21,11 @@ set feedforward_jitter_reduction = 15
 
 # per cell or whole pack voltage readings:
 set report_cell_voltage = ON
-# option begin (unchecked) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
 set report_cell_voltage = OFF
-# option end
+#$ OPTION END
 
 # stronger feedforward smoothing for HD or Cinematic flying (not for racing):
-# option begin (unchecked) Stronger smoothing for HD or cinematic (not for racing)
+#$ OPTION BEGIN (UNCHECKED) Stronger smoothing for HD or cinematic (not for racing)
 set feedforward_smooth_factor = 50
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_link/frsky_sbus.txt
+++ b/presets/4.3/rc_link/frsky_sbus.txt
@@ -1,18 +1,18 @@
-# Title: FrSky Sbus
-# FirmwareVersion: 4.3
-# Category: RC_LINK
-# Official: true
-# Keywords: frsky, sbus, rc, link
-# Author: ctzsnooze
-# Description: Basic RC link settings for a 111hz / 9ms FrSky Sbus link, with the Rx bound in D16 mode with no more than 8 channels
-# Description: These settings work best when used with a version of OpenTx with good module sync
-# Description: Note: Telemetry requires smartPort (s.Port) and does not convey RSSI (use Lua or analog RSSI)
-# Description: Note: When more than 8 channels are bound, manual RC smoothing settings and two point averaging is required
-# Description: Early versions of OpenTx with poor module sync will require two point averaging
-# Description: Cell vs full voltage option affects which value will be sent by telemetry to the handset.  Default is per cell.
-# Description: Units default to metric. Telemetry defaults to non-inverted and half-duple.  Both can be changed with checkbox
-# Description: Other telemetry settings,eg gps format, default latitude and longitude, extra sensors, require manual CLI entries
-# Description: Other options are provided for the intended flying style.
+#$ TITLE: FrSky Sbus
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ OFFICIAL: true
+#$ KEYWORDS: frsky, sbus, rc, link
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Basic RC link settings for a 111hz / 9ms FrSky Sbus link, with the Rx bound in D16 mode with no more than 8 channels
+#$ DESCRIPTION: These settings work best when used with a version of OpenTx with good module sync
+#$ DESCRIPTION: Note: Telemetry requires smartPort (s.Port) and does not convey RSSI (use Lua or analog RSSI)
+#$ DESCRIPTION: Note: When more than 8 channels are bound, manual RC smoothing settings and two point averaging is required
+#$ DESCRIPTION: Early versions of OpenTx with poor module sync will require two point averaging
+#$ DESCRIPTION: Cell vs full voltage option affects which value will be sent by telemetry to the handset.  Default is per cell.
+#$ DESCRIPTION: Units default to metric. Telemetry defaults to non-inverted and half-duple.  Both can be changed with checkbox
+#$ DESCRIPTION: Other telemetry settings,eg gps format, default latitude and longitude, extra sensors, require manual CLI entries
+#$ DESCRIPTION: Other options are provided for the intended flying style.
 
 feature RX_SERIAL
 set serialrx_provider = SBUS
@@ -32,50 +32,50 @@ set rc_smoothing = ON
 
 # per cell or whole pack voltage readings sent to Tx:
 set report_cell_voltage = ON
-# option begin (unchecked) Whole pack voltage readings
+#$ OPTION BEGIN (UNCHECKED) Whole pack voltage readings
 set report_cell_voltage = OFF
-# option end
+#$ OPTION END
 
 # metric or imperial units:
 set frsky_unit = metric
-# option begin (unchecked) Imperial units
+#$ OPTION BEGIN (UNCHECKED) Imperial units
 set frsky_unit = imperial
-# option end
+#$ OPTION END
 
 # telemetry inverted:
 set tlm_inverted = OFF
-# option begin (unchecked) Telemetry inverted 
+#$ OPTION BEGIN (UNCHECKED) Telemetry inverted 
 set tlm_inverted = ON
-# option end
+#$ OPTION END
 
 # telemetry halfduplex:
 set tlm_halfduplex = ON
-# option begin (unchecked) Full duplex telemetry
+#$ OPTION BEGIN (UNCHECKED) Full duplex telemetry
 set tlm_halfduplex = OFF
-# option end
+#$ OPTION END
 
 # if bound in D16 with more than 8 channels - sends duplicates all the time - too slow for racing
-# option begin (unchecked) Bound with >8 channels
+#$ OPTION BEGIN (UNCHECKED) Bound with >8 channels
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 35
-# option end
+#$ OPTION END
 
 # sharper handling for racing:
-# option begin (unchecked) Race
+#$ OPTION BEGIN (UNCHECKED) Race
 set feedforward_smooth_factor = 20
 set set feedforward_jitter_reduction = 5
-# option end
+#$ OPTION END
 
 # stronger smoothing for HD freestyle (not for racing):
-# option begin (unchecked) HD Freestyle
+#$ OPTION BEGIN (UNCHECKED) HD Freestyle
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 45
 set set feedforward_jitter_reduction = 12
-# option end
+#$ OPTION END
 
 # stronger smoothing for Cinematic flying (not for racing):
-# option begin (unchecked) Cinematic
+#$ OPTION BEGIN (UNCHECKED) Cinematic
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 60
 set set feedforward_jitter_reduction = 15
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_smoothing/cinematic_ctzsnooze.txt
+++ b/presets/4.3/rc_smoothing/cinematic_ctzsnooze.txt
@@ -1,15 +1,15 @@
-# Title: Cinematic RC smoothing
-# FirmwareVersion: 4.3
-# Category: RC_SMOOTHING
-# Official: true
-# Keywords: cinematic, rc, smoothing, rc_smoothing, jitter, transition, hd
-# Author: ctzsnooze
-# Description: Warning: will feel VERY 'soft' and unresponsive for small stick inputs!
-# Description: Note: auto-smoothing values are over-ridden by manually configure cutoff values.
-# Description: Option: enable Actual Rates, low centre sensitivity, no expo, 500 deg/s max
-# Description: This preset provides RC smoothing settings for cinematic HD footage.  By using fixed cutoffs, it will give a consistent smooth stick feel across a wide range of RC link frequencies
-# Description: There is no need to turn off feedforward; it should remain at values that give good stick responsiveness.
-# Description: For even smoother stick feel, reduce rc_smoothing_setpoint_cutoff and rc_smoothing_feedforward_cutoff to 10 in CLI.  If too smooth, increase rc_smoothing_setpoint_cutoff and rc_smoothing_feedforward_cutoff to 20 in CLI.
+#$ TITLE: Cinematic RC smoothing
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_SMOOTHING
+#$ OFFICIAL: true
+#$ KEYWORDS: cinematic, rc, smoothing, rc_smoothing, jitter, transition, hd
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Warning: will feel VERY 'soft' and unresponsive for small stick inputs!
+#$ DESCRIPTION: Note: auto-smoothing values are over-ridden by manually configure cutoff values.
+#$ DESCRIPTION: Option: enable Actual Rates, low centre sensitivity, no expo, 500 deg/s max
+#$ DESCRIPTION: This preset provides RC smoothing settings for cinematic HD footage.  By using fixed cutoffs, it will give a consistent smooth stick feel across a wide range of RC link frequencies
+#$ DESCRIPTION: There is no need to turn off feedforward; it should remain at values that give good stick responsiveness.
+#$ DESCRIPTION: For even smoother stick feel, reduce rc_smoothing_setpoint_cutoff and rc_smoothing_feedforward_cutoff to 10 in CLI.  If too smooth, increase rc_smoothing_setpoint_cutoff and rc_smoothing_feedforward_cutoff to 20 in CLI.
 
 set rc_smoothing = ON
 set rc_smoothing_auto_factor = 90
@@ -20,7 +20,7 @@ rc_smoothing_throttle_cutoff = 0
 set feedforward_jitter_reduction = 16
 set feedforward_transition = 0
 
-# option begin (unchecked) Recommended Actual rates
+#$ OPTION BEGIN (UNCHECKED) Recommended Actual rates
 set rates_type = ACTUAL
 set roll_rc_rate = 2
 set pitch_rc_rate = 2
@@ -31,4 +31,4 @@ set yaw_expo = 0
 set roll_srate = 50
 set pitch_srate = 50
 set yaw_srate = 50
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_smoothing/defaults.txt
+++ b/presets/4.3/rc_smoothing/defaults.txt
@@ -1,10 +1,10 @@
-# Title: Default 4.3 RC smoothing settings
-# FirmwareVersion: 4.3
-# Category: RC_SMOOTHING
-# Official: true
-# Keywords: defaults, reset, rc smoothing, rc_smoothing
-# Author: Betaflight
-# Description: Resets RC Smoothing settings to 4.3 defaults
+#$ TITLE: Default 4.3 RC smoothing settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_SMOOTHING
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, rc smoothing, rc_smoothing
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets RC Smoothing settings to 4.3 defaults
 
 set rc_smoothing = ON
 set rc_smoothing_auto_factor = 30

--- a/presets/4.3/rc_smoothing/freestyle_ctzsnooze.txt
+++ b/presets/4.3/rc_smoothing/freestyle_ctzsnooze.txt
@@ -1,13 +1,13 @@
-# Title: Freestyle RC smoothing
-# FirmwareVersion: 4.3
-# Category: RC_SMOOTHING
-# Official: true
-# Keywords: freestyle, rc, smooth, smoothing, rc_smoothing, jitter
-# Author: ctzsnooze
-# Description: RC smoothing settings for Freestyle footage
-# Description: Fixed cutoff frequency for consistent, responsive results over a wide range of RC link frequencies. Auto-smoothing cutoff values are over-ridden by the fixed cutoff values.
-# Description: There should be no need to turn off feedforward or to enable transition, beause the jitter reduction provides dynamic attenuation of feedforward whenever the sticks move slowly.
-# Description: Option: Actual Rates, with centre sensitivity around 60 and 750 deg/s max.
+#$ TITLE: Freestyle RC smoothing
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_SMOOTHING
+#$ OFFICIAL: true
+#$ KEYWORDS: freestyle, rc, smooth, smoothing, rc_smoothing, jitter
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: RC smoothing settings for Freestyle footage
+#$ DESCRIPTION: Fixed cutoff frequency for consistent, responsive results over a wide range of RC link frequencies. Auto-smoothing cutoff values are over-ridden by the fixed cutoff values.
+#$ DESCRIPTION: There should be no need to turn off feedforward or to enable transition, beause the jitter reduction provides dynamic attenuation of feedforward whenever the sticks move slowly.
+#$ DESCRIPTION: Option: Actual Rates, with centre sensitivity around 60 and 750 deg/s max.
 
 set rc_smoothing = ON
 set feedforward_jitter_reduction = 12
@@ -18,7 +18,7 @@ set rc_smoothing_feedforward_cutoff = 40
 set rc_smoothing_auto_factor_throttle = 30
 set rc_smoothing_throttle_cutoff = 0
 
-# option begin (unchecked) Recommended Actual rates
+#$ OPTION BEGIN (UNCHECKED) Recommended Actual rates
 set rates_type = ACTUAL
 set roll_rc_rate = 6
 set pitch_rc_rate = 6
@@ -29,4 +29,4 @@ set yaw_expo = 0
 set roll_srate = 75
 set pitch_srate = 75
 set yaw_srate = 75
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_smoothing/hd_freestyle_ctzsnooze.txt
+++ b/presets/4.3/rc_smoothing/hd_freestyle_ctzsnooze.txt
@@ -1,13 +1,13 @@
-# Title: Freestyle HD RC smoothing
-# FirmwareVersion: 4.3
-# Category: RC_SMOOTHING
-# Official: true
-# Keywords: freestyle, rc, smooth, HD, freestyle_HD, HD_freestyle, smoothing, rc_smoothing, jitter,
-# Author: ctzsnooze
-# Description: RC smoothing settings for smooth HD freestyle footage.
-# Description: This preset uses fixed manual cutoff frequencies for consistent results over a wide range of RC link frequencies - the auto cutoff values are not used.
-# Description: There is no need to turn off feedforward or to enable transition; jitter reduction provides dynamic attenuation of feedforward when sticks move slowly.
-# Description: Option: Actual Rates, centre sensitivity around 30 deg/s, max rate 750 deg/s, with zero expo.
+#$ TITLE: Freestyle HD RC smoothing
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_SMOOTHING
+#$ OFFICIAL: true
+#$ KEYWORDS: freestyle, rc, smooth, HD, freestyle_HD, HD_freestyle, smoothing, rc_smoothing, jitter,
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: RC smoothing settings for smooth HD freestyle footage.
+#$ DESCRIPTION: This preset uses fixed manual cutoff frequencies for consistent results over a wide range of RC link frequencies - the auto cutoff values are not used.
+#$ DESCRIPTION: There is no need to turn off feedforward or to enable transition; jitter reduction provides dynamic attenuation of feedforward when sticks move slowly.
+#$ DESCRIPTION: Option: Actual Rates, centre sensitivity around 30 deg/s, max rate 750 deg/s, with zero expo.
 
 set rc_smoothing = ON
 set feedforward_jitter_reduction = 13
@@ -18,7 +18,7 @@ set rc_smoothing_feedforward_cutoff = 25
 set rc_smoothing_auto_factor_throttle = 30
 set rc_smoothing_throttle_cutoff = 0
 
-# option begin (unchecked) Recommended Actual rates
+#$ OPTION BEGIN (UNCHECKED) Recommended Actual rates
 set rates_type = ACTUAL
 set roll_rc_rate = 3
 set pitch_rc_rate = 3
@@ -29,4 +29,4 @@ set yaw_expo = 0
 set roll_srate = 75
 set pitch_srate = 75
 set yaw_srate = 75
-# option end
+#$ OPTION END

--- a/presets/4.3/rc_smoothing/race_ctzsnooze.txt
+++ b/presets/4.3/rc_smoothing/race_ctzsnooze.txt
@@ -1,14 +1,14 @@
-# Title: Race RC smoothing
-# FirmwareVersion: 4.3
-# Category: RC_SMOOTHING
-# Official: true
-# Keywords: aggressive, rc, smoothing, race, rc_smoothing, jitter
-# Author: ctzsnooze
-# Description: RC smoothing settings for racing that slightly increases stick responsiveness over defaults. 
-# Description: Note: this preset workse best with a locked-frequency RC link. 
-# Description: Uses automatic cutoff adjustment that will optimise the cutoff to the link frequency at arming. As a result, faster RC links will feel more responsive. 
-# Description: If sticks are too sensitive, increase the auto smoothing factors in the CLI. 
-# Description: Note: If motors feel warmer than usual after applying this preset, return the auto RC smoothing values back to default of 30.
+#$ TITLE: Race RC smoothing
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_SMOOTHING
+#$ OFFICIAL: true
+#$ KEYWORDS: aggressive, rc, smoothing, race, rc_smoothing, jitter
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: RC smoothing settings for racing that slightly increases stick responsiveness over defaults. 
+#$ DESCRIPTION: Note: this preset workse best with a locked-frequency RC link. 
+#$ DESCRIPTION: Uses automatic cutoff adjustment that will optimise the cutoff to the link frequency at arming. As a result, faster RC links will feel more responsive. 
+#$ DESCRIPTION: If sticks are too sensitive, increase the auto smoothing factors in the CLI. 
+#$ DESCRIPTION: Note: If motors feel warmer than usual after applying this preset, return the auto RC smoothing values back to default of 30.
 
 set rc_smoothing = ON
 set feedforward_jitter_reduction = 5

--- a/presets/4.3/tune/defaults.txt
+++ b/presets/4.3/tune/defaults.txt
@@ -1,12 +1,12 @@
-# Title: Default 4.3 Tune settings
-# FirmwareVersion: 4.3
-# Category: TUNE
-# Official: true
-# Keywords: defaults, reset, tune, pid
-# Author: Betaflight
-# Description: Resets Tune parameters to 4.3 defaults
-# Description: WARNING: Resets MANY things, check the list before applying!
-# Description: DOES NOT reset filters!  They must be separately reset
+#$ TITLE: Default 4.3 Tune settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, tune, pid
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets Tune parameters to 4.3 defaults
+#$ DESCRIPTION: WARNING: Resets MANY things, check the list before applying!
+#$ DESCRIPTION: DOES NOT reset filters!  They must be separately reset
 
 
 

--- a/presets/4.3/tune/karate_race_tune_preset.txt
+++ b/presets/4.3/tune/karate_race_tune_preset.txt
@@ -1,19 +1,19 @@
-# Title: Karate Race
-# FirmwareVersion: 4.3
-# Category: TUNE
-# Official: true
-# Keywords: karate, 6S, race, world champion, 5 inch, 5", sugarK, limon, ctzsnooze, karatreBrot
-# Author: Zak Smiley SugarK
-# Description: This 6s racing tune was developed with the help of @ctzsnooze around @karatebrot’s RPM crossfade code allowing a pretty aggressive filter array which is the karate array. 
-# Description: This tune works well on any quality airframes and has been flown on the Viper racer (where it was developed ) BMS Js1, 533 switchback, HGLRC wind and of course @limons Open racer. 
-# Description: It should also work on other quality racing frames but use at your own risk as it is an aggressive tune. This tune so far has won a good number of events including the 2021 IO.
-# Description: 
-# Description: Things to note.. YOU HAVE TO USE RPM FILTERING WITH THIS TUNE, failure to do so might result in fire and regarding Dshot600,  if your setup has errors in the motor tab using bidirectional Dshot then change to 8k/4k and dshot300.
-# Description: Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc. To test arm the quad with props on, it should sound clean with no grinding, if it passes that then hover test and check motor temps.
-# Description:  If any thing is off don't fly it!!
-# Description: 
-# Description: SECOND NOTE.... Radio links.. 1. Make sure your radio system is totally up to date using either Edgetx or Opentx and your ADC in the hardware page is OFF 2. Go to the radio presets and apply the correct setup for your system and link speed.
-# Discussion: https://github.com/betaflight/firmware-presets/pull/41
+#$ TITLE: Karate Race
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ OFFICIAL: true
+#$ KEYWORDS: karate, 6S, race, world champion, 5 inch, 5", sugarK, limon, ctzsnooze, karatreBrot
+#$ AUTHOR: Zak Smiley SugarK
+#$ DESCRIPTION: This 6s racing tune was developed with the help of @ctzsnooze around @karatebrot’s RPM crossfade code allowing a pretty aggressive filter array which is the karate array. 
+#$ DESCRIPTION: This tune works well on any quality airframes and has been flown on the Viper racer (where it was developed ) BMS Js1, 533 switchback, HGLRC wind and of course @limons Open racer. 
+#$ DESCRIPTION: It should also work on other quality racing frames but use at your own risk as it is an aggressive tune. This tune so far has won a good number of events including the 2021 IO.
+#$ DESCRIPTION: 
+#$ DESCRIPTION: Things to note.. YOU HAVE TO USE RPM FILTERING WITH THIS TUNE, failure to do so might result in fire and regarding Dshot600,  if your setup has errors in the motor tab using bidirectional Dshot then change to 8k/4k and dshot300.
+#$ DESCRIPTION: Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc. To test arm the quad with props on, it should sound clean with no grinding, if it passes that then hover test and check motor temps.
+#$ DESCRIPTION:  If any thing is off don't fly it!!
+#$ DESCRIPTION: 
+#$ DESCRIPTION: SECOND NOTE.... Radio links.. 1. Make sure your radio system is totally up to date using either Edgetx or Opentx and your ADC in the hardware page is OFF 2. Go to the radio presets and apply the correct setup for your system and link speed.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/41
 
 # master
 set gyro_lpf2_static_hz = 1000
@@ -84,16 +84,16 @@ set tpa_rate = 70
 set tpa_breakpoint = 1250
 
 
-# option begin (checked) dynamic idle 
+#$ OPTION BEGIN (CHECKED) dynamic idle 
 
 #dynamic idle for 6s 2000kv
 set dshot_idle_value = 400
 set dyn_idle_min_rpm = 40
 set dyn_idle_p_gain = 35
-# option end
+#$ OPTION END
 
 
-# option begin (unchecked) spicy tune 
+#$ OPTION BEGIN (UNCHECKED) spicy tune 
 
 #spicy tune use with care
 
@@ -121,10 +121,10 @@ set simplified_dmax_gain = 125
 set simplified_feedforward_gain = 105
 set simplified_pitch_d_gain = 110
 set simplified_pitch_pi_gain = 110
-# option end
+#$ OPTION END
 
-# Option begin (unchecked) Dshot300
+#$ OPTION BEGIN (UNCHECKED) Dshot300
 set dshot_bidir = ON
 set motor_pwm_protocol = Dshot300
-# Option end
+#$ OPTION END
 

--- a/presets/4.3/vtx/defaults.txt
+++ b/presets/4.3/vtx/defaults.txt
@@ -1,11 +1,11 @@
-# Title: Default 4.3 VTX settings
-# FirmwareVersion: 4.3
-# Category: VTX
-# Official: true
-# Keywords: defaults, reset, clear, vtx
-# Author: Betaflight
-# Description: Resets VTx settings and table back to 4.3 Defaults
-# Description: Only the checked settings will be reset
+#$ TITLE: Default 4.3 VTX settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: VTX
+#$ OFFICIAL: true
+#$ KEYWORDS: defaults, reset, clear, vtx
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets VTx settings and table back to 4.3 Defaults
+#$ DESCRIPTION: Only the checked settings will be reset
 
 # reset basic Vtx settings
 


### PR DESCRIPTION
The main purpose of this PR is to change meta-property tag from `#` to `#$`
This would allow the checker script to detect wrong spellings. For example, if a person misspells DESCRIPTION:
![image](https://user-images.githubusercontent.com/2925027/137577577-42351a8a-1be3-4c74-a694-89f5d9b63479.png)

Also renaming `#$ NOSEARCH: true/false` to `#$ HIDDEN: true/false`. And `FirmwareVersion` to `FIRMWARE_VERSION` (with underscore)

Also changing all meta properties to FULL_UPPERCASE, I think this would make things nicer and easier to read.

It's a huge change but I promise it was all regular expressions :) except in these JS files:
indexer/PresetsFile.js
indexer/Settings.js