### PR TITLE
add smoothing options to links

### DIFF
--- a/presets/4.3/rc_link/defaults.txt
+++ b/presets/4.3/rc_link/defaults.txt
@@ -1,13 +1,24 @@
-#$ TITLE: Reset RC link feedforward related settings
+#$ TITLE: Reset RC related settings
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: defaults, reset, rc link, rc_link, feedforward, ff
+#$ KEYWORDS: defaults, Rx, RC, reset, rc link, rc_link, smoothing, rc_smoothing
 #$ AUTHOR: Betaflight
-#$ DESCRIPTION: Resets RC_LINK feedforward smoothing/jitter/averaging parameters.
+#$ DESCRIPTION: Resets RC related settings to defaults
 #$ PRIORITY: 0
+
+# NOTE TO AUTHORS: Always include this Preset in any RC Preset
 
 set feedforward_averaging = OFF
 set feedforward_smooth_factor = 25
 set feedforward_jitter_factor = 7
+set feedforward_transition = 0
+set feedforward_boost = 15
+
 set rc_smoothing = ON
+set rc_smoothing_auto_factor = 30
+set rc_smoothing_auto_factor_throttle = 30
+set rc_smoothing_setpoint_cutoff = 0
+set rc_smoothing_feedforward_cutoff = 0
+set rc_smoothing_throttle_cutoff = 0
+set rc_smoothing_debug_axis = ROLL

--- a/presets/4.3/rc_link/elrs_150hz.txt
+++ b/presets/4.3/rc_link/elrs_150hz.txt
@@ -2,44 +2,84 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: ELRS, rc, link, rc_link, 150Hz, express
+#$ KEYWORDS: ELRS, express, 150Hz, rc, rx, link, smoothing
 #$ AUTHOR: ctzsnooze
-#$ DESCRIPTION: Basic RC link settings for a 150Hz ELRS link via CRSF.
+#$ DESCRIPTION: RC link settings for a 150Hz ELRS link via CRSF.
 #$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
 #$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-#$ DESCRIPTION: Sends single cell voltage back to the transmitter, unless you choose the whole pack option.
+#$ DESCRIPTION: WARNING: Cinematic settings are very smooth - there is noticeable delay in stick response
 
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+# basic requirements for ExpressLRS 
 feature RX_SERIAL
 set serialrx_provider = CRSF
 
-# rc smoothing should always be enabled with ELRS
-set rc_smoothing = ON
-
+# 150hz default settings in case no tuning option is selected
 set feedforward_averaging = OFF
 set feedforward_smooth_factor = 30
 set feedforward_jitter_factor = 7
 
 #$ OPTION_GROUP BEGIN: Fine-tuning...
 
-# sharper handling for racing:
-#$ OPTION BEGIN (UNCHECKED): Race feedforward settings
-set feedforward_averaging = NONE
-set feedforward_smooth_factor = 15
-set feedforward_jitter_factor = 10
+# sharper handling for racing (25 of auto RC smoothing = 80hz RC smoothing):
+#$ OPTION BEGIN (UNCHECKED): Racing
+set feedforward_smooth_factor = 25
+set feedforward_jitter_factor = 5
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25
 #$ OPTION END
 
-# stronger smoothing for HD freestyle:
-#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
-set feedforward_averaging = 2_POINT
+# default is suitable for freestyle (30 of RC smoothing is approx 45hz RC smoothing)
+#$ OPTION BEGIN (UNCHECKED): Freestyle
+set feedforward_jitter_factor = 9
+#$ OPTION END
+
+# stronger smoothing for HD freestyle (not for racing):
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle
+set feedforward_smooth_factor = 30
+set feedforward_jitter_factor = 10
+set rc_smoothing_auto_factor = 80
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25
+#$ OPTION END
+
+# very smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic
 set feedforward_smooth_factor = 35
-set feedforward_jitter_factor = 10
+set feedforward_jitter_factor = 12
+set rc_smoothing_auto_factor = 175
+set rc_smoothing_auto_factor_throttle = 100
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20
 #$ OPTION END
 
-# very smooth for Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 50
-set feedforward_jitter_factor = 18
+# ultra smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
+set feedforward_smooth_factor = 40
+set feedforward_jitter_factor = 16
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 100
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+
+#$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): SPI, on the FC
+feature -RX_SERIAL
+feature RX_SPI
+set rx_spi_protocol = EXPRESSLRS
 #$ OPTION END
 
 #$ OPTION_GROUP END
@@ -57,3 +97,22 @@ set report_cell_voltage = OFF
 #$ OPTION END
 
 #$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Cinematic Rates (optional)
+
+#$ OPTION BEGIN (UNCHECKED): Actual, Centre = 2
+set rates_type = ACTUAL
+set roll_rc_rate = 2
+set pitch_rc_rate = 2
+set yaw_rc_rate = 2
+set roll_expo = 0
+set pitch_expo = 0
+set yaw_expo = 0
+set roll_srate = 50
+set pitch_srate = 50
+set yaw_srate = 50
+#$ OPTION END
+
+#$ OPTION_GROUP END
+

--- a/presets/4.3/rc_link/elrs_250hz.txt
+++ b/presets/4.3/rc_link/elrs_250hz.txt
@@ -2,50 +2,92 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: ELRS, rc, link, 250Hz, express
+#$ KEYWORDS: ELRS, express, 250Hz, rc, rx, link, smoothing
 #$ AUTHOR: ctzsnooze
-#$ DESCRIPTION: Basic RC link settings for a 250Hz ELRS link via CRSF.
+#$ DESCRIPTION: RC link settings for a 250Hz ELRS link via CRSF.
 #$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
 #$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-#$ DESCRIPTION: Sends single cell voltage back to the transmitter, unless you choose the whole pack option.
+#$ DESCRIPTION: WARNING: Cinematic settings are very smooth - there is noticeable delay in stick response
 
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+# basic requirements for ExpressLRS 
 feature RX_SERIAL
 set serialrx_provider = CRSF
 
-# rc smoothing should always be enabled with ELRS
-set rc_smoothing = ON
-
+# 250hz default settings in case no-one selects a tuning option
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 45
 set feedforward_jitter_factor = 6
 
 #$ OPTION_GROUP BEGIN: Fine-tuning...
 
-# sharper handling for racing:
-#$ OPTION BEGIN (UNCHECKED): Race feedforward settings
-set feedforward_averaging = 2_POINT
+# sharp handling for racing:
+#$ OPTION BEGIN (UNCHECKED): Racing (25 of auto RC smoothing = 140hz RC smoothing)
 set feedforward_smooth_factor = 35
-set feedforward_jitter_factor = 5
+set feedforward_jitter_factor = 4
+set feedforward_boost = 18
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25
+#$ OPTION END
+
+# for freestyle auto smoothing of 52 is about 60hz:
+#$ OPTION BEGIN (UNCHECKED): Freestyle
+set feedforward_jitter_factor = 8
+set rc_smoothing_auto_factor = 52
 #$ OPTION END
 
 # stronger smoothing for HD freestyle (not for racing):
-#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
-set feedforward_averaging = 2_POINT
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle
 set feedforward_smooth_factor = 45
-set feedforward_jitter_factor = 9
+set feedforward_jitter_factor = 10
+set rc_smoothing_auto_factor = 140
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25
 #$ OPTION END
 
-# very smooth for Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
+# very smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic
+set feedforward_smooth_factor = 60
 set feedforward_jitter_factor = 12
+set rc_smoothing_auto_factor = 250  
+set rc_smoothing_auto_factor_throttle = 170
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20
+#$ OPTION END
+
+# ultra smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 15
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 170
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20
 #$ OPTION END
 
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+
+#$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): SPI, on the FC
+feature -RX_SERIAL
+feature RX_SPI
+set rx_spi_protocol = EXPRESSLRS
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Voltage telemtry readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values
@@ -54,6 +96,24 @@ set report_cell_voltage = ON
 
 #$ OPTION BEGIN (UNCHECKED): Whole pack values
 set report_cell_voltage = OFF
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Cinematic Rates (optional)
+
+#$ OPTION BEGIN (UNCHECKED): Actual, Centre = 2
+set rates_type = ACTUAL
+set roll_rc_rate = 2
+set pitch_rc_rate = 2
+set yaw_rc_rate = 2
+set roll_expo = 0
+set pitch_expo = 0
+set yaw_expo = 0
+set roll_srate = 50
+set pitch_srate = 50
+set yaw_srate = 50
 #$ OPTION END
 
 #$ OPTION_GROUP END

--- a/presets/4.3/rc_link/elrs_500hz.txt
+++ b/presets/4.3/rc_link/elrs_500hz.txt
@@ -2,50 +2,87 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: ELRS, rc, link, 500Hz, express
+#$ KEYWORDS: ELRS, express, 500Hz, rc, rx, link, smoothing, 
 #$ AUTHOR: ctzsnooze
-#$ DESCRIPTION: Basic RC link settings for a 500Hz ELRS link via CRSF.
+#$ DESCRIPTION: RC link settings for a 500Hz ELRS link via CRSF.
 #$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
 #$ DESCRIPTION: WARNING: Use a compatible version of EdgeTx or OpenTx!
+#$ DESCRIPTION: WARNING: Cinematic settings are very smooth - there is noticeable delay in stick response
 #$ DESCRIPTION: If a log shows excessive noise in your feedforward trace, most likely there is a Tx firmware issue.
-#$ DESCRIPTION: Sends single cell voltage back to the transmitter, unless you choose the whole pack option.
 
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+# basic requirements for ExpressLRS 
 feature RX_SERIAL
 set serialrx_provider = CRSF
 
-# rc smoothing should always be enabled with ELRS
-set rc_smoothing = ON
-
+# 500hz default settings in case no-one selects a tuning option
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 65
 set feedforward_jitter_factor = 5
 
 #$ OPTION_GROUP BEGIN: Fine-tuning...
 
-# sharper handling for racing:
+# sharp handling for racing (25 of auto RC smoothing = 290hz RC smoothing):
 #$ OPTION BEGIN (UNCHECKED): Race feedforward settings
 set feedforward_smooth_factor = 65
-set feedforward_jitter_factor = 4
+set feedforward_jitter_factor = 3
+set feedforward_boost = 18
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25
 #$ OPTION END
 
-# stronger smoothing for HD freestyle:
-#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
-set feedforward_averaging = 3_POINT
+# at 500hz auto smoothing of 120 is close to 60hz:
+#$ OPTION BEGIN (UNCHECKED): Freestyle
+set feedforward_jitter_factor = 7
+set rc_smoothing_auto_factor = 120
+#$ OPTION END
+
+# stronger smoothing for HD freestyle (not for racing):
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 9
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25
+#$ OPTION END
+
+# smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic
 set feedforward_smooth_factor = 70
-set feedforward_jitter_factor = 8
+set feedforward_jitter_factor = 11
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 250
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20
 #$ OPTION END
 
-# very smooth, for Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
-set feedforward_averaging = 3_POINT
+# ultra smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
 set feedforward_smooth_factor = 75
-set feedforward_jitter_factor = 12
+set feedforward_jitter_factor = 13
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 250
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20
 #$ OPTION END
 
-# per cell or whole pack voltage readings back via telemetry to Tx:
-set report_cell_voltage = ON
-#$ OPTION BEGIN (UNCHECKED): Whole pack voltage readings to Tx
-set report_cell_voltage = OFF
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+
+#$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): SPI, on the FC
+feature -RX_SERIAL
+feature RX_SPI
+set rx_spi_protocol = EXPRESSLRS
 #$ OPTION END
 
 #$ OPTION_GROUP END
@@ -63,3 +100,22 @@ set report_cell_voltage = OFF
 #$ OPTION END
 
 #$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Cinematic Rates (optional)
+
+#$ OPTION BEGIN (UNCHECKED): Actual, Centre = 2
+set rates_type = ACTUAL
+set roll_rc_rate = 2
+set pitch_rc_rate = 2
+set yaw_rc_rate = 2
+set roll_expo = 0
+set pitch_expo = 0
+set yaw_expo = 0
+set roll_srate = 50
+set pitch_srate = 50
+set yaw_srate = 50
+#$ OPTION END
+
+#$ OPTION_GROUP END
+

--- a/presets/4.3/rc_link/elrs_50hz.txt
+++ b/presets/4.3/rc_link/elrs_50hz.txt
@@ -2,19 +2,21 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: ELRS, rc, link, rc_link, 50Hz, express
+#$ KEYWORDS: ELRS, express, 50Hz, 20ms, rc, rx, link, smoothing
 #$ AUTHOR: ctzsnooze
-#$ DESCRIPTION: Basic RC link settings for a 50Hz ELRS link via CRSF.
+#$ DESCRIPTION: RC link settings for a 50Hz ELRS link via CRSF.
 #$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
 #$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
-#$ DESCRIPTION: Sends single cell voltage back to the transmitter, unless you choose the whole pack option.
 
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+# basic requirements for ExpressLRS 
 feature RX_SERIAL
 set serialrx_provider = CRSF
 
-# rc smoothing should always be enabled with ELRS
-set rc_smoothing = ON
-
+# 50hz default settings in case no tuning option is selected
 set feedforward_averaging = OFF
 set feedforward_smooth_factor = 0
 set feedforward_jitter_factor = 12
@@ -24,28 +26,63 @@ set feedforward_boost = 5
 #$ OPTION_GROUP BEGIN: Fine-tuning...
 
 # sharper handling for racing - note that 50Hz is too slow for racing
-#$ OPTION BEGIN (UNCHECKED): Race settings (50Hz isn't much good for racing)
+#$ OPTION BEGIN (UNCHECKED): Racing (50Hz isn't any good for racing)
 set feedforward_jitter_factor = 7
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Fast freestyle (better with locked 150hz)
-set feedforward_jitter_factor = 7
+# default is suitable for freestyle, though may transfer 50hz stepping to HD:
+#$ OPTION BEGIN (UNCHECKED): Freestyle
+set feedforward_jitter_factor = 10
 #$ OPTION END
 
 # stronger smoothing for HD freestyle (not for racing):
-#$ OPTION BEGIN (UNCHECKED): HD Freestyle feedforward settings
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle
 set feedforward_jitter_factor = 15
+set rc_smoothing_auto_factor = 20
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25
 #$ OPTION END
 
-# stronger smoothing for Cinematic flying (not for racing):
-#$ OPTION BEGIN (UNCHECKED): Cinematic feedforward settings
-set feedforward_jitter_factor = 25
+# very smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic
+set feedforward_smooth_factor = 20
+set feedforward_jitter_factor = 15
+set rc_smoothing_auto_factor = 35   
+set rc_smoothing_auto_factor_throttle = 28
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20
+#$ OPTION END
+
+# ultra smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
+set feedforward_smooth_factor = 40
+set feedforward_jitter_factor = 20
+set rc_smoothing_auto_factor = 90
+set rc_smoothing_auto_factor_throttle = 28
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20
 #$ OPTION END
 
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage readings (choose one)
+#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+
+#$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): SPI, on the FC
+feature -RX_SERIAL
+feature RX_SPI
+set rx_spi_protocol = EXPRESSLRS
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values
@@ -57,3 +94,22 @@ set report_cell_voltage = OFF
 #$ OPTION END
 
 #$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Cinematic Rates (optional)
+
+#$ OPTION BEGIN (UNCHECKED): Actual, Centre = 2
+set rates_type = ACTUAL
+set roll_rc_rate = 2
+set pitch_rc_rate = 2
+set yaw_rc_rate = 2
+set roll_expo = 0
+set pitch_expo = 0
+set yaw_expo = 0
+set roll_srate = 50
+set pitch_srate = 50
+set yaw_srate = 50
+#$ OPTION END
+
+#$ OPTION_GROUP END
+

--- a/presets/4.3/rc_link/frsky_sbus.txt
+++ b/presets/4.3/rc_link/frsky_sbus.txt
@@ -2,23 +2,22 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: frsky, sbus, rc, link
+#$ KEYWORDS: frsky, sbus, 9ms, 111hz, rc, link, smoothing
 #$ AUTHOR: ctzsnooze
-#$ DESCRIPTION: Basic RC link settings for a 111Hz / 9ms FrSky Sbus link, with the Rx bound in D16 mode with no more than 8 channels.
-#$ DESCRIPTION: These settings work best when used with a version of OpenTx with good module sync.
+#$ DESCRIPTION: RC link settings for a 111Hz / 9ms D16 FrSky Sbus link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: Use a recent version of OpenTx / EdgeTx with good module sync.
 #$ DESCRIPTION: Note: Telemetry requires smartPort (s.Port) and does not convey RSSI (use Lua or analog RSSI).
-#$ DESCRIPTION: Note: When more than 8 channels are bound, manual RC smoothing settings and two point averaging is required.
-#$ DESCRIPTION: Early versions of OpenTx with poor module sync will require two point averaging.
-#$ DESCRIPTION: Cell vs full voltage option affects which value will be sent by telemetry to the handset. Default is per cell.
-#$ DESCRIPTION: Units default to metric. Telemetry defaults to non-inverted and half-duple. Both can be changed with checkbox.
-#$ DESCRIPTION: Other telemetry settings,eg gps format, default latitude and longitude, extra sensors, require manual CLI entries.
-#$ DESCRIPTION: Other options are provided for the intended flying style.
+
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
 
 feature RX_SERIAL
 set serialrx_provider = SBUS
 set feedforward_averaging = OFF
 set feedforward_smooth_factor = 25
-set feedforward_jitter_factor = 7
+set feedforward_jitter_factor = 8
 set frsky_vfas_precision = 1
 
 # we do not recommend disabling rc smoothing
@@ -32,24 +31,47 @@ set rc_smoothing = ON
 
 #$ OPTION_GROUP BEGIN: Fine-tuning...
 
-# sharper handling for racing:
+# sharper handling for racing (25 of auto RC smoothing = 47hz RC smoothing)
 #$ OPTION BEGIN (UNCHECKED): Race
 set feedforward_smooth_factor = 20
-set feedforward_jitter_factor = 5
+set feedforward_jitter_factor = 6
+set rc_smoothing_auto_factor = 25
+#$ OPTION END
+
+# default is suitable for freestyle (30 of auto RC smoothing = 41hz RC smoothing)
+#$ OPTION BEGIN (UNCHECKED): Freestyle
+set feedforward_jitter_factor = 10
 #$ OPTION END
 
 # stronger smoothing for HD freestyle (not for racing):
 #$ OPTION BEGIN (UNCHECKED): HD Freestyle
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 45
+set feedforward_smooth_factor = 40
 set feedforward_jitter_factor = 12
+set rc_smoothing_auto_factor = 60
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25
 #$ OPTION END
 
-# stronger smoothing for Cinematic flying (not for racing):
+# very smooth Cinematic (not for racing):
 #$ OPTION BEGIN (UNCHECKED): Cinematic
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 60
-set feedforward_jitter_factor = 15
+set feedforward_smooth_factor = 45
+set feedforward_jitter_factor = 14
+set rc_smoothing_auto_factor = 130  
+set rc_smoothing_auto_factor_throttle = 70  
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20
+#$ OPTION END
+
+# ultra smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
+set feedforward_smooth_factor = 45
+set feedforward_jitter_factor = 16
+set rc_smoothing_auto_factor = 260
+set rc_smoothing_auto_factor_throttle = 70
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20
 #$ OPTION END
 
 #$ OPTION_GROUP END
@@ -86,17 +108,17 @@ set frsky_unit = imperial
 
 # telemetry inverted:
 set tlm_inverted = OFF
-#$ OPTION BEGIN (UNCHECKED): Telemetry inverted
+#$ OPTION BEGIN (UNCHECKED): Telemetry inverted (not the default)
 set tlm_inverted = ON
 #$ OPTION END
 
 # telemetry halfduplex:
 set tlm_halfduplex = ON
-#$ OPTION BEGIN (UNCHECKED): Full duplex telemetry
+#$ OPTION BEGIN (UNCHECKED): Full duplex telemetry (not the default)
 set tlm_halfduplex = OFF
 #$ OPTION END
 
-# if bound in D16 with more than 8 channels - sends duplicates all the time - too slow for racing
+# IMPORTANT: Bound in D16 with more than 8 channels = too slow for racing
 #$ OPTION BEGIN (UNCHECKED): Bound with >8 channels (not recommended)
 set feedforward_averaging = 2_POINT
 set feedforward_smooth_factor = 35
@@ -104,3 +126,20 @@ set feedforward_smooth_factor = 35
 
 #$ OPTION_GROUP END
 
+
+#$ OPTION_GROUP BEGIN: Cinematic Rates (optional)
+
+#$ OPTION BEGIN (UNCHECKED): Actual, Centre = 2
+set rates_type = ACTUAL
+set roll_rc_rate = 2
+set pitch_rc_rate = 2
+set yaw_rc_rate = 2
+set roll_expo = 0
+set pitch_expo = 0
+set yaw_expo = 0
+set roll_srate = 50
+set pitch_srate = 50
+set yaw_srate = 50
+#$ OPTION END
+
+#$ OPTION_GROUP END

--- a/presets/4.3/rc_link/redpine_mpm.txt
+++ b/presets/4.3/rc_link/redpine_mpm.txt
@@ -1,12 +1,12 @@
-#$ TITLE: Redpine 666Hz
+#$ TITLE: Redpine MPM
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: RC_LINK
 #$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: Redpine, rc, link, 666Hz
 #$ AUTHOR: ctzsnooze
-#$ DESCRIPTION: Basic RC link settings for a 666Hz Redpine SPI link on a Deviation Tx
-#$ DESCRIPTION: WARNING: Do not use this Preset with Redpine on OpenTx!
-#$ DESCRIPTION: WARNING: be SURE that the Tx hardware ADC Filter is un-checked!
+#$ DESCRIPTION: Basic RC link settings Redpine in a multiprotocol module for OpenTx
+#$ DESCRIPTION: WARNING: This is a slow link, effectively 140hz, not well suited to racing
+#$ DESCRIPTION: WARNING: Be SURE that the Tx hardware ADC Filter is un-checked!
 #$ DESCRIPTION: If a log shows excessive noise in your feedforward trace, most likely there is a Tx firmware issue.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/148
 
@@ -14,46 +14,32 @@
 
 #$ INCLUDE: presets/4.3/rc_link/defaults.txt
 
-
 # rc smoothing should always be enabled with Redpine
 set rc_smoothing = ON
 
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
-set feedforward_jitter_factor = 5
+set feedforward_averaging = 3_POINT
+set feedforward_smooth_factor = 50
+set feedforward_jitter_factor = 8
 
 #$ OPTION_GROUP BEGIN: Fine-tuning...
 
-# sharper handling for racing:
-#$ OPTION BEGIN (UNCHECKED): Race
-set feedforward_jitter_factor = 4
-set feedforward_boost = 18
-set rc_smoothing_auto_factor = 25
-set rc_smoothing_auto_factor_throttle = 25
-#$ OPTION END
-
-# at 500hz auto smoothing of 150 is close to 60hz:
+# manually setting rc_smoothing to 60hz:
 #$ OPTION BEGIN (UNCHECKED): Freestyle
-set feedforward_jitter_factor = 7
-set rc_smoothing_auto_factor = 150
+set feedforward_jitter_factor = 12
+set rc_smoothing_setpoint_cutoff = 60
+set rc_smoothing_feedforward_cutoff = 60
 #$ OPTION END
 
 # stronger smoothing for HD freestyle (not for racing):
 #$ OPTION BEGIN (UNCHECKED): HD Freestyle
-set feedforward_smooth_factor = 70
-set feedforward_jitter_factor = 9
-set rc_smoothing_auto_factor = 250
+set feedforward_jitter_factor = 12
 set rc_smoothing_setpoint_cutoff = 25
 set rc_smoothing_feedforward_cutoff = 25
 #$ OPTION END
 
 # smooth Cinematic (not for racing):
 #$ OPTION BEGIN (UNCHECKED): Cinematic
-set feedforward_averaging = 3_POINT
-set feedforward_smooth_factor = 70
-set feedforward_jitter_factor = 11
-set rc_smoothing_auto_factor = 250
-set rc_smoothing_auto_factor_throttle = 250
+set feedforward_jitter_factor = 12
 set rc_smoothing_setpoint_cutoff = 12
 set rc_smoothing_feedforward_cutoff = 12
 set rc_smoothing_throttle_cutoff = 20
@@ -61,11 +47,7 @@ set rc_smoothing_throttle_cutoff = 20
 
 # ultra smooth Cinematic (not for racing):
 #$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
-set feedforward_averaging = 3_POINT
-set feedforward_smooth_factor = 75
-set feedforward_jitter_factor = 13
-set rc_smoothing_auto_factor = 250
-set rc_smoothing_auto_factor_throttle = 250
+set feedforward_jitter_factor = 14
 set rc_smoothing_setpoint_cutoff = 6
 set rc_smoothing_feedforward_cutoff = 6
 set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_smoothing/cinematic.txt
+++ b/presets/4.3/rc_smoothing/cinematic.txt
@@ -14,7 +14,7 @@
 
 
 set rc_smoothing = ON
-set rc_smoothing_auto_factor = 110
+set rc_smoothing_auto_factor = 100
 set rc_smoothing_auto_factor_throttle = 50
 set rc_smoothing_setpoint_cutoff = 15
 set rc_smoothing_feedforward_cutoff = 15
@@ -36,14 +36,15 @@ set feedforward_smooth_factor = 0
 # for 250Hz RC links:
 #$ OPTION BEGIN (UNCHECKED): 250Hz 
 set rc_smoothing_auto_factor = 120
-set feedforward_smooth_factor = 55
+set rc_smoothing_auto_factor_throttle = 60
+set feedforward_smooth_factor = 60
 set feedforward_jitter_factor = 12
 #$ OPTION END
 
 # for 500Hz RC links:
 #$ OPTION BEGIN (UNCHECKED): 500Hz
 set rc_smoothing_auto_factor = 190
-set feedforward_smooth_factor = 75
+set feedforward_smooth_factor = 70
 set feedforward_jitter_factor = 9
 set feedforward_boost = 18
 #$ OPTION END
@@ -57,7 +58,7 @@ set feedforward_boost = 18
 set rc_smoothing_auto_factor = 130
 set rc_smoothing_setpoint_cutoff = 10
 set rc_smoothing_feedforward_cutoff = 10
-set rc_smoothing_throttle_cutoff = 17
+set rc_smoothing_throttle_cutoff = 15
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): Normal Cinematic

--- a/presets/4.3/rc_smoothing/freestyle.txt
+++ b/presets/4.3/rc_smoothing/freestyle.txt
@@ -35,7 +35,7 @@ set rc_smoothing_feedforward_cutoff = 20
 # for 250Hz RC links:
 #$ OPTION BEGIN (UNCHECKED): 250Hz 
 set feedforward_smooth_factor = 45
-set feedforward_jitter_factor = 10
+set feedforward_jitter_factor = 8
 #$ OPTION END
 
 # for 500Hz RC links:


### PR DESCRIPTION
This is an early draft of how we might include smoothing options within RC links.

The intent is to get, as much as possible, similar stick feel for each 'fine tuning' option, and an appropriate balance between feedforward noise and stick responsiveness.