### PR TITLE
Add SpeedyBee TX800 VTX Tables EU and US

### DIFF
--- a/presets/4.3/vtx/speedybee_tx800.txt
+++ b/presets/4.3/vtx/speedybee_tx800.txt
@@ -11,21 +11,7 @@
 #$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
 #$ DISCUSSION:  https://github.com/betaflight/firmware-presets/pull/105
 
-# reset basic Vtx settings
-set vtx_channel = 0
-set vtx_power = 0
-set vtx_low_power_disarm = OFF
-set vtx_freq = 0
-set vtx_pit_mode_freq = 0
-set vtx_halfduplex = ON
-set vtx_spi_bus = 0
-
-# reset VTx table
-vtxtable bands 0
-vtxtable channels 0
-vtxtable powerlevels 0
-vtxtable powervalues
-vtxtable powerlabels
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
 
 # Configure common vtxtable settings
 vtxtable bands 5

--- a/presets/4.3/vtx/speedybee_tx800.txt
+++ b/presets/4.3/vtx/speedybee_tx800.txt
@@ -1,0 +1,51 @@
+#$ TITLE: SpeedyBee TX800 VTX Tables
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, speedybee, tx800
+#$ AUTHOR: NemesisXB
+#$ DESCRIPTION: VTX tables for the SpeedyBee TX800.
+#$ DESCRIPTION: Select the regulatory domain in the options (EU or US).
+#$ DISCLAIMER:  Only select one regulatory option. All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+#$ DISCUSSION:  https://github.com/betaflight/firmware-presets/pull/105
+
+# reset basic Vtx settings
+set vtx_channel = 0
+set vtx_power = 0
+set vtx_low_power_disarm = OFF
+set vtx_freq = 0
+set vtx_pit_mode_freq = 0
+set vtx_halfduplex = ON
+set vtx_spi_bus = 0
+
+# reset VTx table
+vtxtable bands 0
+vtxtable channels 0
+vtxtable powerlevels 0
+vtxtable powervalues
+vtxtable powerlabels
+
+# Configure common vtxtable settings
+vtxtable bands 5
+vtxtable channels 8
+vtxtable powerlevels 5
+vtxtable powervalues 25 200 400 600 600
+vtxtable powerlabels 25 200 400 800 800
+
+#$ OPTION BEGIN (UNCHECKED): EU
+vtxtable bands 4
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745    0
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860    0
+vtxtable band 4 RACEBAND R CUSTOM     0    0    0 5769 5806 5843    0    0
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): US
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665    0 5885 5905    0    0
+vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
+#$ OPTION END


### PR DESCRIPTION
## SpeedyBee TX800 VTX tables

Added the SpeedyBee TX800 tables for both EU and US

Link to official VTX Table json file for EU: https://speedybee.s3.amazonaws.com/vtxtable/betaflight/TX800/SpeedyBee-TX800(EU).json

Link to official VTX Table json file for US: https://speedybee.s3.amazonaws.com/vtxtable/betaflight/TX800/SpeedyBee-TX800(USA).json
