### PR TITLE
Gyroflow minimum blackbox settings

### DIFF
--- a/presets/4.3/other/gyroflow_min_blackbox.txt
+++ b/presets/4.3/other/gyroflow_min_blackbox.txt
@@ -1,0 +1,32 @@
+#$ TITLE: Gyroflow minimum settings
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: gyroflow, blackbox, log, DDC, Acrobaix, Garban 
+#$ AUTHOR: Garban
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://github.com/gyroflow/gyroflow/raw/master/resources/logo_black.svg" width="250px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Description
+#$ DESCRIPTION: ------------
+#$ DESCRIPTION: Disables all blackblox fields which are not necessary to use [Gyroflow](https://gyroflow.xyz). Only gyro data will be recorded at the lowest logging rate possible. This allows for smaller blackbox files, longer blackbox recordings and lower CPU overhead.
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/226
+
+set blackbox_sample_rate = 1/16
+set debug_mode = NONE
+set blackbox_disable_pids = ON
+set blackbox_disable_rc = ON
+set blackbox_disable_setpoint = ON
+set blackbox_disable_bat = ON
+set blackbox_disable_mag = ON
+set blackbox_disable_alt = ON
+set blackbox_disable_rssi = ON
+set blackbox_disable_gyro = OFF
+set blackbox_disable_acc = ON
+set blackbox_disable_debug = ON
+set blackbox_disable_motors = ON
+set blackbox_disable_gps = ON


### PR DESCRIPTION
Disables all blackblox fields which are not necessary to use [Gyroflow](https://gyroflow.xyz). Only gyro data will be recorded at the lowest logging rate possible. This allows for smaller blackbox files, longer blackbox recordings and lower CPU overhead.

The space gain is substantial. For every 10 seconds of flight, with the minimum configuration the space occupied is approximately 32.5kB and for a typical blackbox configuration (debug mode in Gyro_scaled and a rate of 2kHz) the occupation is 574.7kB
These values are approximate and should be taken as an example. Every drone and every flight are different.