### PR TITLE
Freedom spec tune

### DIFF
--- a/misc/warnings/en/dshot.txt
+++ b/misc/warnings/en/dshot.txt
@@ -1,0 +1,1 @@
+This preset sets your motor protocol to DSHOT. If your ESC does not support DSHOT then using this preset is extremely DANGEROUS. It can spin up motors even before you arm a drone!!! DO NOT APPLY THIS PRESET IF YOU ARE NOT SURE!

--- a/presets/4.3/filters/defaults.txt
+++ b/presets/4.3/filters/defaults.txt
@@ -6,6 +6,9 @@
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Resets Filter settings to 4.3 defaults
 
+# -- Motor protocol --
+set motor_pwm_protocol = DISABLED
+
 # -- Gyro lowpass filters --
 set gyro_lpf1_type = PT1
 set gyro_lpf1_dyn_min_hz = 250

--- a/presets/4.3/tune/freedom_spec_460g.txt
+++ b/presets/4.3/tune/freedom_spec_460g.txt
@@ -1,0 +1,73 @@
+#$ TITLE: Freedom Spec 460 - 500g
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: sugarK, limon, ctzsnooze, freedom, freedom spec, headsup, five33, 533, racing, race, 5"
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: This tune works ONLY with bidirectional DSHOT 600/300. If your FC can't handle DSHOT600, pelase select DSHOT 300 in the options here.
+#$ DESCRIPTION: If your RC link is anything different from 250hz, please use corresponding preset from RC link category on top of this preset. 
+#$ DESCRIPTION: DO NOT try to fly this tune on any battery besides 3S!
+#$ DESCRIPTION: Freedom spec: 3S LiPo, Headsup 1960kv 2207 motors, HQ R38 5 inch props. Minimum weight with the battery: 460g.
+#$ DESCRIPTION:
+#$ DESCRIPTION: This tune prioritizes clean motor traces at full throttle to make sure your quad flies as fast as possible without loosing energy for heating the motors.
+#$ DESCRIPTION: The less noise the faster your quad flies at full throttle. Make sure your frame is solid, all screws are tight, RC link/OpenTX/EdgeTX is up to date.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Credits: sugarK and ctzsnooze for helping with this preset. It is not done yet and there is some room for more impromements. Stay tuned!
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/116
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+set motor_pwm_protocol = DSHOT600
+
+#$ OPTION BEGIN (UNCHECKED): Dshot300
+set motor_pwm_protocol = Dshot300
+#$ OPTION END
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 600
+set dyn_notch_min_hz = 180
+set dyn_notch_max_hz = 360
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 2
+set rpm_filter_fade_range_hz = 100
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 7
+set dterm_lpf1_type = BIQUAD
+set dterm_lpf1_static_hz = 0
+
+# -- PID Sliders --
+set simplified_i_gain = 80
+set simplified_d_gain = 145
+set simplified_pi_gain = 140
+set simplified_dmax_gain = 50
+set simplified_feedforward_gain = 130
+
+# -- TPA --
+set tpa_rate = 60
+
+# -- Feedforward --
+set feedforward_max_rate_limit = 100
+
+# -- DShot Idle (default)--
+set dshot_idle_value = 100
+
+# -- Dyn Idle --
+set dyn_idle_min_rpm = 30
+
+#$ OPTION BEGIN (UNCHECKED): Force LiPo sell count = 3
+set force_battery_cell_count = 3
+#$ OPTION END
+
+simplified_tuning apply


### PR DESCRIPTION
credits to @sugaarK  and @ctzsnooze 
This tune is not 100% done yet, that's why it is experimantal.
For freedom spec the focus is on clean motor traces at full throttle to make sure the drone does not loose speed because of the extra noisy motor traces. This one seems to be ok so far:

![image](https://user-images.githubusercontent.com/2925027/146754527-a1e7d4eb-e944-4d10-885d-04f703d53961.png)


While still maintaining a good setpoint tracking:

![image](https://user-images.githubusercontent.com/2925027/146754721-53d1090d-97d7-48a9-8af0-6e4d812679b4.png)

there is still some propwash after full throttle sharp 180 turns, but it is moderate.

[logs.zip](https://github.com/betaflight/firmware-presets/files/7744690/logs.zip)



