### PR TITLE
Wrong band ids and power levels

### DIFF
--- a/presets/4.3/vtx/Eachine_Nano_V2.txt
+++ b/presets/4.3/vtx/Eachine_Nano_V2.txt
@@ -3,31 +3,21 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: VTX
 #$ STATUS: COMMUNITY
-#$ KEYWORDS: eachine, Eachine, nano, Nano, smart, Smart, Audio, audio, SmartAudio, smartaudio, 2.1, SmartAudio 2.1, smartaudio 2.1, SA 2.1
+#$ KEYWORDS: eachine, Eachine, nano, Nano, irc, IRC, tramp, TRAMP, Tramp, IRC Tramp, irc tramp, IRC TRAMP
 #$ AUTHOR: MrAlucardDante
-#$ DESCRIPTION: VTX Table for the Eachine Nano V2 VTX (TBS SmartAudio 2.1)
+#$ DESCRIPTION: VTX Table for the Eachine Nano V2 VTX (IRC Tramp)
 #$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/220
 
 #$ INCLUDE: presets/4.3/vtx/defaults.txt
-
-# Basic Vtx settings
-
-set vtx_band = 5
-set vtx_channel = 6
-set vtx_power = 4
-set vtx_low_power_disarm = ON
-set vtx_freq = 5732
-set vtx_pit_mode_freq = 0
-set vtx_halfduplex = ON
 
 # VTx table
 
 vtxtable bands 5
 vtxtable channels 8
 vtxtable powerlevels 4
-vtxtable powervalues 14 23 27 29
-vtxtable powerlabels 25 200 500 800
+vtxtable powervalues 25 100 200 400
+vtxtable powerlabels 25 100 200 400
 
 #$ OPTION_GROUP BEGIN: Regulatory Domain
 
@@ -43,8 +33,8 @@ vtxtable band 5 RACEBAND R CUSTOM 5658 5695 5732 5769 5806 5843 5880 5917
 vtxtable bands 4
 vtxtable band 1 BOSCAM_A A CUSTOM 5865 5845 5825 5805 5785 5765 5745 5725
 vtxtable band 2 BOSCAM_B B CUSTOM 5733 5752 5771 5790 5809 5828 5847 5866
-vtxtable band 4 FATSHARK F CUSTOM 5740 5760 5780 5800 5820 5840 5860    0
-vtxtable band 5 RACEBAND R CUSTOM    0    0 5732 5769 5806 5843    0    0
+vtxtable band 3 FATSHARK F CUSTOM 5740 5760 5780 5800 5820 5840 5860    0
+vtxtable band 4 RACEBAND R CUSTOM    0    0 5732 5769 5806 5843    0    0
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): HAM


### PR DESCRIPTION
I forgot to change the ids when I remove the BOSCAM_E band and the power levels were for TBS SA but it's an IRC Tramp VTX (copy paste from another VTX)
My bad