### PR TITLE
TehLlama BMS-Spec 1600-2150KV 4/5/6S MultiVoltage Preset (OTHER/Tune)

### DIFF
--- a/presets/4.3/other/Tehllama_5in_BMS-Spec_1600-2350KV_4S-5S-6S_Race_TUNE-OTHER.txt
+++ b/presets/4.3/other/Tehllama_5in_BMS-Spec_1600-2350KV_4S-5S-6S_Race_TUNE-OTHER.txt
@@ -1,0 +1,326 @@
+#$ TITLE: 5in Tehllama Race Tune 1600-2350KV on 4S/5S/6S including BMS Spec
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Race, Llama, Safe, Tune, MultiVoltage
+#$ AUTHOR: Daniel Appel / Tehllama
+#$ DESCRIPTION: Built for Powerful racing builds on bidir DShot ESCs at 48kHz PWM with 23°-27°/MedHigh timing
+#$ DESCRIPTION: Each battery setting will will run a conservative race tune that should withstand damaged props and bent motor shafts.
+#$ DESCRIPTION: Strongly recommend a full chip erase reflash if alternative tunes are desired.
+#$ WARNING: Use at your own risk.  Extensive testing has been done across 67+ builds, however not every craft will run best on this tune.     This tune will auto-select profiles based on battery voltage at plugin, but only for 4S, 5S, and 6S packs.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/237
+
+# FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+
+
+#$ OPTION_GROUP BEGIN: Tune Profiles
+#$ OPTION BEGIN (CHECKED): Apply 6S Auto-Select Tune to Profile 1
+# master
+
+set dshot_idle_value = 440
+# Fallback value if dynamic idle does not operate correctly or is deselected
+
+profile 0
+# profile 0
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set p_pitch = 43
+set i_pitch = 65
+set d_pitch = 28
+set f_pitch = 133
+set p_roll = 39
+set i_roll = 59
+set d_roll = 25
+set f_roll = 121
+set p_yaw = 39
+set i_yaw = 59
+set f_yaw = 121
+set d_min_roll = 19
+set d_min_pitch = 21
+set d_max_advance = 0
+set auto_profile_cell_count = 6
+set feedforward_boost = 8
+set throttle_boost = 2
+
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+set simplified_master_multiplier = 70
+set simplified_i_gain = 85
+set simplified_d_gain = 95
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 90
+set simplified_feedforward_gain = 145
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Apply 5S Auto-Select Tune to Profile 2
+# master
+set dshot_bidir = ON
+
+set dshot_idle_value = 440
+# Fallback value if dynamic idle does not operate correctly or is deselected
+profile 1
+# profile 1
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set p_pitch = 58
+set i_pitch = 88
+set d_pitch = 38
+set f_pitch = 181
+set p_roll = 53
+set d_roll = 34
+set f_roll = 165
+set p_yaw = 53
+set f_yaw = 165
+set d_min_roll = 27
+set d_min_pitch = 29
+set d_max_advance = 0
+set auto_profile_cell_count = 5
+set feedforward_boost = 12
+set throttle_boost = 7
+
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+set simplified_master_multiplier = 95
+set simplified_i_gain = 85
+set simplified_d_gain = 95
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 145
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+
+simplified_tuning apply
+
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply 4S Auto-Select Tune to Profile 3
+# master
+set dshot_bidir = ON
+
+set dshot_idle_value = 440
+# Fallback value if dynamic idle does not operate correctly or is deselected
+profile 2
+# profile 2
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+set yaw_lowpass_hz = 115
+set p_pitch = 77
+set i_pitch = 116
+set d_pitch = 50
+set f_pitch = 231
+set p_roll = 70
+set i_roll = 106
+set d_roll = 45
+set f_roll = 210
+set p_yaw = 70
+set i_yaw = 106
+set f_yaw = 210
+set d_min_roll = 35
+set d_min_pitch = 39
+set d_max_advance = 0
+set auto_profile_cell_count = 4
+set feedforward_boost = 18
+set throttle_boost = 12
+
+set dyn_idle_p_gain = 42
+set dyn_idle_i_gain = 42
+set dyn_idle_d_gain = 42
+set simplified_master_multiplier = 125
+set simplified_i_gain = 85
+set simplified_d_gain = 95
+set simplified_pi_gain = 125
+set simplified_dmax_gain = 85
+set simplified_feedforward_gain = 140
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Filters
+
+#$ OPTION BEGIN (CHECKED): Apply Matching Filters to ALL Profiles
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+# master
+set dshot_bidir = ON
+
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 675
+set dyn_notch_q = 333
+set dyn_notch_min_hz = 98
+set dyn_notch_max_hz = 674
+set gyro_lpf1_dyn_min_hz = 337
+set gyro_lpf1_dyn_max_hz = 675
+set gyro_lpf1_dyn_expo = 7
+set rpm_filter_harmonics = 2
+set rpm_filter_q = 750
+set rpm_filter_min_hz = 125
+set rpm_filter_fade_range_hz = 100
+
+set simplified_gyro_filter_multiplier = 135
+
+profile 0
+# profile 0
+set dterm_lpf1_dyn_min_hz = 100
+set dterm_lpf1_dyn_max_hz = 266
+set dterm_lpf1_dyn_expo = 10
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 202
+
+set simplified_dterm_filter_multiplier = 140
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+profile 1
+# profile 1
+set dterm_lpf1_dyn_min_hz = 100
+set dterm_lpf1_dyn_max_hz = 244
+set dterm_lpf1_dyn_expo = 9
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 202
+
+set simplified_dterm_filter_multiplier = 140
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+profile 2
+# profile 2
+set dterm_lpf1_dyn_min_hz = 101
+set dterm_lpf1_dyn_max_hz = 222
+set dterm_lpf1_dyn_expo = 7
+set dterm_lpf1_static_hz = 0
+set dterm_lpf2_static_hz = 202
+
+set simplified_dterm_filter_multiplier = 135
+set simplified_dterm_filter = OFF
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Features and TPA
+
+#$ OPTION BEGIN (CHECKED): Apply Dynamic Idle
+set dshot_bidir = ON
+
+profile 0
+set dyn_idle_min_rpm = 24
+profile 1
+set dyn_idle_min_rpm = 24
+profile 2
+set dyn_idle_min_rpm = 24
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation = 88
+profile 0
+set vbat_sag_compensation = 88
+profile 1
+set vbat_sag_compensation = 88
+profile 2
+set vbat_sag_compensation = 88
+
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply TPA Settings to all rateprofiles
+rateprofile 0
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 1
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 2
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 3
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 4
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 5
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+
+rateprofile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Apply TPA Settings to current rateprofile only
+set tpa_rate = 72
+set tpa_breakpoint = 1250
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2070KV 6S Motor Output Limit
+profile 0
+set motor_output_limit = 98
+profile 2
+set simplified_master_multiplier = 120
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2150KV 6S Motor Output Limit
+profile 0
+set motor_output_limit = 98
+profile 2
+set simplified_master_multiplier = 115
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2250KV 6S Motor Output Limit
+profile 0
+set motor_output_limit = 95
+profile 2
+set simplified_master_multiplier = 110
+simplified_tuning apply
+profile 1
+set simplified_master_multiplier = 90
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2300KV 6S Motor Output Limit
+profile 0
+set motor_output_limit = 93
+profile 2
+set simplified_master_multiplier = 105
+simplified_tuning apply
+profile 1
+set simplified_master_multiplier = 90
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2350KV 6S Motor Output Limit
+profile 0
+set motor_output_limit = 92
+profile 2
+set simplified_master_multiplier = 105
+simplified_tuning apply
+profile 1
+set simplified_master_multiplier = 90
+simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
Official repo version of the Tehllama Multivoltage Tune Preset for lowKV (with options that color outside the lines).

The profile auto-select has been invaluable for me on rigs that get used as TesasSpec and open class racers, the flexibility and stupid-proofing of profile selection has been a massive help.
The multi-voltage filters are a bit of a singular package, but have been extensively tested on a lot of builds, from multiple builders.

End result is a softer tune than the Karate setup, this does allow some propwash at the ~480g AUW for FreedomSpec, but is actually a solid alternative to the Karate tune for the open configurations. I recommend trying this for anybody that has a quad that struggles on the Karate tune (but since this is an 'other' preset, strongly recommend a full chip erase reflash if alternative tunes are desired).