### PR TITLE
Added DJI Normal RC_Link Preset

### DIFF
--- a/presets/4.3/rc_link/DJI_Normal.txt
+++ b/presets/4.3/rc_link/DJI_Normal.txt
@@ -1,0 +1,53 @@
+#$ TITLE: DJI Normal
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: DJI, rc, link, transmitter
+#$ AUTHOR: UAV Tech (Mark Spatz)
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/179
+#$ DESCRIPTION: Basic RC link settings for DJI link via. "NORMAL" SBUS.
+#$ DESCRIPTION: See the Settings -> Device -> Protocol in your DJI goggles for which TX link speed you have selected.
+#$ DESCRIPTION: This preset is for any Air Unit (full size (DJI) or Lite (CADXX Vista))
+#$ DESCRIPTION: 
+#$ DESCRIPTION: This preset sets:
+#$ DESCRIPTION: - Feedforward Jitter Factor
+#$ DESCRIPTION: - Feedforward Smoothing Factor
+#$ DESCRIPTION: - Feedforward Averaging
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+feature RX_SERIAL
+set serialrx_provider = SBUS
+set sbus_baud_fast = OFF
+
+# rc smoothing should always be enabled with DJI
+set rc_smoothing = ON
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 30
+set feedforward_jitter_factor = 7
+
+# sharper handling for racing:
+#$ OPTION BEGIN (UNCHECKED): Race feedforward settings
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 25
+set feedforward_jitter_factor = 7
+#$ OPTION END
+
+# stronger smoothing for HD freestyle:
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 30
+set feedforward_jitter_factor = 12
+#$ OPTION END
+
+# stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 40
+set feedforward_jitter_factor = 15
+#$ OPTION END


### PR DESCRIPTION

DJI "Normal" protocol preset.

Settings/Option under this preset include ---

Race feedforward settings:
![image](https://user-images.githubusercontent.com/25570978/152368224-c6736e56-a2aa-4b56-ba06-f909369e3fab.png)


HD Freestyle feedforward settings:
![image](https://user-images.githubusercontent.com/25570978/152368482-d24a3acf-bd22-4500-89e3-613ab8053fd1.png)


Cinematch feedforward settings:
![image](https://user-images.githubusercontent.com/25570978/152368580-7315cc4e-24e5-4837-ba40-1213eaf9c3d9.png)
