### PR TITLE
Removed vtx_spi_bus from vtx/defaults. Replaced vtx/defaults.txt with…

### DIFF
--- a/presets/4.3/vtx/HDZero_race2.txt
+++ b/presets/4.3/vtx/HDZero_race2.txt
@@ -5,12 +5,12 @@
 #$ STATUS: COMMUNITY
 #$ KEYWORDS:  vtx, vtx table, HDzero, divimath, shark bite, SA 2.1
 #$ AUTHOR: sugarK
-#$ DESCRIPTION: VTX table for HDZero race 2 
-#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations. 
+#$ DESCRIPTION: VTX table for HDZero race 2
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
 #$ DESCRIPTION: ----------
-#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations. 
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/89
-#$ INCLUDE: presets/4.3/vtx/defaults.txt
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
 #$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
 
 

--- a/presets/4.3/vtx/defaults.txt
+++ b/presets/4.3/vtx/defaults.txt
@@ -15,7 +15,6 @@ set vtx_low_power_disarm = OFF
 set vtx_freq = 0
 set vtx_pit_mode_freq = 0
 set vtx_halfduplex = ON
-set vtx_spi_bus = 0
 
 # reset VTx table
 

--- a/presets/4.3/vtx/rush_sa2.1_vtx_tables.txt
+++ b/presets/4.3/vtx/rush_sa2.1_vtx_tables.txt
@@ -11,7 +11,7 @@
 #$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
 #$ DISCUSSION:  https://github.com/betaflight/firmware-presets/pull/78
 
-#$ INCLUDE: presets/4.3/vtx/defaults.txt
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
 vtxtable bands 5
 vtxtable channels 8
 vtxtable band 1 BAND_A   A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725


### PR DESCRIPTION
vtx_spi_bus in CLI is available only for some targets and really should be set from unified target defaults.