### PR TITLE
update filters for updated 4.3 slider behaviour

### DIFF
--- a/presets/4.3/filters/ctzsnooze_race.txt
+++ b/presets/4.3/filters/ctzsnooze_race.txt
@@ -12,17 +12,17 @@
 # -- Gyro filters --
 # Single static gyro lowpass at 500hz
 set gyro_lpf1_dyn_min_hz = 0
-set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_dyn_max_hz = 500
 set gyro_lpf1_static_hz = 0
 set gyro_lpf2_static_hz = 500
 
-# Gyro Sliders OFF since only lpf2 is active
-set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 200
+# -- Gyro Sliders (on by default at default but only lowpass2 is active) --
+# only lpf2 is active
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 2
 set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
 
 # -- RPM filtering --
 set dshot_bidir = ON

--- a/presets/4.3/filters/default_rpm_clean.txt
+++ b/presets/4.3/filters/default_rpm_clean.txt
@@ -4,10 +4,10 @@
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: rpm, DShot telemetry, filter, filters, clean, basic, default, betaflight
 #$ AUTHOR: Betaflight
-#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: Required RPM filtering.  Ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: WARNING: May cause motor overheating!
 #$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.  
-#$ DESCRIPTION: If motors get hot, try a filter set for normal or noisy motors, or try enabling gyro filter slider.
+#$ DESCRIPTION: If motors get hot, try a filter set for normal or noisy motors.
 #$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -18,14 +18,13 @@ set dshot_bidir = ON
 # -- Gyro filters --
 # Single static gyro lowpass at 1000Hz
 set gyro_lpf1_dyn_min_hz = 0
-set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_dyn_max_hz = 875
 set gyro_lpf1_static_hz = 0
-set gyro_lpf2_static_hz = 1000
+set gyro_lpf2_static_hz = 875
 
-# -- Gyro Sliders OFF --
-# since only lpf2 is active
-set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 200
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 175
 
 # -- Gyro Static Notches (default)--
 

--- a/presets/4.3/filters/default_rpm_noisy.txt
+++ b/presets/4.3/filters/default_rpm_noisy.txt
@@ -6,7 +6,7 @@
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.
-#$ DESCRIPTION: If motors get hot, try the filter Preset for very noisy motors, or enable slider control for gyro filtering.
+#$ DESCRIPTION: If motors get hot, try the filter Preset for very noisy motors.
 #$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -17,14 +17,13 @@ set dshot_bidir = ON
 # -- Gyro filters --
 # Single static gyro lowpass at 250hz
 set gyro_lpf1_dyn_min_hz = 0
-set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_dyn_max_hz = 250
 set gyro_lpf1_static_hz = 0
 set gyro_lpf2_static_hz = 250
  
-# -- Gyro Sliders OFF --
-# since only lpf2 is active
-set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 75
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 50
 
 # -- Gyro Static Notches (default)--
 
@@ -43,7 +42,7 @@ set dterm_lpf1_static_hz = 127
 
 set dterm_lpf2_static_hz = 127
 
-# -- Dterm sliders --
+# -- Dterm sliders (both filters on by default) --
 set simplified_dterm_filter_multiplier = 85
 
 # -- Yaw lowpass --

--- a/presets/4.3/filters/default_rpm_normal.txt
+++ b/presets/4.3/filters/default_rpm_normal.txt
@@ -4,9 +4,9 @@
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: rpm, DShot telemetry, filter, filters, normal, basic, default, betaflight
 #$ AUTHOR: Betaflight
-#$ DESCRIPTION: Intended for a well maintained build in good condition.
+#$ DESCRIPTION: Intended for a well maintained build in good condition with RPM filtering.
 #$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
-#$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors, or enable the gyro filter slider.
+#$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors.
 #$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -17,22 +17,23 @@ set dshot_bidir = ON
 # -- Gyro filters --
 # Single static gyro lowpass at 500hz
 set gyro_lpf1_dyn_min_hz = 0
-set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_dyn_max_hz = 500
 set gyro_lpf1_static_hz = 0
 set gyro_lpf2_static_hz = 500
 
-# -- Gyro Sliders OFF --
-# since only lpf2 is active
-set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 200
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 100
 
 # -- Gyro Static Notches (default)--
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 2
 set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
 
-# -- RPM filtering --
+# -- RPM filtering (default of 3 notches each at 500hz) --
+# forcing rpm_filter_q to 500 in case it was set to 300 when RPM filtering was off
 set dshot_bidir = ON
 set rpm_filter_q = 500
 

--- a/presets/4.3/filters/default_rpm_very_clean.txt
+++ b/presets/4.3/filters/default_rpm_very_clean.txt
@@ -7,7 +7,7 @@
 #$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!
 #$ DESCRIPTION: Intended only for rock hard frames, motors with good bearings and true shafts, and perfectly balanced props.
-#$ DESCRIPTION: If motors get hot, try a filter set for clean or normal motors, or try enabling gyro filter slider.
+#$ DESCRIPTION: If motors get hot, try a filter set for clean or normal motors.
 #$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -20,11 +20,10 @@ set dshot_bidir = ON
 set gyro_lpf1_dyn_min_hz = 0
 set gyro_lpf1_dyn_max_hz = 1000
 set gyro_lpf1_static_hz = 0
-set gyro_lpf2_static_hz = 0
+set gyro_lpf2_static_hz = 1000
 
-# -- Gyro Sliders OFF --
-# since no gyro filters are active
-set simplified_gyro_filter = OFF
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
 set simplified_gyro_filter_multiplier = 200
 
 # -- Gyro Static Notches (default)--

--- a/presets/4.3/filters/default_rpm_very_noisy.txt
+++ b/presets/4.3/filters/default_rpm_very_noisy.txt
@@ -4,10 +4,10 @@
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: rpm, filter, filters, filtering, very, noisy, very noisy, hot, basic, default, betaflight
 #$ AUTHOR: Betaflight
-#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: Requires RPM filtering - ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.
 #$ DESCRIPTION: Intended for worn, beaten up, or larger (10" and above), builds.
-#$ DESCRIPTION: If motors get hot, try the filter Preset for very noisy motors, or enable sliders for gyro filtering. If motors remain hot despite strong filtering, it may not be a filtering problem.
+#$ DESCRIPTION: If motors remain hot despite strong filtering, it may not be a filtering problem.
 #$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -22,10 +22,9 @@ set gyro_lpf1_dyn_max_hz = 250
 set gyro_lpf1_static_hz = 0
 set gyro_lpf2_static_hz = 125
  
-# -- Gyro Sliders OFF --
-# since only lpf2 is active
-set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 50
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 25
 
 # -- Gyro Static Notches (default)--
 
@@ -44,7 +43,7 @@ set dterm_lpf1_static_hz = 120
 
 set dterm_lpf2_static_hz = 120
 
-# -- Dterm sliders (default) --
+# -- Dterm sliders (on by default) --
 set simplified_dterm_filter_multiplier = 80
 
 # -- Yaw lowpass (default) --


### PR DESCRIPTION
Updates the default filter Presets with support for the changed filter slider behaviours now introduced to 4.3

In most cases just enables the gyro lowpass slider, which now works fine while running only one gyro lowpass in the RPM filter enabled presets.

This will allow a user to apply the gyro filter slider to change their gyro filtering, even if they are only running a single gyro lowpass 2 filter.