### PR TITLE
update both karate  filter and tune use a single fixed lpf

### DIFF
--- a/presets/4.3/filters/karate_array.txt
+++ b/presets/4.3/filters/karate_array.txt
@@ -14,10 +14,10 @@
 
 
 # -- Gyro lowpass filters --
-set gyro_lpf1_dyn_min_hz = 500
-set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
 set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 140
+
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 2
@@ -28,11 +28,11 @@ set dyn_notch_min_hz = 200
 set dshot_bidir = ON
 set rpm_filter_harmonics = 2
 set rpm_filter_fade_range_hz = 100
+set rpm_filter_min_hz = 150
 
 # -- Dterm filtering --
-set dterm_lpf1_dyn_expo = 10
-set simplified_dterm_filter = ON
-set simplified_dterm_filter_multiplier = 100
+set dterm_lpf1_dyn_expo = 7
+
 
 
 # OPTION BEGIN (UNCHECKED): Dshot300

--- a/presets/4.3/tune/karate_race.txt
+++ b/presets/4.3/tune/karate_race.txt
@@ -21,11 +21,10 @@
 
 
 # -- Gyro lowpass filters --
-set gyro_lpf2_static_hz = 500
-set gyro_lpf1_dyn_min_hz = 500
-set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
 set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 140
+
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 2
@@ -34,10 +33,7 @@ set dyn_notch_min_hz = 200
 set dyn_notch_max_hz = 650
 
 # -- Dterm filtering --
-set dterm_lpf1_dyn_min_hz = 70
-set dterm_lpf1_dyn_expo = 10
-set simplified_dterm_filter = OFF
-set simplified_dterm_filter_multiplier = 100
+
 
 # -- RPM filtering --
 set dshot_bidir = ON
@@ -113,9 +109,12 @@ set dyn_notch_q = 600
 set dyn_notch_min_hz = 250
 set dyn_notch_max_hz = 650
 
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 7
+
 # -- RPM filtering --
 set rpm_filter_harmonics = 2
-set rpm_filter_min_hz = 200
+set rpm_filter_min_hz = 150
 
 # -- PID values --
 set p_pitch = 42


### PR DESCRIPTION
after talking with @ctzsnooze  and some testing with the fixed gyro LPF I've changed the karate tune and filter array to use a single 500hz fixed lpf.
the benefit of this is more consistent gyro phase delay which is around 0.25ms lower on average than the 500-1000hz dynamic lpf and a fixed 500hz Glpf. I've also backed up the Dterm lpf expo from 10 to 7 to give better idle performance with messed up props.
