### PR TITLE
SupaflyFpv Freestyle EasyTune

### DIFF
--- a/presets/4.3/tune/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
+++ b/presets/4.3/tune/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
@@ -1,0 +1,185 @@
+#$ TITLE: SupaflyFPV Freestyle 5 Inch EasyTune
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: Supafly, SupaflyFPV, 4S, 5s, 6S, Freestyle, 5 inch, 5"
+#$ AUTHOR: SupaflyFPV
+#$ DESCRIPTION: Supa-Easy Freestyle Preset - Easily tune freestyle builds using only the Master Multiplier Slider
+#$ DESCRIPTION: Select the option for your build with or without HD camera (eg GoPro) as the base tune
+#$ DESCRIPTION: Half to one click up or down Master Slider to tweak the tune - in OSD or Configurator
+#$ DESCRIPTION: Quad feels loose, click Master up. Quad shakes/oscillates click Master down
+#$ DESCRIPTION: RPM Filtering for best performance (default) - or de-select for Non RPM Setup (check esc compatibility)
+#$ DESCRIPTION: Enjoy!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/41
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Non-RPM Filtering --
+
+set dshot_bidir = OFF
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 600
+set dyn_notch_count = 3
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+
+# -- Dterm filtering --
+
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 0
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_dyn_expo = 0
+set dterm_lpf1_static_hz = 90
+
+# -- Antigravity --
+
+set anti_gravity_gain = 4000
+
+# -- Feedforward jitter reduction --
+
+set feedforward_jitter_reduction = 12
+
+#$ OPTION BEGIN (CHECKED): RPM filtering
+
+set dshot_bidir = ON
+set simplified_gyro_filter = OFF
+set rpm_filter_harmonics = 1
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 600
+set gyro_lpf1_dyn_expo = 8
+set dyn_notch_count = 2
+set dyn_notch_q = 400
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): 4s Lipo with HD Cam (2400-2700kv motors)
+
+# -- PID values --
+
+set p_pitch = 71
+set i_pitch = 88
+set d_pitch = 43
+set f_pitch = 146
+set p_roll = 59
+set i_roll = 73
+set d_roll = 39
+set f_roll = 122
+set p_yaw = 59
+set i_yaw = 73
+set f_yaw = 122
+set d_min_roll = 39
+set d_min_pitch = 43
+
+# -- Sliders --
+
+set simplified_master_multiplier = 120
+set simplified_i_gain = 70
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 85
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 120
+set simplified_dterm_filter = OFF
+
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 4s Lipo with No HD Cam (2400-2700kv motors)
+
+# -- PID values --
+
+set p_pitch = 65
+set i_pitch = 81
+set d_pitch = 43
+set f_pitch = 134
+set p_roll = 59
+set i_roll = 73
+set d_roll = 39
+set f_roll = 122
+set p_yaw = 59
+set i_yaw = 73
+set f_yaw = 122
+set d_min_roll = 39
+set d_min_pitch = 43
+
+# -- Sliders --
+
+set simplified_master_multiplier = 120
+set simplified_i_gain = 70
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 85
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+set simplified_dterm_filter = OFF
+
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 6s Lipo with HD Cam (1750 - 1950kv motors)
+
+# -- PID values --
+
+set p_pitch = 59
+set i_pitch = 79
+set d_pitch = 39
+set f_pitch = 136
+set p_roll = 49
+set i_roll = 66
+set d_roll = 33
+set f_roll = 114
+set p_yaw = 49
+set i_yaw = 66
+set f_yaw = 114
+set d_min_roll = 33
+set d_min_pitch = 39
+
+# -- Sliders --
+
+set simplified_i_gain = 75
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 95
+set simplified_pitch_d_gain = 120
+set simplified_pitch_pi_gain = 120
+set simplified_dterm_filter = OFF
+
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 6s Lipo with No HD Cam (1750 - 1950kv motors)
+
+# -- PID values --
+
+set p_pitch = 54
+set i_pitch = 77
+set d_pitch = 36
+set p_roll = 49
+set i_roll = 70
+set d_roll = 33
+set f_roll = 114
+set p_yaw = 49
+set i_yaw = 70
+set f_yaw = 114
+set d_min_roll = 33
+set d_min_pitch = 36
+
+# -- Sliders --
+
+set simplified_i_gain = 80
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 95
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+set simplified_dterm_filter = OFF
+
+#$ OPTION END

--- a/presets/4.3/tune/SupaflyFPV_Freestyle_6_and_EasyTune.txt
+++ b/presets/4.3/tune/SupaflyFPV_Freestyle_6_and_EasyTune.txt
@@ -1,0 +1,119 @@
+#$ TITLE: SupaflyFPV Freestyle 6 Inch EasyTune
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: Supafly, SupaflyFPV, Freestyle, 6", 6 Inch
+#$ AUTHOR: SupaflyFPV
+#$ DESCRIPTION: Supa-Easy Freestyle Preset for 6 Inch Builds
+#$ DESCRIPTION: Easily tune freestyle builds using only the Master Multiplier Slider
+#$ DESCRIPTION: Select the option for your build with or without HD camera (eg GoPro)
+#$ DESCRIPTION: Half to one click up or down Master Slider to tweak the tune - in OSD or Configurator
+#$ DESCRIPTION: Quad feels loose, click Master up. Quad shakes/oscillates click Master down
+#$ DESCRIPTION: RPM Filtering for best performance (default) - or de-select for Non RPM Setup (check esc compatibility)
+#$ DESCRIPTION: Enjoy!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/41
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Non-RPM Filtering --
+set dshot_bidir = OFF
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 120
+set gyro_lpf1_dyn_max_hz = 350
+set dyn_notch_count = 4
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+
+# -- Dterm filtering --
+
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 0
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_dyn_expo = 0
+set dterm_lpf1_static_hz = 90
+
+# -- Antigravity --
+
+set anti_gravity_gain = 4000
+
+# -- Feedforward jitter reduction --
+
+set feedforward_jitter_reduction = 12
+
+#$ OPTION BEGIN (CHECKED): RPM filtering --
+
+set dshot_bidir = ON
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 120
+set gyro_lpf1_dyn_max_hz = 350
+set dyn_notch_count = 2
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+set rpm_filter_harmonics = 3
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): With HD Cam
+
+# -- PID values --
+
+set p_pitch = 77
+set i_pitch = 96
+set d_pitch = 51
+set f_pitch = 159
+set p_roll = 64
+set d_roll = 42
+set f_roll = 132
+set p_yaw = 64
+set f_yaw = 132
+set d_min_roll = 42
+set d_min_pitch = 51
+
+# -- Sliders --
+
+set simplified_master_multiplier = 130
+set simplified_i_gain = 70
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 85
+set simplified_pitch_d_gain = 120
+set simplified_pitch_pi_gain = 120
+set simplified_dterm_filter = OFF
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Without HD Cam
+
+# -- PID values --
+
+set p_pitch = 70
+set i_pitch = 88
+set d_pitch = 47
+set f_pitch = 145
+set p_roll = 64
+set d_roll = 42
+set f_roll = 132
+set p_yaw = 64
+set f_yaw = 132
+set d_min_roll = 42
+set d_min_pitch = 47
+
+# -- Sliders --
+
+set simplified_master_multiplier = 130
+set simplified_i_gain = 70
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 85
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+set simplified_dterm_filter = OFF
+
+#$ OPTION END

--- a/presets/4.3/tune/SupaflyFPV_Freestyle_7_Inch_EasyTune
+++ b/presets/4.3/tune/SupaflyFPV_Freestyle_7_Inch_EasyTune
@@ -1,0 +1,122 @@
+#$ TITLE: SupaflyFPV Freestyle 7 Inch EasyTune
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: Supafly, SupaflyFPV, Freestyle, 7", 7 Inch
+#$ AUTHOR: SupaflyFPV
+#$ DESCRIPTION: Supa-Easy Freestyle Preset for 7 Inch Builds
+#$ DESCRIPTION: Easily tune freestyle builds using only the Master Multiplier Slider
+#$ DESCRIPTION: Select the option for your build with or without HD camera (eg GoPro)
+#$ DESCRIPTION: Half to one click up or down Master Slider to tweak the tune - in OSD or Configurator
+#$ DESCRIPTION: Quad feels loose, click Master up. Quad shakes/oscillates click Master down
+#$ DESCRIPTION: RPM Filtering for best performance (default) - or de-select for Non RPM Setup (check esc compatibility)
+#$ DESCRIPTION: Enjoy!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/41
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Non-RPM Filtering --
+set dshot_bidir = OFF
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 120
+set gyro_lpf1_dyn_max_hz = 350
+set dyn_notch_count = 5
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+
+# -- Dterm filtering --
+
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 0
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_dyn_expo = 0
+set dterm_lpf1_static_hz = 90
+
+# -- Antigravity --
+
+set anti_gravity_gain = 4000
+
+# -- Feedforward jitter reduction --
+
+set feedforward_jitter_reduction = 12
+
+#$ OPTION BEGIN (CHECKED): RPM filtering --
+
+set dshot_bidir = ON
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 120
+set gyro_lpf1_dyn_max_hz = 350
+set dyn_notch_count = 2
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+set rpm_filter_harmonics = 3
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): With HD Cam
+
+# -- PID values --
+
+set p_pitch = 83
+set i_pitch = 103
+set d_pitch = 57
+set f_pitch = 161
+set p_roll = 69
+set i_roll = 86
+set d_roll = 46
+set f_roll = 134
+set p_yaw = 69
+set i_yaw = 86
+set f_yaw = 134
+set d_min_roll = 46
+set d_min_pitch = 57
+
+# -- Sliders --
+
+set simplified_master_multiplier = 140
+set simplified_i_gain = 70
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 80
+set simplified_pitch_d_gain = 125
+set simplified_pitch_pi_gain = 120
+set simplified_dterm_filter = OFF
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Without HD Cam
+
+# -- PID values --
+
+set p_pitch = 76
+set i_pitch = 94
+set d_pitch = 53
+set f_pitch = 147
+set p_roll = 69
+set i_roll = 86
+set d_roll = 46
+set f_roll = 134
+set p_yaw = 69
+set i_yaw = 86
+set f_yaw = 134
+set d_min_roll = 46
+set d_min_pitch = 53
+
+# -- Sliders --
+
+set simplified_master_multiplier = 140
+set simplified_i_gain = 70
+set simplified_d_gain = 110
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 80
+set simplified_pitch_pi_gain = 110
+set simplified_dterm_filter = OFF
+
+#$ OPTION END


### PR DESCRIPTION
SupaflyFPV Freestyle EasyTune

This preset should be applicable to a wide variety of of freetyle builds, and easily tuned using the Master Multiplier Slider.

I think the slider positions correlate quite well with the main Betaflight default when considering the needs of freestyle, and I have taken a policy of leaving any exotic ideas for parameters out and settling for Betaflight defaults and philosophies rather than splitting hairs.

Those 'needs' of freestyle are no great surprise - more PIDs on the pitch axis due to typical freestyle frame design and HD camera...slightly higher D gain for propwash...some of my 'subjective' preferences such as moderate I gains, FF Jitter at 12, Moderate FF, med-heavy static Dterm filtering, reduced Gyro filters to cover the main noise issues robustly and not worry about that which is not there.

RPM option selected as default, if deselected, Non-RPM setup saved. Both setups tested and working well with good performance / robust balance.

Preset Options: 4s and 6s 5” , and a 6/7" Option. They are all made from the same fundamental slider tune.

Can post pics/logs and video to demonstrate if necessary. These numbers have been tested by me and my pilots over the last couple of years and should be about right. A tad on the low side to be safe, easily tweaked with the sliders...
