### PR TITLE
ghost 11bit 250hz preset

### DIFF
--- a/presets/4.3/rc_link/ghost_250hz.txt
+++ b/presets/4.3/rc_link/ghost_250hz.txt
@@ -1,0 +1,95 @@
+#$ TITLE: Ghost 250Hz
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: Ghost, rc, rx, link, 250Hz, 11bit, smoothing
+#$ AUTHOR: ctzsnooze
+#$ DESCRIPTION: RC link settings for an 11-bit 250Hz Ghost link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible, recent version of EdgeTx or OpenTx!
+#$ DESCRIPTION: WARNING: Cinematic settings are very smooth - there is noticeable delay in stick response
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/194
+
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+feature RX_SERIAL
+set serialrx_provider = GHST
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+# basic requirements for Ghost
+set rc_smoothing = ON
+
+# some default settings in case no-one selects a tuning option
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 35
+set feedforward_jitter_factor = 6
+
+#$ OPTION_GROUP BEGIN: Fine-tuning...
+
+# sharp handling for racing:
+#$ OPTION BEGIN (UNCHECKED): Racing (25 of auto RC smoothing = 140hz RC smoothing)
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 25
+set feedforward_jitter_factor = 4
+set feedforward_boost = 18
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25
+#$ OPTION END
+
+# for freestyle auto smoothing of 52 is about 60hz:
+#$ OPTION BEGIN (UNCHECKED): Freestyle
+set feedforward_jitter_factor = 8
+set rc_smoothing_auto_factor = 52
+#$ OPTION END
+
+# stronger smoothing for HD freestyle (not for racing):
+#$ OPTION BEGIN (UNCHECKED): HD Freestyle
+set feedforward_jitter_factor = 10
+set rc_smoothing_auto_factor = 140
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25
+#$ OPTION END
+
+# very smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Cinematic
+set feedforward_smooth_factor = 45
+set feedforward_jitter_factor = 12
+set rc_smoothing_auto_factor = 230  
+set rc_smoothing_auto_factor_throttle = 170
+set rc_smoothing_setpoint_cutoff = 15
+set rc_smoothing_feedforward_cutoff = 15
+set rc_smoothing_throttle_cutoff = 20
+#$ OPTION END
+
+# ultra smooth Cinematic (not for racing):
+#$ OPTION BEGIN (UNCHECKED): Ultra Cinematic
+set feedforward_smooth_factor = 60
+set feedforward_jitter_factor = 15
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 170
+set rc_smoothing_setpoint_cutoff = 8
+set rc_smoothing_feedforward_cutoff = 8
+set rc_smoothing_throttle_cutoff = 20
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Cinematic Rates (optional)
+
+#$ OPTION BEGIN (UNCHECKED): Actual, Centre = 2
+set rates_type = ACTUAL
+set roll_rc_rate = 2
+set pitch_rc_rate = 2
+set yaw_rc_rate = 2
+set roll_expo = 0
+set pitch_expo = 0
+set yaw_expo = 0
+set roll_srate = 50
+set pitch_srate = 50
+set yaw_srate = 50
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
@daleckystepan provided me some logs with the latest 11-bit 250Hz Ghost setup, and from that data I have made this Preset.

Values are very similar to ELRS 250hz but with 11 bit resolution, a bit less smoothing and averaging is needed.  