### PR TITLE
Initial filter sets

### DIFF
--- a/presets/4.3/filters/default_no_rpm_clean.txt
+++ b/presets/4.3/filters/default_no_rpm_clean.txt
@@ -1,0 +1,46 @@
+#$ TITLE: 4.3 Filter settings for CLEAN build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, filtering, clean, no rpm, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.  
+#$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.  
+#$ DESCRIPTION: If motors get hot, try lowering the gyro or D filter sliders.   If motors remain hot despite strong filtering, it may not be a filtering problem.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_static_hz = 500
+set gyro_lpf2_static_hz = 500
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 100
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 350
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 67
+set dterm_lpf1_dyn_max_hz = 135
+set dterm_lpf1_static_hz = 135
+
+set dterm_lpf2_static_hz = 135
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 90
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_no_rpm_noisy.txt
+++ b/presets/4.3/filters/default_no_rpm_noisy.txt
@@ -1,0 +1,45 @@
+#$ TITLE: 4.3 Filter settings for NOISY build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, filtering, noisy, no rpm, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.
+#$ DESCRIPTION: If motors get hot, try a filter set for very noisy motors, or try lowering the D filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 137
+set gyro_lpf1_dyn_max_hz = 275
+set gyro_lpf1_static_hz = 275
+set gyro_lpf2_static_hz = 275
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 55
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 5
+set dyn_notch_q = 325
+set dyn_notch_min_hz = 90
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 52
+set dterm_lpf1_dyn_max_hz = 105
+set dterm_lpf1_static_hz = 105
+
+set dterm_lpf2_static_hz = 105
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 70
+
+# -- Yaw lowpass --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_no_rpm_normal.txt
+++ b/presets/4.3/filters/default_no_rpm_normal.txt
@@ -1,0 +1,45 @@
+#$ TITLE: 4.3 Filter settings for NORMAL build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, filtering, normal, no rpm, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for a well maintained build in good condition.
+#$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors, or try lowering the D filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 150
+set gyro_lpf1_dyn_max_hz = 300
+set gyro_lpf1_static_hz = 300
+set gyro_lpf2_static_hz = 300
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 60
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 5
+set dyn_notch_q = 350
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 60
+set dterm_lpf1_dyn_max_hz = 120
+set dterm_lpf1_static_hz = 120
+
+set dterm_lpf2_static_hz = 120
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 80
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_no_rpm_very_clean.txt
+++ b/presets/4.3/filters/default_no_rpm_very_clean.txt
@@ -1,0 +1,47 @@
+#$ TITLE: 4.3 Filter settings for VERY CLEAN build WITHOUT RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: no rpm, filter, filters, filtering, very clean, very, clean, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!
+#$ DESCRIPTION: Intended only for rock hard frames, motors with good bearings and true shafts, and perfectly balanced props.
+#$ DESCRIPTION: If motors get hot, try a filter set for clean or normal motors, or try enabling gyro filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+# None
+set gyro_lpf1_dyn_min_hz = 400
+set gyro_lpf1_dyn_max_hz = 800
+set gyro_lpf1_static_hz = 800
+set gyro_lpf2_static_hz = 800
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 160
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 75
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_static_hz = 150
+
+set dterm_lpf2_static_hz = 150
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 100
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_no_rpm_very_noisy.txt
+++ b/presets/4.3/filters/default_no_rpm_very_noisy.txt
@@ -1,0 +1,45 @@
+#$ TITLE: 4.3 Filter settings for VERY NOISY build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, very noisy, very, noisy, no rpm, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for slightly beaten up, or larger (10" and above), builds.
+#$ DESCRIPTION: If motors get hot, they may simply be being asked to do too much.
+#$ DESCRIPTION: May cause 5" or smaller quads to wobble due to lag.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 125
+set gyro_lpf1_dyn_max_hz = 250
+set gyro_lpf1_static_hz = 250
+set gyro_lpf2_static_hz = 250
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 50
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 5
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 80
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 45
+set dterm_lpf1_dyn_max_hz = 90
+set dterm_lpf1_static_hz = 90
+
+set dterm_lpf2_static_hz = 90
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 60
+
+# -- Yaw lowpass --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_rpm_clean.txt
+++ b/presets/4.3/filters/default_rpm_clean.txt
@@ -1,0 +1,51 @@
+#$ TITLE: 4.3 Filter settings for CLEAN build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, clean, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: May cause motor overheating!
+#$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.  
+#$ DESCRIPTION: If motors get hot, try a filter set for normal or noisy motors, or try enabling gyro filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 1000Hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 1000
+
+# -- Gyro Sliders OFF --
+# since only lpf2 is active
+set simplified_gyro_filter = OFF
+set simplified_gyro_filter_multiplier = 200
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 300
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 650
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 78
+set dterm_lpf1_dyn_max_hz = 157
+set dterm_lpf1_static_hz = 157
+
+set dterm_lpf2_static_hz = 157
+
+# -- Dterm sliders 105 --
+set simplified_dterm_filter_multiplier = 105
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_rpm_noisy.txt
+++ b/presets/4.3/filters/default_rpm_noisy.txt
@@ -1,0 +1,52 @@
+#$ TITLE: 4.3 Filter settings for NOISY build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, noisy, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.
+#$ DESCRIPTION: If motors get hot, try the filter Preset for very noisy motors, or enable slider control for gyro filtering.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 250hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 250
+ 
+# -- Gyro Sliders OFF --
+# since only lpf2 is active
+set simplified_gyro_filter = OFF
+set simplified_gyro_filter_multiplier = 75
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 400
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 450
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 63
+set dterm_lpf1_dyn_max_hz = 127
+set dterm_lpf1_static_hz = 127
+
+set dterm_lpf2_static_hz = 127
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 85
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 75
+
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_rpm_normal.txt
+++ b/presets/4.3/filters/default_rpm_normal.txt
@@ -1,0 +1,43 @@
+#$ TITLE: 4.3 Filter settings for NORMAL build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, normal, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for a well maintained build in good condition.
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors, or enable the gyro filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 500hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 500
+
+# -- Gyro Sliders OFF --
+# since only lpf2 is active
+set simplified_gyro_filter = OFF
+set simplified_gyro_filter_multiplier = 200
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 450
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 500
+
+# -- Dterm filtering (default) --
+# -- Dterm sliders (default) --
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_rpm_very_clean.txt
+++ b/presets/4.3/filters/default_rpm_very_clean.txt
@@ -1,0 +1,52 @@
+#$ TITLE: 4.3 Filter settings for VERY CLEAN build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, filter, filters, filtering, very clean, very, clean, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!
+#$ DESCRIPTION: Intended only for rock hard frames, motors with good bearings and true shafts, and perfectly balanced props.
+#$ DESCRIPTION: If motors get hot, try a filter set for clean or normal motors, or try enabling gyro filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# None
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 0
+
+# -- Gyro Sliders OFF --
+# since no gyro filters are active
+set simplified_gyro_filter = OFF
+set simplified_gyro_filter_multiplier = 200
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 500
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 750
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 82
+set dterm_lpf1_dyn_max_hz = 165
+set dterm_lpf1_static_hz = 165
+
+set dterm_lpf2_static_hz = 165
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 110
+
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/default_rpm_very_noisy.txt
+++ b/presets/4.3/filters/default_rpm_very_noisy.txt
@@ -1,0 +1,53 @@
+#$ TITLE: 4.3 Filter settings for VERY NOISY build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, filter, filters, filtering, very, noisy, very noisy, hot, basic, default, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.
+#$ DESCRIPTION: Intended for worn, beaten up, or larger (10" and above), builds.
+#$ DESCRIPTION: If motors get hot, try the filter Preset for very noisy motors, or enable sliders for gyro filtering. If motors remain hot despite strong filtering, it may not be a filtering problem.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 125hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 250
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 125
+ 
+# -- Gyro Sliders OFF --
+# since only lpf2 is active
+set simplified_gyro_filter = OFF
+set simplified_gyro_filter_multiplier = 50
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 350
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 350
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 60
+set dterm_lpf1_dyn_max_hz = 120
+set dterm_lpf1_static_hz = 120
+
+set dterm_lpf2_static_hz = 120
+
+# -- Dterm sliders (default) --
+set simplified_dterm_filter_multiplier = 80
+
+# -- Yaw lowpass (default) --
+set yaw_lowpass_hz = 50
+
+# -- Accelerometer lowpass (default) --

--- a/presets/4.3/filters/defaults.txt
+++ b/presets/4.3/filters/defaults.txt
@@ -6,48 +6,60 @@
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Resets Filter settings to 4.3 defaults
 
+# -- Gyro lowpass filters --
 set gyro_lpf1_type = PT1
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_dyn_expo = 5
 set gyro_lpf1_static_hz = 250
+
 set gyro_lpf2_type = PT1
 set gyro_lpf2_static_hz = 500
+
+# -- Gyro sliders --
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 100
+
+# -- Gyro Static Notches --
 set gyro_notch1_hz = 0
 set gyro_notch1_cutoff = 0
 set gyro_notch2_hz = 0
 set gyro_notch2_cutoff = 0
 
+# -- Gyro Dynamic Notches --
 set dyn_notch_count = 3
 set dyn_notch_q = 300
 set dyn_notch_min_hz = 150
 set dyn_notch_max_hz = 600
-set gyro_lpf1_dyn_min_hz = 250
-set gyro_lpf1_dyn_max_hz = 500
-set gyro_lpf1_dyn_expo = 5
 set gyro_filter_debug_axis = ROLL
 
-set acc_lpf_hz = 10
-
-set simplified_gyro_filter = ON
-set simplified_gyro_filter_multiplier = 100
-
+# -- RPM filtering --
 set rpm_filter_harmonics = 3
 set rpm_filter_q = 500
 set rpm_filter_min_hz = 100
 set rpm_filter_fade_range_hz = 50
 set rpm_filter_lpf_hz = 150
 
+# -- Dterm filtering --
+set dterm_lpf1_type = PT1
 set dterm_lpf1_dyn_min_hz = 75
 set dterm_lpf1_dyn_max_hz = 150
 set dterm_lpf1_dyn_expo = 5
-set dterm_lpf1_type = PT1
 set dterm_lpf1_static_hz = 150
+
 set dterm_lpf2_type = PT1
 set dterm_lpf2_static_hz = 150
+
 set dterm_notch_hz = 0
 set dterm_notch_cutoff = 0
 
+# -- Dterm sliders --
 set simplified_dterm_filter = ON
 set simplified_dterm_filter_multiplier = 100
 
-
+# -- Yaw lowpass --
 set yaw_lowpass_hz = 100
+
+# -- Accelerometer lowpass --
+set acc_lpf_hz = 10
 


### PR DESCRIPTION
First draft of a range of filter presets.

There are RPM and NON-RPM versions, each with 5 'grades' of filtering, for very noisy through 'normal' to very clean builds. This allows:

- any user to change the filtering to suit the build
- a user without RPM filtering to use a tune that otherwise would only support RPM filtering configurations

I can take off and fly with all of these presets on a standard race quad, with clean props and good motors.  None 'flew to the moon' on arming.

There is probably too much noise in the clean or very clean presets for everyday use on ordinary builds.  

The `v_clean`or 'very clean' filter sets should only be used on truly clean, resonance-free builds.  They will head for the moon if the props or frame have flex.  While they give the most responsive performance with the least propwash, they are very prone to exaggerated resonance and noise. I'm not sure that `no_rpm_v_clean` setup is usable at all, but maybe it will.

The 'normal' settings are comparable, with and without RPM, in overall noise outcome, and are recommended for general purpose freestyle.  For the normal settings, RPM filtering will typically give a better overall result, with less noise and less delay.

For hard core racing, RPM filtering is vert strongly recommended.  The `rpm_normal` setup is pretty good, especially if you look after your gear, the `rpm_noisy` preset may be required if you want to continue a race with damaged props and not melt the insulation on the motors.

Heavier filtering of 5" or smaller quads is likely to add to propwash or other slow wobbles, especially the filtering for very noisy quads.  There is a limit to how much filtering can be applied before the lag causes wobble.  

The filters for `very noisy` quads are useful for 10" and larger builds where the frame responsiveness is slow and very high P and D values are required.  They tend to cause wobble in 5" and smaller builds.

Without RPM filtering, it's obvious that the dynamic notches take a moment to find the peaks, and do let more a bit more motor noise through during rapid rpm changes.  

Presets intended for use with RPM filtering active set `dshot_bidir` to ON, and vice versa.

As a result, if a `TUNE` preset calls an `RPM_ON` filter set, the motors will only spin if DShot telemetry is properly enabled in the ESC. 

This table summarises the settings in each preset

**For RPM ON setups only:**
| preset  | Glpf1 | Glpf2 | DynNotch | RPM    | Dlpf1   | Dlpf2 |
| -- | -- | -- | -- | -- | -- | -- |
| v_clean | -     | -     | 1 @ 500    | 3 @ 750  | 82 >165 | 165   |
| clean   | -     | 1000  | 1 @ 300    | 3 @ 650  | 79 >157 | 157   |
| normal  | -     | 500   | 2 @ 450    | 3 @ 500  | 75 >150 | 150   |
| noisy   | -     | 250   | 2 @ 400    | 3 @ 450  | 64 >127 | 127   |
| v_noisy | -     | 125   | 2 @ 350    | 3 @ 350  | 60 >120 | 120   |

**For RPM filtering OFF setups only:**
| preset  | Glpf1    | Glpf2 | DynNotch | RPM | Dlpf1   | Dlpf2 |
| -- | -- | -- | -- | -- | -- | -- |
| v_clean | 400->800 | 800   | 4 @ 450    | -   | 75 >150 | 150   | 
| clean   | 250->500 | 500   | 4 @ 350    | -   | 67 >135 | 135   |
| normal  | 150->300 | 300   | 5 @ 350    | -   | 60 >120 | 120   |
| noisy   | 137->275 | 275   | 5 @ 325    | -   | 52 >105 | 105   |
| v_noisy | 125->250  | 250   | 5 @ 300    | -   | 45 >90  | 90    |

The RPM presets have either 1 or 2 dynamic notches, with min cutoff at 150, with RPM filter min at 100 crossfading to 150.
The Non-RPM presets have either 4 or 5 dynamic notches, with min cutoff from 80-100.