### PR TITLE
TehLlama TexasSpec 2300-2750KV 3/4/5S MultiVoltage Preset (OTHER/Tune)

### DIFF
--- a/presets/4.3/other/Tehllama_5in_2350-2750KV-TexasSpec_3S-4S-5S_Race_TUNE_OTHER.txt
+++ b/presets/4.3/other/Tehllama_5in_2350-2750KV-TexasSpec_3S-4S-5S_Race_TUNE_OTHER.txt
@@ -1,0 +1,317 @@
+#$ TITLE: 5in TexasSpec Freedom Race Tune 2350-2750KV on 3S (Spec) and 4S/5S (Open)
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 533, HighKV, FreedomSpec, Spec, Tune, Race, Llama, MultiVoltage, Texas
+#$ AUTHOR: Daniel Appel / Tehllama
+#$ DESCRIPTION: This tune is intended for builds on bidir DShot ESCs at 48kHz PWM with 23-27°/MedHigh timing.
+#$ DESCRIPTION: 3S batteries will EMULATE 533 FreedomSpec (3S 2200mAh) with motor output limits, and select the spec tune on Profile #3 that auto-selects with correct motor KV selections.
+#$ DESCRIPTION: 4S and 5S will run a conservative open race tune on Profiles #1/#2 respectively, based on voltage plugged in.
+#$ DESCRIPTION: Strongly recommend a full chip erase reflash if alternative tunes are desired.
+#$ DESCRIPTION: Extensive testing has been done across 57+ builds, however not every craft will run best on this tune.
+#$ DESCRIPTION: This tune will auto-select profiles based on battery voltage at plugin by default, but only for 3S, 4S and 5S packs. 
+#$ WARNING: Use at your own risk.  NO 6-cell tune or throttle limit is provided with this tune.  Plugging in a 6S pack with 3S profile active will likely cause SERIOUS damage.  
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/236
+
+# FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+# master
+
+set dshot_idle_value = 440
+# Fallback value if dynamic idle does not work, or is deselected
+
+#$ OPTION_GROUP BEGIN: Tune Profiles
+
+#$ OPTION BEGIN (CHECKED): Apply 4S Auto-Select Tune to Profile 1
+profile 0
+# profile 0 - 4S
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set p_pitch = 56
+set i_pitch = 85
+set f_pitch = 176
+set p_roll = 49
+set i_roll = 74
+set d_roll = 36
+set f_roll = 153
+set p_yaw = 49
+set i_yaw = 74
+set f_yaw = 153
+set d_min_roll = 28
+set d_min_pitch = 35
+set d_max_advance = 0
+set auto_profile_cell_count = 4
+set feedforward_jitter_factor = 12
+set feedforward_boost = 12
+set throttle_boost = 12
+
+set simplified_master_multiplier = 95
+set simplified_i_gain = 85
+set simplified_pi_gain = 115
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 135
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+simplified_tuning apply
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply 5S Auto-Select Tune to Profile 2
+profile 1
+# profile 1 - 5S
+set iterm_rotation = ON
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set throttle_boost = 2
+set p_pitch = 42
+set i_pitch = 63
+set d_pitch = 34
+set f_pitch = 134
+set p_roll = 36
+set i_roll = 55
+set d_roll = 27
+set f_roll = 116
+set p_yaw = 36
+set i_yaw = 55
+set f_yaw = 116
+set d_min_roll = 21
+set d_min_pitch = 26
+set d_max_advance = 0
+set motor_output_limit = 92
+set auto_profile_cell_count = 5
+set feedforward_jitter_factor = 12
+set feedforward_boost = 8
+set throttle_boost = 5
+set feedforward_max_rate_limit = 103
+
+set simplified_master_multiplier = 65
+set simplified_i_gain = 85
+set simplified_d_gain = 110
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 150
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+simplified_tuning apply
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply 3S TexasSpec Auto-Select Tune to Profile 3
+profile 2
+# profile 2 - 3S Spec
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set throttle_boost = 12
+set p_pitch = 64
+set i_pitch = 98
+set f_pitch = 220
+set p_roll = 59
+set i_roll = 89
+set d_roll = 42
+set f_roll = 201
+set p_yaw = 59
+set i_yaw = 89
+set f_yaw = 201
+set d_min_roll = 33
+set d_min_pitch = 35
+set d_max_advance = 0
+set motor_output_limit = 81
+set auto_profile_cell_count = 3
+set feedforward_jitter_factor = 12
+set feedforward_boost = 18
+set throttle_boost = 18
+set feedforward_max_rate_limit = 103
+
+set simplified_master_multiplier = 105
+set simplified_i_gain = 85
+set simplified_d_gain = 105
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 160
+set simplified_pitch_d_gain = 95
+set simplified_pitch_pi_gain = 105
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Filters
+
+#$ OPTION BEGIN (CHECKED): Apply Matching Multi Voltage Filters to ALL Profiles
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+set dshot_bidir = ON
+
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 675
+set dyn_notch_q = 333
+set dyn_notch_min_hz = 98
+set dyn_notch_max_hz = 674
+set gyro_lpf1_dyn_min_hz = 337
+set gyro_lpf1_dyn_max_hz = 675
+set gyro_lpf1_dyn_expo = 7
+
+set simplified_gyro_filter_multiplier = 135
+simplified_tuning apply
+
+set rpm_filter_harmonics = 2
+set rpm_filter_q = 750
+set rpm_filter_min_hz = 125
+set rpm_filter_fade_range_hz = 100
+
+profile 0
+set dterm_lpf1_dyn_min_hz = 98
+set dterm_lpf1_dyn_max_hz = 244
+set dterm_lpf1_dyn_expo = 8
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 210
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+profile 1
+set dterm_lpf1_dyn_min_hz = 98
+set dterm_lpf1_dyn_max_hz = 277
+set dterm_lpf1_dyn_expo = 10
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 210
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+
+profile 2
+set dterm_lpf1_dyn_min_hz = 98
+set dterm_lpf1_dyn_max_hz = 222
+set dterm_lpf1_dyn_expo = 7
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 210
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Features and TPA
+
+#$ OPTION BEGIN (CHECKED): Apply Dynamic idle to all profiles
+set dshot_bidir = ON
+
+profile 0
+set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+
+profile 1
+set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+
+profile 2
+set dyn_idle_min_rpm = 24
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Set VBat Sag Compensation
+profile 0
+set vbat_sag_compensation = 88
+profile 1
+set vbat_sag_compensation = 88
+profile 2
+set vbat_sag_compensation = 99
+
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply TPA Settings to all rateprofiles (Will select RateProfile #1)
+rateprofile 0
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 1
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 2
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 3
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 4
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 5
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Apply TPA Settings to current rateprofile only
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2350KV Motor Output Limiting (3S)
+profile 2
+set motor_output_limit = 83
+#$ OPTION END 
+
+#$ OPTION BEGIN (UNCHECKED):  2400KV Motor Output Limiting (3S)
+profile 2
+set motor_output_limit = 82
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2450KV Motor Output Limiting (3S and 5S)
+profile 1
+set motor_output_limit = 98
+profile 2
+set motor_output_limit = 80
+set simplified_master_multiplier = 100
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2500KV Motor Output Limiting (3S and 5S)
+profile 1
+set motor_output_limit = 96
+profile 2
+set motor_output_limit = 78
+set simplified_master_multiplier = 95
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2650KV Motor Output Limiting (3S and 5S)
+profile 1
+set motor_output_limit = 94
+profile 2
+set motor_output_limit = 74
+set simplified_master_multiplier = 90
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2750KV Motor Output Limiting (3/4/5S)
+profile 0
+set simplified_master_multiplier = 90
+profile 1
+set motor_output_limit = 90
+profile 2
+set motor_output_limit = 71
+set simplified_master_multiplier = 85
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
Official repo version of the Tehllama Multivoltage Tune Preset (with options that color outside the lines) used for emulating FreedomSpec using the TexasSpec calculator for quads in this KV range.

Biggest known limitation is plugging in a 6S battery is BAD, especially with the 3S tune selected, expectation is HOT motors and marginal performance with 4S profiles selected, and basically guaranteed bad things with the 3S tune using the FreedomSpec gains.

The profile auto-select has been invaluable for me on rigs that get used as TesasSpec and open class racers, the flexibility and stupid-proofing of profile selection has been a massive help.
The multi-voltage filters are a bit of a singular package, but have been extensively tested on a lot of builds, from multiple builders.

End result is a softer tune than the Karate setup, this does allow some propwash at the ~480g AUW for FreedomSpec, but is actually a solid alternative to the Karate tune for the open configurations. I recommend trying this for anybody that has a quad that struggles on the Karate tune (but since this is an 'other' preset, strongly recommend a full chip erase reflash if alternative tunes are desired).