### PR TITLE
Create rpm_filters.txt  warning in misc folder 

### DIFF
--- a/misc/warnings/en/rpm_filters.txt
+++ b/misc/warnings/en/rpm_filters.txt
@@ -1,1 +1,1 @@
-This tune works ONLY with DSHOT 600 and DSHOT 300. Using anything else is extremely unsafe.
+This tune works ONLY with DSHOT 600 or DSHOT 300. Using anything else is extremely unsafe.


### PR DESCRIPTION
warning file for tunes that must have bidirectional enabled
accessed with 

`#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt`
