### PR TITLE
FreedomSpec Tune: remove dshot_idle_value

### DIFF
--- a/presets/4.3/tune/freedom_spec_460g.txt
+++ b/presets/4.3/tune/freedom_spec_460g.txt
@@ -60,9 +60,6 @@ set tpa_rate = 60
 # -- Feedforward --
 set feedforward_max_rate_limit = 100
 
-# -- DShot Idle (default)--
-set dshot_idle_value = 100
-
 # -- Dyn Idle --
 set dyn_idle_min_rpm = 30
 


### PR DESCRIPTION
dshot_idle_value does not matter in this preset because dynamic idle is being used anyways.