### PR TITLE
redpine

### DIFF
--- a/presets/4.3/rc_link/redpine_666hz.txt
+++ b/presets/4.3/rc_link/redpine_666hz.txt
@@ -1,0 +1,37 @@
+#$ TITLE: Redpine 666Hz
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Redpine, rc, link, 666hz
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: Basic RC link settings for a 666hz Redpine SPI link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the Tx hardware ADC Filter is un-checked!
+#$ DESCRIPTION: If a log shows excessive noise in your feedforward trace, most likely there is a Tx firmware issue.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/148
+
+# rc smoothing should always be enabled with Redpine
+set rc_smoothing = ON
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 70
+set feedforward_jitter_factor = 5
+
+# sharper handling for racing:
+#$ OPTION BEGIN (UNCHECKED): Race feedforward settings
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 4
+#$ OPTION END
+
+# stronger smoothing for HD freestyle:
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
+set feedforward_averaging = 3_POINT
+set feedforward_smooth_factor = 75
+set feedforward_jitter_factor = 9
+#$ OPTION END
+
+# even stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
+set feedforward_averaging = 3_POINT
+set feedforward_smooth_factor = 80
+set feedforward_jitter_factor = 12
+#$ OPTION END


### PR DESCRIPTION
Initial Redpine Filter Preset for its 666Hz link speed protocol, to set appropriate feedforward averaging and smoothing.

If someone has a log file to confirm that it works as expected, please share.