### PR TITLE
update Tune preset defaults.txt to indicate which elements will be reset

### DIFF
--- a/presets/4.3/tune/defaults.txt
+++ b/presets/4.3/tune/defaults.txt
@@ -1,109 +1,69 @@
-# Title: Default 4.3 Tune settings
-# FirmwareVersion: 4.3
-# Category: TUNE
-# Official: true
-# Keywords: defaults, reset, tune, pid
-# Author: Betaflight
-# Description: Resets Tune parameters to 4.3 defaults
-# Description: WARNING: Resets MANY things, check the list before applying!
-# Description: DOES NOT reset filters!  They must be separately reset
+#$ TITLE: Default 4.3 Tune settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ OFFICIAL: true
+#$ KEYWORDS defaults, reset, tune, pid
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets Tune parameters to 4.3 defaults.
+#$ DESCRIPTION: WARNING: Resets MANY things, check the list before applying!
+#$ DESCRIPTION: WARNING: Tune authors must explicitly set these values if something other than default is needed.
+#$ DESCRIPTION: DOES NOT reset rates, filters, rc_smoothing and many other parameters!  
+
+# THESE PARAMETERS WILL BE RESET TO DEFAULTS
 
 
-
-set deadband = 0
-set yaw_deadband = 0
-
-set thrust_linear = 0
-set transient_throttle_limit = 0
-
-set vbat_sag_compensation = 0
-set pid_at_min_throttle = ON
-
-set anti_gravity_mode = SMOOTH
-set anti_gravity_threshold = 250
-set anti_gravity_gain = 3500
-
-set acc_limit_yaw = 0
-set acc_limit = 0
-
-set crash_dthreshold = 50
-set crash_gthreshold = 400
-set crash_setpoint_threshold = 350
-set crash_time = 500
-set crash_delay = 0
-set crash_recovery_angle = 10
-set crash_recovery_rate = 100
-set crash_limit_yaw = 200
-set crash_recovery = OFF
-
-set iterm_rotation = OFF
-
-set iterm_relax = RP
-set iterm_relax_type = SETPOINT
-set iterm_relax_cutoff = 15
-set iterm_windup = 85
-set iterm_limit = 400
-
-set pidsum_limit = 500
-set pidsum_limit_yaw = 400
-
-set throttle_boost = 5
-set throttle_boost_cutoff = 15
-
-set acro_trainer_angle_limit = 20
-set acro_trainer_lookahead_ms = 50
-set acro_trainer_debug_axis = ROLL
-set acro_trainer_gain = 75
-
+# -- PID values (default) --
 set p_pitch = 47
 set i_pitch = 84
 set d_pitch = 46
+set d_min_pitch = 34
 set f_pitch = 125
+
 set p_roll = 45
 set i_roll = 80
 set d_roll = 40
+set d_min_roll = 30
 set f_roll = 120
+
 set p_yaw = 45
 set i_yaw = 80
 set d_yaw = 0
-set f_yaw = 120
-set d_min_roll = 30
-set d_min_pitch = 34
 set d_min_yaw = 0
+set f_yaw = 120
+
+# -- iTerm relax (default) --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 15
+
+# -- iTerm windup (default) --
+set iterm_windup = 85
+
+# -- iTerm rotation (off, default) --
+set iterm_rotation = OFF
+
+# -- Dmax (default) --
 set d_min_boost_gain = 37
 set d_min_advance = 20
 
-set angle_level_strength = 50
-set horizon_level_strength = 50
-set horizon_transition = 75
-set level_limit = 55
-set horizon_tilt_effect = 75
-set horizon_tilt_expert_mode = OFF
+# -- TPA (default) --
+set tpa_rate = 65
+set tpa_breakpoint = 1350
+set tpa_mode = D
 
-set abs_control_gain = 0
-set abs_control_limit = 90
-set abs_control_error_limit = 20
-set abs_control_cutoff = 11
-
-set use_integrated_yaw = OFF
-set integrated_yaw_relax = 200
-
-set motor_output_limit = 100
-
+# -- Feedforward (default) --
 set feedforward_transition = 0
-set feedforward_averaging = OFF
-
-set feedforward_jitter_reduction = 7
 set feedforward_boost = 15
 set feedforward_max_rate_limit = 90
+# Note: the other two feedforward parameters are related to both RC link and flying style
+# They must be configured as options (see below) and WILL NOT be reset automatically here
 
-set dyn_idle_min_rpm = 0
-set dyn_idle_p_gain = 50
-set dyn_idle_i_gain = 50
-set dyn_idle_d_gain = 50
-set dyn_idle_max_increase = 150
-set level_race_mode = OFF
+# -- PIDsum limits (default) --
+set pidsum_limit = 500
+set pidsum_limit_yaw = 400
+set iterm_limit = 400
 
+# -- Sliders (default) --
 set simplified_pids_mode = RPY
 set simplified_master_multiplier = 100
 set simplified_i_gain = 100
@@ -113,3 +73,185 @@ set simplified_dmax_gain = 100
 set simplified_feedforward_gain = 100
 set simplified_pitch_d_gain = 115
 set simplified_pitch_pi_gain = 105
+
+# -- Antigravity (default) --
+set anti_gravity_mode = SMOOTH
+set anti_gravity_threshold = 250
+set anti_gravity_gain = 3500
+
+# -- Absolute control (off, default) --
+set abs_control_gain = 0
+set abs_control_limit = 90
+set abs_control_error_limit = 20
+set abs_control_cutoff = 11
+
+# -- Accecleration limits (off, default) --
+set acc_limit_yaw = 0
+set acc_limit = 0
+
+# -- Angle and Horizon mode tuning (default) 
+set angle_level_strength = 50
+set horizon_level_strength = 50
+set horizon_transition = 75
+set level_limit = 55
+set horizon_tilt_effect = 75
+set horizon_tilt_expert_mode = OFF
+
+
+# ------ THE FOLLOWING PARAMETERS ARE NOT RESET BY THIS DEFAULT FILE ------
+
+# These parameters are NOT reset to defaults by this preset.
+# They may only be configured in a TUNE within Option tags, so that the user can either:
+# - choose to retain their existing settings, or
+# - reset sthe ettings to defaults (if you provide that option), or 
+# - apply new values (if you provide them as options)
+
+# The list below groups parameters in a way that may be useful when drafting a preset, including  default values and some notes.
+# This list doesn't include all the avilable parameters that can be changed in the CLI.
+# If your Preset requires a parameter to be at a particular value for it to behave as intended, include those parameters with your reccomended value/s as options. 
+
+# -- Rates --
+# May be provided in your tune preset only with an 'Option' to 'Include'  one or more external Rates preset files.
+
+# -- RC_Smoothing --
+# May be provided in your tune preset only with an 'Option' to 'Include'  one or more external RC_Smoothing preset files.
+
+# -- Filters --
+# May be provided in your tune preset only with an 'Option' to 'Include'  one or more external Filter preset files.
+
+# -- Startup and arming --
+# set gyro_cal_on_first_arm = OFF
+# set pwr_on_arm_grace = 5
+# set small_angle = 25
+
+# -- Airmode --
+## permanently on (default)
+# feature AIRMODE
+## or enabled by switch, eg Aux 2 above 1700...
+# feature -AIRMODE
+# aux 2 28 0 1700 2100 0 0
+
+# -- Level Race mode --
+# set level_race_mode = OFF
+
+# -- Mixer type --
+## default is LEGACY
+# set mixer_type = LEGACY
+
+# -- PIDs active below min throttle --
+# set pid_at_min_throttle = ON
+
+# -- min throttle value --
+# set min_throttle = 1070
+
+# -- Feedforward averaging --
+# should be set according to RC link type and speed
+# set feedforward_averaging = OFF
+
+# -- Feedforward jitter reduction --
+# depends on RC link and flying style
+# set feedforward_jitter_reduction = 7
+
+# -- Stick behaviour -- 
+# set deadband = 0
+# set yaw_deadband = 0
+# set min_check = 1050
+
+# -- Yaw spin recovery --
+# set yaw_spin_recovery = AUTO
+
+# -- Integrated yaw --
+# set use_integrated_yaw = OFF
+# set integrated_yaw_relax = 200
+
+# -- Transient throttle limit --
+## dynamically lifts and cuts throttle to keep noise within motor limits
+## do not enable if using dynamic idle
+# set transient_throttle_limit = 0
+
+# -- Thrust linear --
+## increases motor output differentials at low throttle, useful if low thrust at low rpm
+# set thrust_linear = 0
+
+# -- Motor output limit --
+## linearly attenuates motor output
+# set motor_output_limit = 100
+
+# -- Throttle boost --
+## add more throttle when throttle is moved rapidly, to compensate for motor lag
+# set throttle_boost = 5
+# set throttle_boost_cutoff = 15
+
+# -- Throttle curve --
+# set thr_mid = 50
+# set thr_expo = 0
+
+# -- Throttle limit --
+# set throttle_limit_type = OFF
+# set throttle_limit_percent = 100
+
+# -- VBat sag compensation --
+# set vbat_sag_compensation = 0
+# set vbat_sag_lpf_period = 2
+
+# -- VBat thresholds and display update rate --
+# set vbat_max_cell_voltage = 430
+# set vbat_full_cell_voltage = 410
+# set vbat_warning_cell_voltage = 350
+# set vbat_min_cell_voltage = 330
+# set vbat_detect_cell_voltage = 300
+# set vbat_hysteresis = 1
+# set vbat_display_lpf_period = 10
+
+# -- Report single cell voltages in telemetry back to OpenTx Radio Transmitters --
+# set report_cell_voltage = OFF
+
+# -- DShot Telemetry --
+## must be ON for Dynamic Idle and RPM filtering to work
+# set dshot_bidir = OFF
+
+# -- Dynamic Idle --
+# set dyn_idle_min_rpm = 0
+# set dyn_idle_p_gain = 50
+# set dyn_idle_i_gain = 50
+# set dyn_idle_d_gain = 50
+# set dyn_idle_max_increase = 150
+
+# -- Runaway takeoff prevention --
+# set runaway_takeoff_prevention = ON
+# set runaway_takeoff_deactivate_delay = 500
+# set runaway_takeoff_deactivate_throttle_percent = 20
+
+# -- Crash Recovery settings --
+# set crash_dthreshold = 50
+# set crash_gthreshold = 400
+# set crash_setpoint_threshold = 350
+# set crash_time = 500
+# set crash_delay = 0
+# set crash_recovery_angle = 10
+# set crash_recovery_rate = 100
+# set crash_limit_yaw = 200
+# set crash_recovery = OFF
+
+# -- Turtle mode settings --
+## this will enable turtle mode on aux 3 when above 1300:
+# aux 3 35 2 1300 2100 0 0
+## defaults:
+# set crashflip_motor_percent = 0
+# set crashflip_expo = 35
+
+# -- Acro trainer settings --
+# set acro_trainer_angle_limit = 20
+# set acro_trainer_lookahead_ms = 50
+# set acro_trainer_debug_axis = ROLL
+# set acro_trainer_gain = 75
+
+# -- Launch control settings --
+# set launch_control_mode = NORMAL
+# set launch_trigger_allow_reset = ON
+# set launch_trigger_throttle_percent = 20
+# set launch_angle_limit = 0
+# set launch_control_gain = 40
+
+
+


### PR DESCRIPTION
This is a major revision of the default tune preset.

This file must be included at the start of every TUNE document with the command `#$ Include tune/default.txt`

The parameters listed in the `THESE PARAMETERS WILL BE RESET TO DEFAULTS` section:
- will be reset to 4.3 defaults by this file
- may be overridden directly by a CLI line in a `TUNE` preset
- shall not be used in any other kind of preset

The parameters listed later, in the `THE FOLLOWING PARAMETERS ARE NOT RESET BY THIS DEFAULT FILE` section:
- will NOT be reset or modified by this file
- shall not be included in a TUNE preset *except* as `Option` elements that the user may accept or reject
- are included only as a convenient grouped listing to remind a `TUNE Preset` author that they may wish to control these settings, while providing the user a means to retain their existing settings.

Authors of `TUNE` presets should control the values of all parameters that could influence their tune.

This requirement is best met by:
- resetting the defined `TUNE` parameters (and only those parameters) to defaults (mandatory)
- over-writing some of those values to the specific settings as required by the `TUNE`
- providing any other parameters that are needed by the `TUNE`, enclosed inside `Option` statements.  The user then user knows what the tuner wants to change, and can accept the default user recommendations by just pressing the `Accept` button, or alternatively can uncheck some of the recommended changes to selectively retain their current configuration values.

The following parameters are part of a `TUNE` defaults file, and will be reset:
```
Absolute Control
Anti_Gravity
Acceleration Limits
iTerm Relax
iTerm Windup
iTerm Rotation
PID Sum limits
PID values
Dmax sub-settings
TPA
Feedforward sub-settings (but not feedforward_averaging or feedforward_jitter_reduction)
PID slider settings
Angle and Horizon tuning settings
```

The following parameters are NOT reset by a `TUNE` defaults.txt  file, and may only be be controlled in the calling `TUNE` Preset within `Option` tags:
```
Rates, RR_Smoothing, Filters, etc
Startup and Arming settings
Airmode settings
Level Race mode
Mixer type
Min_throttle value
PID_at_min_throttle
Feedforward_averaging
Feedforward_jitter_reduction
Deadbands
Min_check
Yaw_spin_recovery
Integrated yaw
Transient Throttle Limit
Thrust Linear
Motor Output Limit
Throttle Boost
Throttle Curve
Throttle Limit
Vbat Sag Compensation
Battery warning thresholds
Cell or pack voltage reporting in OpenTx  telemetry
DShot Telemetry on/off (important)
Dynamic Idle settings
Runaway Takeoff prevention
Crash Recovery
Turtle Mode
Acro Trainer
Launch Control
```
