### PR TITLE
Added DJI SBUS Fast RC_Link Preset

### DIFF
--- a/presets/4.3/rc_link/DJI_SBUS_Fast.txt
+++ b/presets/4.3/rc_link/DJI_SBUS_Fast.txt
@@ -1,0 +1,53 @@
+#$ TITLE: DJI SBUS FAST
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: DJI, rc, link, SBUS fast
+#$ AUTHOR: UAV Tech (Mark Spatz)
+#$ DISCUSSION: 
+#$ DESCRIPTION: Basic RC link settings for DJI link via. "SBUS FAST".
+#$ DESCRIPTION: See the Settings -> Device -> Protocol in your DJI goggles for which TX link speed you have selected.
+#$ DESCRIPTION: This preset is for any Air Unit (full size (DJI) or Lite (CADXX Vista))
+#$ DESCRIPTION: 
+#$ DESCRIPTION: This preset sets:
+#$ DESCRIPTION: - Feedforward Jitter Factor
+#$ DESCRIPTION: - Feedforward Smoothing Factor
+#$ DESCRIPTION: - Feedforward Averaging
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+feature RX_SERIAL
+set serialrx_provider = SBUS
+set sbus_baud_fast = ON
+
+# rc smoothing should always be enabled with DJI
+set rc_smoothing = ON
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 45
+set feedforward_jitter_factor = 10
+
+# sharper handling for racing:
+#$ OPTION BEGIN (UNCHECKED): Race feedforward settings
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 35
+set feedforward_jitter_factor = 7
+#$ OPTION END
+
+# stronger smoothing for HD freestyle (not for racing):
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 12
+#$ OPTION END
+
+# stronger smoothing for Cinematic flying (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 70
+set feedforward_jitter_factor = 15
+#$ OPTION END


### PR DESCRIPTION
DJI "SBUS Fast" protocol preset.

Settings/Option under this preset include ---

Race feedforward settings:
![image](https://user-images.githubusercontent.com/25570978/152369956-d3943d41-b321-462e-bae2-dda04f37405b.png)


HD Freestyle feedforward settings:
![image](https://user-images.githubusercontent.com/25570978/152370057-2aa999ba-5b1c-4c6a-9ba1-9ee616486c13.png)


Cinematch feedforward settings:
![image](https://user-images.githubusercontent.com/25570978/152370133-a349fa62-32a3-4782-b84c-b8666bc927fd.png)
