### PR TITLE
Update Tracer_CFV2.txt

### DIFF
--- a/presets/4.3/rc_link/Tracer_CFV2.txt
+++ b/presets/4.3/rc_link/Tracer_CFV2.txt
@@ -7,7 +7,7 @@
 #$ DESCRIPTION: setup fo the various TBS radio links via CRSF
 #$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Hardware > ADC Filter is un-checked! and both radio and the TX unit are all up to date with the latest EdgeTX, OpenTX or FreedomTX
 #$ DESCRIPTION: Please use RC smoothing presets for flying style required. Note base settings are for racing, there is a check box at the end for freestyle.
-#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 this can be checked in your TBS lua.
+#$ DESCRIPTION: There are 2 current types of Crossfire protocol, CFV2 and CFV3 (CFV3 with TBS Firmware V6.07 and newer for Crossfire and Tracer) this can be checked in your TBS lua.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/30
 
 feature RX_SERIAL


### PR DESCRIPTION
Couldn´t find the  version of CFV3 in the Lua Script. Asked in the TBS facebook group and Raphael Pirker answered:

It will automatically negotiate this for you. If you use a recent version of betaflight and a version of tracer or crossfire 6.07 and up it will be v3
