### PR TITLE
Create Tehllama 533_TinyTrainer 3in_3S_TUNE Preset

### DIFF
--- a/presets/4.3/tune/Tehllama_533_TinyTrainer_3in_3S_TUNE_Options.txt
+++ b/presets/4.3/tune/Tehllama_533_TinyTrainer_3in_3S_TUNE_Options.txt
@@ -1,0 +1,142 @@
+#$ TITLE: FlyFive33 3in TinyTrainer 3S Tune
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: TinyTrainer, 533, Spec, Race, Llama
+#$ AUTHOR: Daniel Appel / Tehllama 
+#$ DESCRIPTION: Tune developed by Armando 'Mondo' Gallegos and Evan 'HeadsUp' Turner
+#$ DESCRIPTION: This is an adaptation of the 533 TinyTrainer tune, and expects works best using ESCs with Bidirectional DShot Capable Firmware at 48kHz PWM with MedHigh timing. 
+#$ DESCRIPTION: These fly best on 3S batteries in the 450-550mAh capacity range with 533 1404 motors.
+#$ DISCLAIMER: If 'Apply RPM Features' is selected, strongly recommend selecting 'Set Motor Poles = 12' option as well. By default, this overwrites the current tune profile and makes TPA changes in the current rateprofile.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/233
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+
+set dshot_idle_value = 700
+# Fallback if Dynamic Idle not working or not selected
+
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+
+set throttle_boost = 8
+set p_pitch = 69
+set i_pitch = 80
+set d_pitch = 40
+set f_pitch = 144
+set p_roll = 63
+set i_roll = 72
+set d_roll = 38
+set f_roll = 132
+set p_yaw = 63
+set i_yaw = 72
+set f_yaw = 132
+set d_min_roll = 28
+set d_min_pitch = 29
+set d_max_advance = 0
+
+set thrust_linear = 10
+
+
+set simplified_gyro_filter_multiplier = 130
+
+set simplified_i_gain = 65
+set simplified_d_gain = 95
+set simplified_pi_gain = 140
+set simplified_dmax_gain = 110
+set simplified_feedforward_gain = 110
+set simplified_pitch_d_gain = 90
+set simplified_pitch_pi_gain = 105
+simplified_tuning apply
+
+#$ OPTION_GROUP BEGIN: Filters
+#$ OPTION BEGIN (CHECKED): Apply Matching Filters
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+set gyro_lpf1_static_hz = 325
+set gyro_lpf2_static_hz = 650
+set dyn_notch_count = 3
+set dyn_notch_q = 250
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 650
+set gyro_lpf1_dyn_min_hz = 325
+set gyro_lpf1_dyn_max_hz = 650
+
+set yaw_lowpass_hz = 125
+
+set dterm_lpf1_dyn_min_hz = 97
+set dterm_lpf1_dyn_max_hz = 195
+set dterm_lpf1_dyn_expo = 8
+set dterm_lpf1_static_hz = 97
+set dterm_lpf2_static_hz = 195
+set simplified_dterm_filter_multiplier = 130
+
+#$ OPTION END
+#$ OPTION_GROUP END
+#$ OPTION_GROUP BEGIN: RPM Features
+
+#$ OPTION BEGIN (UNCHECKED): Apply RPM Features (Strongly Recommended)
+set dshot_bidir = ON
+set rpm_filter_harmonics = 2
+set rpm_filter_q = 750
+set rpm_filter_min_hz = 150
+set rpm_filter_fade_range_hz = 75
+set dyn_notch_count = 2
+set dyn_notch_q = 350
+set dyn_idle_min_rpm = 28
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Set Motor Poles = 12 (Required for RPM Features)
+set motor_poles = 12
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+#$ OPTION_GROUP BEGIN: Other Features and TPA
+
+#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation = 100
+set vbat_sag_compensation = 100
+
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Set Small Angle to 180
+set small_angle = 180
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Apply TPA Settings to all rateprofiles (Will Select RateProfile #1)
+rateprofile 0
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+
+rateprofile 1
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+
+rateprofile 2
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+
+rateprofile 3
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+
+rateprofile 4
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+
+rateprofile 5
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+
+rateprofile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Apply TPA Settings to current rateprofile only
+set tpa_rate = 60
+set tpa_breakpoint = 1200
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
This is a PR to adapt the existing 533 Tiny Trainer Tune developed by Armando and Evan for the TinyTrainer spec class setups.

This tune is a 4.3 adaptation leveraging the SDFT and adjusting the RPM Idle parameters slightly, and works on a variety of non-spec motor/prop configurations as well *( So far tested on Emax Eco 1404, Talon 1404+, Xing 1404, TMotor 1404, Mamba 1404, Mamba 1105, GEPRC 1404, BetaFPV 1404, and Foxeer 1404).

