### PR TITLE
RPM off by Default

### DIFF
--- a/presets/4.3/filters/defaults.txt
+++ b/presets/4.3/filters/defaults.txt
@@ -34,6 +34,7 @@ set dyn_notch_max_hz = 600
 set gyro_filter_debug_axis = ROLL
 
 # -- RPM filtering --
+set dshot_bidir = OFF
 set rpm_filter_harmonics = 3
 set rpm_filter_q = 500
 set rpm_filter_min_hz = 100


### PR DESCRIPTION
The default for Betaflight (after the Reset button) is that the RPM filter is OFF.  However, the default Filter preset has the RPM filter enabled.  This change turns it OFF to be more consistent with the true default.

![image](https://user-images.githubusercontent.com/25570978/158018177-732395f4-8ee9-494a-8b92-c7f65f9f0db2.png)
