### PR TITLE
add normal tune to Justice's Whoop PR

### DIFF
--- a/presets/4.3/tune/whoop_justice.txt
+++ b/presets/4.3/tune/whoop_justice.txt
@@ -159,7 +159,11 @@ set simplified_i_gain = 50
 set simplified_master_multiplier = 110
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Safer tune (normal builds)
+#$ OPTION BEGIN (UNCHECKED): Normal tune (normal builds)
+# do nothing, it's already applied
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Safer tune (older builds)
 # -- PID values --
 set p_pitch = 68
 set i_pitch = 60


### PR DESCRIPTION
Initial build didn't give user a 'normal tune' option, because it was already applied.

User now chooses
- spicy (Gary's regular tune, on his well maintained quads)
- normal (Slightly softer, for people who occasionally have bent props)
- safer (for people with well used whoops)
