### PR TITLE
Attribute renamed NOSEARCH to HIDDEN

### DIFF
--- a/indexer/Settings.js
+++ b/indexer/Settings.js
@@ -58,7 +58,7 @@ const settings = {
         description:          {type: MetadataTypes.STRING_ARRAY,     optional: true   },
         include:              {type: MetadataTypes.FILE_PATH_ARRAY,  optional: true   },
         keywords:             {type: MetadataTypes.WORDS_ARRAY,      optional: true   },
-        nosearch:             {type: MetadataTypes.BOOLEAN,          optional: true   },
+        hidden:               {type: MetadataTypes.BOOLEAN,          optional: true   },
         discussion:           {type: MetadataTypes.STRING,           optional: true   },
         warning:              {type: MetadataTypes.STRING,           optional: true   },
         disclaimer:           {type: MetadataTypes.STRING,           optional: true   },


### PR DESCRIPTION
I apologize, forgot to do it long ago.
Readme is already updated by @ctzsnooze and correctly shows `#$ HIDDEN`, not `#$ NOSEARCH`