### PR TITLE
Blackbox field disable preset

### DIFF
--- a/presets/4.3/other/blackbox_disable.txt
+++ b/presets/4.3/other/blackbox_disable.txt
@@ -1,0 +1,60 @@
+#$ TITLE: 4.3 Blackbox disable settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: OFFICIAL
+#$ KEYWORDS:  blackbox, logging, log, disable, sugarK
+#$ AUTHOR: sugarK
+#$ DESCRIPTION: Allows you to disable certain blackbox data fields to save space and CPU resources 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/110
+#$ INCLUDE: presets/4.3/other/reset_blackbox.txt
+
+
+#$ OPTION BEGIN (UNCHECKED): Disable PID data
+set blackbox_disable_pids = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable RC data
+set blackbox_disable_rc = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable SETPOINT data
+set blackbox_disable_setpoint = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable BATTERY data
+set blackbox_disable_bat = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable MAGNETOMETER data
+set blackbox_disable_mag = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable ALTIMETER data
+set blackbox_disable_alt = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable RSSI data
+set blackbox_disable_rssi = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable GYRO data
+set blackbox_disable_gyro = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable ACCELEROMETER data
+set blackbox_disable_acc = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable DEBUG data
+set blackbox_disable_debug = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable MOTOR data
+set blackbox_disable_motors = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Disable GPS data
+set blackbox_disable_gps = ON
+#$ OPTION END
+
+


### PR DESCRIPTION
this preset alloys to disable logging of the individual data streams in blackbox. useful for saving space or CPU resources on less powerful chipsets.