### PR TITLE
Garban rates

### DIFF
--- a/presets/4.3/rates/Garban_race.txt
+++ b/presets/4.3/rates/Garban_race.txt
@@ -1,0 +1,28 @@
+#$ TITLE: Garban Official race rates
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RATES
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: racing, rates, DDC, Acrobaix, Garban
+#$ AUTHOR: Garban
+#$ DESCRIPTION: Racing rates from Josep de la Fuente (Garban), one of the fastest pilot in Catalonia.
+#$ DESCRIPTION: With 482 deg/sec on roll, pitch and yaw. 
+#$ DESCRIPTION: Garban's throttle curve is available as an option here. Check it out! 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/188
+#$ INCLUDE: presets/4.3/rates/defaults.txt
+
+set rates_type = BETAFLIGHT
+set roll_rc_rate = 106
+set pitch_rc_rate = 106
+set yaw_rc_rate = 106
+set roll_expo = 10
+set pitch_expo = 10
+set yaw_expo = 5
+set roll_srate = 56
+set pitch_srate = 56
+set yaw_srate = 56
+
+# improved curve:
+#$ OPTION BEGIN (UNCHECKED): Improved throttle curve
+set thr_mid = 30
+set thr_expo = 18
+#$ OPTION END


### PR DESCRIPTION
Racing rates from Josep de la Fuente (Garban), one of the fastest pilot in Catalonia
With 482 deg/sec on roll, pitch and  yaw
Also with a throttle curve in order to improve low throttle

Still using Betaflight Rates.

![Rates Garban](https://user-images.githubusercontent.com/55061207/154802479-752ae37a-e8f4-409d-a1d4-6928747274b5.JPG)

and a comparison of the percentages of change in each stick position with other fastest pilot rates

![comp](https://user-images.githubusercontent.com/55061207/154804142-2a6b5435-3396-444d-9cf4-fbe2d92a3ec2.JPG)


