### PR TITLE
Bardwell rates

### DIFF
--- a/presets/4.3/rates/Bardwell.txt
+++ b/presets/4.3/rates/Bardwell.txt
@@ -1,0 +1,34 @@
+#$ TITLE: Joshua Bardwell rates
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RATES
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: youtube, bardwell, freestyle
+#$ AUTHOR: Joshua Bardwell
+#$ DESCRIPTION: Freestyle rates with 907 deg/sec for roll/pitch and 800 deg/sec for yaw. Relatively smooth around the sticks middle.
+#$ DESCRIPTION: I am Joshua Bardwell and you gonna learn something today!
+#$ DESCRIPTION: Joshua Bardwell - one of the most famous YouTubers in FPV. From thorough gear reviews, to tons of videos about drone building and tuning, his videos have helped get many pilots into the air. People love him for his ability to give simple explanations for difficult and technical issues in FPV.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/94
+#$ INCLUDE: presets/4.3/rates/defaults.txt
+
+set rates_type = BETAFLIGHT
+set roll_rc_rate = 127
+set pitch_rc_rate = 127
+set yaw_rc_rate = 100
+set roll_expo = 40
+set pitch_expo = 40
+set roll_srate = 72
+set pitch_srate = 72
+set yaw_srate = 75
+
+#$ OPTION BEGIN (UNCHECKED): Actual rates analogue
+set rates_type = ACTUAL
+set roll_rc_rate = 15
+set pitch_rc_rate = 15
+set yaw_rc_rate = 20
+set roll_expo = 76
+set pitch_expo = 76
+set yaw_expo = 64
+set roll_srate = 91
+set pitch_srate = 91
+set yaw_srate = 80
+#$ OPTION END


### PR DESCRIPTION
#$ Option provides optional almost identical ACTUAL rates. By default - original JB rates
![image](https://user-images.githubusercontent.com/2925027/143674833-05e8d600-e306-482f-8e2f-e75ec5822457.png)
