### PR TITLE
Freedom spec tune: make COMMUNITY, add noise frame option

### DIFF
--- a/presets/4.3/tune/freedom_spec_460g.txt
+++ b/presets/4.3/tune/freedom_spec_460g.txt
@@ -1,7 +1,7 @@
 #$ TITLE: Freedom Spec 460 - 500g
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: sugarK, limon, ctzsnooze, freedom, freedom spec, headsup, five33, 533, racing, race, 5"
 #$ AUTHOR: Ivan Efimov (Limon)
 
@@ -40,7 +40,7 @@
 set motor_pwm_protocol = DSHOT600
 
 #$ OPTION BEGIN (UNCHECKED): Dshot300
-set motor_pwm_protocol = Dshot300
+    set motor_pwm_protocol = Dshot300
 #$ OPTION END
 
 # -- Gyro lowpass filters --
@@ -79,8 +79,13 @@ set feedforward_max_rate_limit = 100
 # -- Dyn Idle --
 set dyn_idle_min_rpm = 30
 
-#$ OPTION BEGIN (UNCHECKED): Force LiPo sell count = 3
-set force_battery_cell_count = 3
+#$ OPTION BEGIN (UNCHECKED): Noisy frames
+    set dyn_notch_count = 3
+    set dyn_notch_min_hz = 100
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Force LiPo cell count = 3
+    set force_battery_cell_count = 3
 #$ OPTION END
 
 simplified_tuning apply


### PR DESCRIPTION
Making freedom spec preset COMMUNITY after massive testing by a lot of pilots.
31 pilots voted (International race hosted in Costa Rica, 2022):
![image](https://user-images.githubusercontent.com/2925027/159377070-b259f2ca-b046-4c69-8956-fdaa10726037.png)

Also adding an option for the noisy frames that have resonances 100hz-180hz.
Saw two freedom  spec quads like that with long 6 inch arms (CWM Merica Frame)

Also fixed indentation for the options