### PR TITLE
Vanover rates

### DIFF
--- a/presets/4.3/rates/Vanover.txt
+++ b/presets/4.3/rates/Vanover.txt
@@ -1,0 +1,35 @@
+#$ TITLE: Vanover racing/freestyle rates
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RATES
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: racing, race, vanover, rates, MultiGP, freestyle
+#$ AUTHOR: Alex Vanover
+#$ DESCRIPTION: Racing and freestyle rates by Vanover.
+#$ DESCRIPTION: 488 deg/sec for all axes sounds slow, but it's not if you check Vanover's freestyle and race videos.
+#$ DESCRIPTION: Alex - 2017 MultiGP Champion and DRL pilot 2019, 2020, 2021. 2018 FAI Drone Sports and DR1 Champion. Professional acro drone operator for cinematrography.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/96
+#$ INCLUDE: presets/4.3/rates/defaults.txt
+
+set rates_type = BETAFLIGHT
+set roll_rc_rate = 100
+set pitch_rc_rate = 100
+set yaw_rc_rate = 100
+set roll_expo = 1
+set pitch_expo = 1
+set yaw_expo = 1
+set roll_srate = 59
+set pitch_srate = 59
+set yaw_srate = 59
+
+#$ OPTION BEGIN (UNCHECKED): Actual rates analogue
+set rates_type = ACTUAL
+set roll_rc_rate = 20
+set pitch_rc_rate = 20
+set yaw_rc_rate = 20
+set roll_expo = 43
+set pitch_expo = 43
+set yaw_expo = 43
+set roll_srate = 49
+set pitch_srate = 49
+set yaw_srate = 49
+#$ OPTION END


### PR DESCRIPTION
#$ option provides also actual rates close analogue.
![image](https://user-images.githubusercontent.com/2925027/143725184-04c88d08-2cd3-479c-9e2b-9f2ba3e4404f.png)
