### PR TITLE
Added parser metaproperty: text/marked

### DIFF
--- a/indexer/PresetsFile.js
+++ b/indexer/PresetsFile.js
@@ -49,6 +49,7 @@ class PresetsFile
         delete this.disclaimer;
         delete this.include_warning;
         delete this.include_disclaimer;
+        delete this.parser;
     }
 
     _checkProperties()
@@ -304,6 +305,9 @@ class PresetsFile
             case this._settings.MetadataTypes.PRIORITY:
                 this._processPriorityProperty(property, line);
                 break;
+            case this._settings.MetadataTypes.PARSER:
+                this._processParserProperty(property, line);
+                break;
             default:
                 this._addError(`line ${this._currentLine}, unknown property type '${this._presetsFileMetadata[property].type}' for the property '${property}'`);
         }
@@ -316,11 +320,20 @@ class PresetsFile
         if (this._settings.PresetStatusEnum.includes(line)) {
             this[property] = line;
         } else {
-            this._addError(`line ${this._currentLine}, unknown ${property} values: '${line}'; available values: ${this._settings.PresetStatusEnum}`);
+            this._addError(`line ${this._currentLine}, unknown ${property} value: '${line}'; available values: ${this._settings.PresetStatusEnum}`);
         }
-
     }
 
+    _processParserProperty(property, line)
+    {
+        this._checkPropertyDublicated(property);
+
+        if (this._settings.ParserEnum.includes(line)) {
+            this[property] = line;
+        } else {
+            this._addError(`line ${this._currentLine}, unknown ${property} value: '${line}'; available values: ${this._settings.ParserEnum}`);
+        }
+    }
 
     _processWordsArrayProperty(property, line)
     {

--- a/indexer/Settings.js
+++ b/indexer/Settings.js
@@ -10,9 +10,11 @@ const MetadataTypes = {
         FILE_PATH_ARRAY:    "FILE_PATH_ARRAY", // array of path/to/file.ext and check if files exist
         PRESET_STATUS:      "PRESET_STATUS", // official/community/experimental
         PRIORITY:           "PRIORITY", // 0..99
+        PARSER:             "PARSER", // TEXT, MARKED
 }
 
 const PresetStatusEnum = ["OFFICIAL", "COMMUNITY", "EXPERIMENTAL"];
+const ParserEnum =       ["TEXT", "MARKED"];
 
 const PresetCategories = {
     TUNE:           "TUNE",
@@ -63,6 +65,7 @@ const settings = {
     OptionsDirectives : Object.freeze(OptionsDirectives),
 
     PresetStatusEnum : Object.freeze(PresetStatusEnum),
+    ParserEnum : Object.freeze(ParserEnum),
 
     presetsDir: "presets",
     presetsFileEncoding: "utf-8",
@@ -84,6 +87,7 @@ const settings = {
         include_disclaimer:   {type: MetadataTypes.FILE_PATH_ARRAY,  optional: true   },
         priority:             {type: MetadataTypes.PRIORITY,         optional: true   },
         force_options_review: {type: MetadataTypes.BOOLEAN,          optional: true   },
+        parser:               {type: MetadataTypes.PARSER,           optional: true   },
     }),
 }
 

--- a/presets/4.3/tune/freedom_spec_460g.txt
+++ b/presets/4.3/tune/freedom_spec_460g.txt
@@ -4,15 +4,31 @@
 #$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: sugarK, limon, ctzsnooze, freedom, freedom spec, headsup, five33, 533, racing, race, 5"
 #$ AUTHOR: Ivan Efimov (Limon)
-#$ DESCRIPTION: This tune works ONLY with bidirectional DSHOT 600/300. If your FC can't handle DSHOT600, pelase select DSHOT 300 in the options here.
-#$ DESCRIPTION: If your RC link is anything different from 250Hz, please use corresponding preset from RC link category on top of this preset.
-#$ DESCRIPTION: DO NOT try to fly this tune on any battery besides 3S!
-#$ DESCRIPTION: Freedom spec: 3S LiPo, Headsup 1960kv 2207 motors, HQ R38 5 inch props. Minimum weight with the battery: 460g.
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/2925027/156102810-87aadfd2-5910-4381-8930-189ff7aa4e87.png" width="250px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Important
+#$ DESCRIPTION: ----------
+#$ DESCRIPTION: 1.  This tune works ONLY with **bidirectional** DSHOT 600/300. If your FC can't handle DSHOT600, pelase select DSHOT 300 in the options here.
+#$ DESCRIPTION: 2.  If your RC link is anything different from 250Hz, please use corresponding preset from RC link category on top of this preset.
+#$ DESCRIPTION: 3.  **Do NOT** try to fly this tune on any battery besides 3S!
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Freedom spec most recent rules are listed [here](https://freedomspec.com/about-1).
 #$ DESCRIPTION:
 #$ DESCRIPTION: This tune prioritizes clean motor traces at full throttle to make sure your quad flies as fast as possible without loosing energy for heating the motors.
 #$ DESCRIPTION: The less noise the faster your quad flies at full throttle. Make sure your frame is solid, all screws are tight, RC link/OpenTX/EdgeTX is up to date.
 #$ DESCRIPTION:
-#$ DESCRIPTION: Credits: sugarK and ctzsnooze for helping with this preset. It is not done yet and there is some room for more impromements. Stay tuned!
+#$ DESCRIPTION: This preset is not done yet and there is some room for more impromements. Stay tuned!
+#$ DESCRIPTION:
+#$ DESCRIPTION: Credits:
+#$ DESCRIPTION: -------
+#$ DESCRIPTION: *  [sugarK](https://github.com/sugaarK)
+#$ DESCRIPTION: *  [ctzsnooze](https://github.com/ctzsnooze)
 
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/116
 #$ INCLUDE_WARNING: misc/warnings/en/dshot.txt


### PR DESCRIPTION
Allowing [Marked ](https://marked.js.org/)for presets description to make them nicer.

new optional metaproperty:
`#$ PARSER: MARKED/TEXT`

default is TEXT

Corresponding Configurator PR:
https://github.com/betaflight/betaflight-configurator/pull/2841

Example:

![image](https://user-images.githubusercontent.com/2925027/156114694-c5dbd6aa-f7d5-4370-b5f4-7d2d9c694343.png)

To test:
Download Configurator from the configurator PR.
Add custom preset source - yours or this one:
link: https://github.com/limonspb/firmware-presets
branch: marked-demo
