### PR TITLE
Added generic RC link presets: 50hz, 150hz, 250hz, 500hz

### DIFF
--- a/presets/4.3/rc_link/generic/150hz_cinematic.txt
+++ b/presets/4.3/rc_link/generic/150hz_cinematic.txt
@@ -1,0 +1,23 @@
+#$ TITLE: Generic 150Hz Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 150Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for cinematic flying with 150Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 35
+set feedforward_jitter_factor = 12
+
+set rc_smoothing_auto_factor = 175
+set rc_smoothing_auto_factor_throttle = 100
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/150hz_freestyle.txt
+++ b/presets/4.3/rc_link/generic/150hz_freestyle.txt
@@ -1,0 +1,17 @@
+#$ TITLE: Generic 150Hz Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 150Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for freestyle with 150Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 30
+set feedforward_jitter_factor = 9

--- a/presets/4.3/rc_link/generic/150hz_hd_freestyle.txt
+++ b/presets/4.3/rc_link/generic/150hz_hd_freestyle.txt
@@ -1,0 +1,21 @@
+#$ TITLE: Generic 150Hz HD Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 150Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for HD freestyle with 150Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 30
+set feedforward_jitter_factor = 10
+
+set rc_smoothing_auto_factor = 80
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25

--- a/presets/4.3/rc_link/generic/150hz_race.txt
+++ b/presets/4.3/rc_link/generic/150hz_race.txt
@@ -1,0 +1,20 @@
+#$ TITLE: Generic 150Hz Race
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 150Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for racing with 150Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 25
+set feedforward_jitter_factor = 5
+
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25

--- a/presets/4.3/rc_link/generic/150hz_ultra_cinematic.txt
+++ b/presets/4.3/rc_link/generic/150hz_ultra_cinematic.txt
@@ -1,0 +1,23 @@
+#$ TITLE: Generic 150Hz Ultra Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 150Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for ultra smooth cinematic with 150Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 40
+set feedforward_jitter_factor = 16
+
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 100
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/250hz_cinematic.txt
+++ b/presets/4.3/rc_link/generic/250hz_cinematic.txt
@@ -1,0 +1,23 @@
+#$ TITLE: Generic 250Hz Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 250Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for cinematic flying with 250Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 60
+set feedforward_jitter_factor = 12
+
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 170
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/250hz_freestyle.txt
+++ b/presets/4.3/rc_link/generic/250hz_freestyle.txt
@@ -1,0 +1,19 @@
+#$ TITLE: Generic 250Hz Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 250Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for freestyle with 250Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 45
+set feedforward_jitter_factor = 8
+
+set rc_smoothing_auto_factor = 52

--- a/presets/4.3/rc_link/generic/250hz_hd_freestyle.txt
+++ b/presets/4.3/rc_link/generic/250hz_hd_freestyle.txt
@@ -1,0 +1,21 @@
+#$ TITLE: Generic 250Hz HD Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 250Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for HD freestyle with 250Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 45
+set feedforward_jitter_factor = 10
+
+set rc_smoothing_auto_factor = 140
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25

--- a/presets/4.3/rc_link/generic/250hz_race.txt
+++ b/presets/4.3/rc_link/generic/250hz_race.txt
@@ -1,0 +1,21 @@
+#$ TITLE: Generic 250Hz Race
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 250Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for racing with 250Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 35
+set feedforward_jitter_factor = 4
+set feedforward_boost = 18
+
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25

--- a/presets/4.3/rc_link/generic/250hz_ultra_cinematic.txt
+++ b/presets/4.3/rc_link/generic/250hz_ultra_cinematic.txt
@@ -1,0 +1,23 @@
+#$ TITLE: Generic 250Hz Ultra Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 250Hz, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for ultra smooth cinematic with 250Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 15
+
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 170
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/500hz_cinematic.txt
+++ b/presets/4.3/rc_link/generic/500hz_cinematic.txt
@@ -1,0 +1,23 @@
+#$ TITLE: Generic 500Hz Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 500Hz, 2ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for cinematic flying with 500Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 70
+set feedforward_jitter_factor = 11
+
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 250
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/500hz_freestyle.txt
+++ b/presets/4.3/rc_link/generic/500hz_freestyle.txt
@@ -1,0 +1,19 @@
+#$ TITLE: Generic 500Hz Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 500Hz, 2ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for freestyle with 500Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 7
+
+set rc_smoothing_auto_factor = 120

--- a/presets/4.3/rc_link/generic/500hz_hd_freestyle.txt
+++ b/presets/4.3/rc_link/generic/500hz_hd_freestyle.txt
@@ -1,0 +1,21 @@
+#$ TITLE: Generic 500Hz HD Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 500Hz, 2ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for HD freestyle with 500Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 9
+
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25

--- a/presets/4.3/rc_link/generic/500hz_race.txt
+++ b/presets/4.3/rc_link/generic/500hz_race.txt
@@ -1,0 +1,21 @@
+#$ TITLE: Generic 500Hz Race
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 500Hz, 2ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for racing with 500Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 65
+set feedforward_jitter_factor = 3
+set feedforward_boost = 18
+
+set rc_smoothing_auto_factor = 25
+set rc_smoothing_auto_factor_throttle = 25

--- a/presets/4.3/rc_link/generic/500hz_ultra_cinematic.txt
+++ b/presets/4.3/rc_link/generic/500hz_ultra_cinematic.txt
@@ -1,0 +1,23 @@
+#$ TITLE: Generic 500Hz Ultra Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 500Hz, 2ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for ultra smooth cinematic flying with 500Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = 2_POINT
+set feedforward_smooth_factor = 75
+set feedforward_jitter_factor = 13
+
+set rc_smoothing_auto_factor = 250
+set rc_smoothing_auto_factor_throttle = 250
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/50hz_cinematic.txt
+++ b/presets/4.3/rc_link/generic/50hz_cinematic.txt
@@ -1,0 +1,24 @@
+#$ TITLE: Generic 50Hz Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 50Hz, 20ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for cinematic flying with 50Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 20
+set feedforward_jitter_factor = 15
+set feedforward_boost = 5
+
+set rc_smoothing_auto_factor = 35
+set rc_smoothing_auto_factor_throttle = 28
+set rc_smoothing_setpoint_cutoff = 12
+set rc_smoothing_feedforward_cutoff = 12
+set rc_smoothing_throttle_cutoff = 20

--- a/presets/4.3/rc_link/generic/50hz_freestyle.txt
+++ b/presets/4.3/rc_link/generic/50hz_freestyle.txt
@@ -1,0 +1,18 @@
+#$ TITLE: Generic 50Hz Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 50Hz, 20ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for freestyle with 50Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 0
+set feedforward_jitter_factor = 10
+set feedforward_boost = 5

--- a/presets/4.3/rc_link/generic/50hz_hd_freestyle.txt
+++ b/presets/4.3/rc_link/generic/50hz_hd_freestyle.txt
@@ -1,0 +1,22 @@
+#$ TITLE: Generic 50Hz HD Freestyle
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 50Hz, 20ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for HD freestyle with 50Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 0
+set feedforward_jitter_factor = 15
+set feedforward_boost = 5
+
+set rc_smoothing_auto_factor = 20
+set rc_smoothing_setpoint_cutoff = 25
+set rc_smoothing_feedforward_cutoff = 25

--- a/presets/4.3/rc_link/generic/50hz_race.txt
+++ b/presets/4.3/rc_link/generic/50hz_race.txt
@@ -1,0 +1,18 @@
+#$ TITLE: Generic 50Hz Race
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 50Hz, 20ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for racing with 50Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 0
+set feedforward_jitter_factor = 7
+set feedforward_boost = 5

--- a/presets/4.3/rc_link/generic/50hz_ultra_cinematic.txt
+++ b/presets/4.3/rc_link/generic/50hz_ultra_cinematic.txt
@@ -1,0 +1,24 @@
+#$ TITLE: Generic 50Hz Ultra Cinematic
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 50Hz, 20ms, rc, rx, link, smoothing
+#$ AUTHOR: Ivan Efimov (Limon)
+#$ DESCRIPTION: Generic RC link settings for ultra smooth cinematic flying with 50Hz RC link.
+#$ DESCRIPTION: WARNING: make ABSOLUTELY SURE that the OpenTx or EdgeTx Hardware ADC Filter is un-checked!
+#$ DESCRIPTION: WARNING: check that you are using a compatible version of EdgeTx or OpenTx!
+
+#$ PRIORITY: 0
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+set feedforward_averaging = OFF
+set feedforward_smooth_factor = 40
+set feedforward_jitter_factor = 20
+set feedforward_boost = 5
+
+set rc_smoothing_auto_factor = 90
+set rc_smoothing_auto_factor_throttle = 28
+set rc_smoothing_setpoint_cutoff = 6
+set rc_smoothing_feedforward_cutoff = 6
+set rc_smoothing_throttle_cutoff = 20


### PR DESCRIPTION
Next step for removing the RC_SMOOTHING category.
Those are just ERLS presets separated by Hz and flying purpose into separate files.

Now ghost/tracer/crossfire presets will be able to #$ INCLUDE these presets.