### PR TITLE
limon rates

### DIFF
--- a/presets/4.3/rates/limon.txt
+++ b/presets/4.3/rates/limon.txt
@@ -1,0 +1,25 @@
+#$ TITLE: Limon racing rates
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RATES
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: racing, Limon, OpenRacer, texas, russia, rates, MultiGP
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Fastest Russian racing rates by Limon - Ivan Efimov.
+#$ DESCRIPTION: Actual type of rates with 670 degrees/sec max on all three axes.
+#$ DESCRIPTION: Ivan Efimov - Designer of OpenRacer, Betaflight Dev (fastest Dev in any project) and fastest Russian in the USA
+#$ DESCRIPTION: Optional checkbox provides almost identical rates, but with the type = BETAFLIGHT.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/100/
+#$ INCLUDE: presets/4.3/rates/defaults.txt
+
+#$ OPTION BEGIN (UNCHECKED): Betaflight rates analogue
+set rates_type = BETAFLIGHT
+set roll_rc_rate = 141
+set pitch_rc_rate = 141
+set yaw_rc_rate = 141
+set roll_expo = 22
+set pitch_expo = 22
+set yaw_expo = 22
+set roll_srate = 58
+set pitch_srate = 58
+set yaw_srate = 58
+#$ OPTION END


### PR DESCRIPTION
#$ option provides close analogue in BETAFLIGHT rates
<img width="550" alt="Screen Shot 2021-11-30 at 6 03 01 pm" src="https://user-images.githubusercontent.com/83344205/144003737-3f16f69c-3e12-4de4-b186-c06f2a1df3d0.png">
<img width="532" alt="Screen Shot 2021-11-30 at 6 39 58 pm" src="https://user-images.githubusercontent.com/83344205/144005732-80487782-83a5-495a-9f26-911363312eac.png">

