### PR TITLE
TehLlama FreedomSpec & TexasSpec 1900-2250KV 3/5/6S MultiVoltage Preset (OTHER/Tune)

### DIFF
--- a/presets/4.3/other/Tehllama_5in_1900-2250KV_FreedomSpec_3S-5S-6S_Race_TUNE_OTHER.txt
+++ b/presets/4.3/other/Tehllama_5in_1900-2250KV_FreedomSpec_3S-5S-6S_Race_TUNE_OTHER.txt
@@ -1,0 +1,288 @@
+#$ TITLE: 5in FreedomSpec Race Tune 1900-2250KV on 3S (Spec) and 5S/6S (Open)
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 533, FreedomSpec, Tune, Spec, Race, Llama, MultiVoltage
+#$ AUTHOR: Daniel Appel / Tehllama
+#$ DESCRIPTION: Tune is built for 533 FreedomSpec and similar builds with 1900-2150KV Motors.
+#$ DESCRIPTION: This tune works best with bidirectional DShot ESCs at 48kHz PWM with 23°-27°/MedHigh timing.
+#$ DESCRIPTION: 3S (2200mAh) will run a spec tune on Profile 3 and auto-select this tune when a 3S pack is plugged in.  
+#$ DESCRIPTION: 6S and 5S will run a conservative open race tune of Profiles 1 and 2 respectively.
+#$ DESCRIPTION: !!! Strongly recommend a full chip erase reflash if alternative tunes are desired after installing this preset!!!
+#$ DESCRIPTION: Extensive testing has been done across 57+ builds, however not every craft will run best on this tune.
+#$ DESCRIPTION: This tune will auto-select profiles based on battery voltage at plugin, but only for 3S, 5S, and 6S packs.  
+#$ WARNING: Use at your own risk.  This tune does NOT have a profile auto-select with 4S batteries, which may case flyaways or potential damage if Profile 3 (3S) is selected. 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/235
+
+# FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+
+# Fallback if dynamic idle does not function or is deselected
+set dshot_idle_value = 440
+
+#$ OPTION_GROUP BEGIN: Tune Profiles
+
+#$ OPTION BEGIN (CHECKED): Apply 6S Auto-Select Tune to Profile 1
+profile 0
+# profile 0 - 6S
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set p_pitch = 40
+set i_pitch = 60
+set d_pitch = 27
+set f_pitch = 137
+set p_roll = 36
+set i_roll = 55
+set d_roll = 25
+set f_roll = 124
+set p_yaw = 36
+set i_yaw = 55
+set f_yaw = 124
+set d_min_roll = 19
+set d_min_pitch = 21
+set d_max_advance = 0
+set auto_profile_cell_count = 6
+set feedforward_boost = 5
+set throttle_boost = 2
+
+set simplified_master_multiplier = 65
+set simplified_i_gain = 85
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 160
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Apply 5S Auto-Select Tune to Profile 2
+profile 1
+# profile 1
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set i_pitch = 71
+set d_pitch = 33
+set f_pitch = 161
+set p_roll = 44
+set i_roll = 67
+set d_roll = 31
+set f_roll = 153
+set p_yaw = 44
+set i_yaw = 67
+set f_yaw = 153
+set d_min_roll = 23
+set d_min_pitch = 25
+set d_max_advance = 0
+set auto_profile_cell_count = 5
+set feedforward_boost = 12
+set throttle_boost = 7
+# set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+set simplified_master_multiplier = 80
+set simplified_i_gain = 85
+set simplified_pi_gain = 125
+set simplified_feedforward_gain = 160
+set simplified_pitch_d_gain = 105
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Apply 3S Freedom Spec Tune on Auto-Select to Profile 3
+profile 2
+# profile 2
+set dterm_lpf1_dyn_min_hz = 100
+set dterm_lpf1_dyn_max_hz = 222
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 175
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set p_pitch = 83
+set i_pitch = 126
+set d_pitch = 65
+set f_pitch = 240
+set p_roll = 75
+set i_roll = 114
+set d_roll = 57
+set f_roll = 218
+set p_yaw = 75
+set i_yaw = 114
+set f_yaw = 218
+set d_min_roll = 44
+set d_min_pitch = 51
+set d_max_advance = 0
+set auto_profile_cell_count = 3
+set feedforward_boost = 18
+set throttle_boost = 12
+
+set simplified_master_multiplier = 135
+set simplified_i_gain = 85
+set simplified_d_gain = 110
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 135
+set simplified_pitch_pi_gain = 110
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Filters
+
+#$ OPTION BEGIN (CHECKED): Apply Matching Filters to ALL Profiles
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+# master
+set dshot_bidir = ON
+
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 675
+set dyn_notch_q = 333
+set dyn_notch_min_hz = 98
+set dyn_notch_max_hz = 674
+set gyro_lpf1_dyn_min_hz = 337
+set gyro_lpf1_dyn_max_hz = 675
+set gyro_lpf1_dyn_expo = 7
+
+set simplified_gyro_filter_multiplier = 135
+
+set rpm_filter_harmonics = 2
+set rpm_filter_q = 750
+set rpm_filter_min_hz = 125
+set rpm_filter_fade_range_hz = 100
+
+simplified_tuning apply
+
+profile 0
+# profile 0
+set dterm_lpf1_dyn_min_hz = 100
+set dterm_lpf1_dyn_max_hz = 266
+set dterm_lpf1_dyn_expo = 10
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 175
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+profile 1
+# profile 1
+set dterm_lpf1_dyn_min_hz = 100
+set dterm_lpf1_dyn_max_hz = 244
+set dterm_lpf1_dyn_expo = 9
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 202
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+profile 2
+# profile 2
+set dterm_lpf1_dyn_min_hz = 101
+set dterm_lpf1_dyn_max_hz = 222
+set dterm_lpf1_dyn_expo = 7
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 202
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Features and TPA 
+
+#$ OPTION BEGIN (CHECKED): Apply Dynamic Idle to ALL Profiles
+set dshot_bidir = ON
+
+profile 0
+set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+profile 1
+set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+profile 2
+set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation = 77 for ALL Profiles
+profile 0
+set vbat_sag_compensation = 77
+profile 1
+set vbat_sag_compensation = 77
+profile 2
+set vbat_sag_compensation = 77
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Apply TPA Settings to all rateprofiles
+rateprofile 0
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 1
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 2
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 3
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 4
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 5
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Apply TPA Settings to current rateprofile only
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2000KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 97
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2050KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 95
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2100KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 93
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2150KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 92
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2250KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 90
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
Official repo version of the Tehllama Multivoltage Tune Preset (with options that color outside the lines) used for FreedomSpec and TexasSpec quads in this KV range.

Biggest known limitation is plugging in a 4S battery with the 3S tune selected, expectation is HOT motors and marginal performance (but works great with 5/6S profiles selected).

The profile auto-select has been invaluable for me on rigs that get used as Freedom spec and open class racers, the flexibility and stupid-proofing of profile selection has been a massive help.

The multi-voltage filters are a bit of a singular package, but have been extensively tested on a lot of builds, from multiple builders.

End result is a softer tune than the Karate setup, this does allow some propwash at the ~480g AUW for FreedomSpec, but is actually a solid alternative to the Karate tune for the open configurations.  I recommend trying this for anybody that has a quad that struggles on the Karate tune (but since this is an 'other' preset, strongly recommend a full chip erase reflash if alternative tunes are desired).
