### PR TITLE
Added verification for #$ INCLUDE loops

### DIFF
--- a/indexer/PresetsFolder.js
+++ b/indexer/PresetsFolder.js
@@ -31,6 +31,49 @@ class PresetsFolder
             }
         });
     }
+
+    static checkForIncludeLoops(presetFilesArray, errors)
+    {
+        const filesDb = PresetsFolder._createFilesDictionary(presetFilesArray);
+        const fileNameErrors = {};
+
+        presetFilesArray.forEach((file) => {
+            const parents = [];
+            PresetsFolder._checkFileForIncludeLoops(file, filesDb, parents, fileNameErrors);
+        });
+
+        for (const fileNameError in fileNameErrors) {
+            const errorText = `File ${fileNameError}, takes part in the #$ INCLUDE loop'`;
+            errors.push(errorText);
+            console.error(errorText);
+        }
+    }
+
+    static _checkFileForIncludeLoops(file, filesDb, parents, fileNameErrors)
+    {
+        if (parents.includes(file.fullPath)) {
+            fileNameErrors[file.fullPath] = true;
+        } else {
+            parents.push(file.fullPath);
+            if (file.hasOwnProperty("include")) {
+                file.include.forEach((includedFileName) => {
+                    const clonedParents = [...parents];
+                    PresetsFolder._checkFileForIncludeLoops(filesDb[includedFileName], filesDb, clonedParents, fileNameErrors);
+                });
+            }
+        }
+    }
+
+    static _createFilesDictionary(presetFilesArray)
+    {
+        let result = {};
+
+        presetFilesArray.forEach((file) => {
+            result[file.fullPath] = file;
+        });
+
+        return result;
+    }
 }
 
 module.exports = PresetsFolder;

--- a/indexer/indexer.js
+++ b/indexer/indexer.js
@@ -19,6 +19,7 @@ if (process.argv.length === 3) {
 
 let presetFilesArray = [];
 let presetsFolder = new PresetsFolder(settings.presetsDir, settings, presetFilesArray, errors);
+PresetsFolder.checkForIncludeLoops(presetFilesArray, errors);
 
 //console.log(getUniqueValues(presetFilesArray, "firmwareVersion"));
 


### PR DESCRIPTION
check.js and indexer.js need to verify for #$ INCLUDE loops and fail if any are found.
For example:
**A** includes B, B includes C, C includes **A**
and similar cases.