### PR TITLE
adds OpenVTx presets

### DIFF
--- a/presets/4.3/vtx/OpenVTx_Default_SA2_1.txt
+++ b/presets/4.3/vtx/OpenVTx_Default_SA2_1.txt
@@ -1,0 +1,27 @@
+#$ TITLE: OpenVTx Default - SA 2.1
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, SA 2.1, E7082VM, OVX300, OVX303, OP400
+#$ AUTHOR: Jye Smith
+#$ DESCRIPTION: Default VTX tables for OpenVTx capable video transmitters (Smart Audio 2.1)
+#$ DESCRIPTION: https://github.com/OpenVTx/OpenVTx
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations. 
+#$ DESCRIPTION: ----------
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+#$ DISCUSSION:  https://github.com/betaflight/firmware-presets/pull/155
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+
+vtxtable bands 6
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY 5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B FACTORY 5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E FACTORY 5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F FACTORY 5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 LOWRACE  L FACTORY 5333 5373 5413 5453 5493 5533 5573 5613
+vtxtable powerlevels 5
+vtxtable powervalues 1 2 14 20 26
+vtxtable powerlabels 0 RCE 25 100 400

--- a/presets/4.3/vtx/OpenVTx_Default_TRAMP.txt
+++ b/presets/4.3/vtx/OpenVTx_Default_TRAMP.txt
@@ -1,0 +1,28 @@
+#$ TITLE: OpenVTx Default - TRAMP
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, TRAMP, E7082VM, OVX300, OVX303, OP400
+#$ AUTHOR: Jye Smith
+#$ DESCRIPTION: Default VTX tables for OpenVTx capable video transmitters (TRAMP)
+#$ DESCRIPTION: https://github.com/OpenVTx/OpenVTx
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations. 
+#$ DESCRIPTION: ----------
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+#$ DISCUSSION:  https://github.com/betaflight/firmware-presets/pull/155
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+
+vtxtable bands 7
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 LOWRACE  L CUSTOM  5333 5373 5413 5453 5493 5533 5573 5613
+vtxtable band 7 IMD6     I CUSTOM  5732 5765 5828 5840 5866 5740    0    0
+vtxtable powerlevels 5
+vtxtable powervalues 1 2 25 100 400
+vtxtable powerlabels 0 RCE 25 100 400


### PR DESCRIPTION
This PR adds default VTx tables for the OpenVTx project. https://github.com/OpenVTx/OpenVTx

Currently there are 2 HappyModel and a NamelessRC VTx available.  A 4th is in production.