### PR TITLE
Added CRSF preset for 4.2

### DIFF
--- a/presets/4.2/rc_link/crsf.txt
+++ b/presets/4.2/rc_link/crsf.txt
@@ -1,0 +1,11 @@
+#$ TITLE: Basic requirements for CRSF 
+#$ FIRMWARE_VERSION: 4.2
+#$ CATEGORY: RC_LINK
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: ExpressLRS, expresslrs, ELRS, elrs, CRSF, Crossfire, Tracer, crossfire, tracer
+#$ AUTHOR: MrAlucardDante
+#$ DESCRIPTION: RC link settings for a link via CRSF.
+
+# basic requirements for CRSF 
+feature RX_SERIAL
+set serialrx_provider = CRSF


### PR DESCRIPTION
Since all the ELRS presets have the new feedforward, I made a very basic preset that enables Serial RX and set the protocol to CRSF so ELRS (or other RXs that use CRSF) can be configured on 4.2