### PR TITLE
Added Llama SWPR Spec Tune for GTB339 3in on 2S or 3S (Works with TP3 1303 5000KV Builds)

### DIFF
--- a/presets/4.3/other/Tehllama_GTB339_3in_SWPR-Spec_2S-3S_Race_TUNE_OTHER.txt
+++ b/presets/4.3/other/Tehllama_GTB339_3in_SWPR-Spec_2S-3S_Race_TUNE_OTHER.txt
@@ -1,0 +1,215 @@
+#$ TITLE: 3in Lightweight 3S/2S Tune for GTB-339 or 3" Racing Toothpick 
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: GTB339, Toothpick, Spec, Race, Llama, SWPR, Multi, Voltage, 2S, 3S
+#$ AUTHOR: Daniel Appel / Tehllama
+#$ DESCRIPTION: This tune was designed for GTB339 3in 1105-5500KV Racers on on bidir DShot ESCs at 48kHz PWM with MedHigh timing. 
+#$ DESCRIPTION: These fly best on 2S-3S batteries in the 450-650mAh capacity range, resulting in an AUW of 95-105g on these motors.  
+#$ DESCRIPTION: This tune works with biblade and triblade props, such as Gemfan 3016-3, GF 3018-2, HQ 3x1.8x3, and HQ 3x1.5x3.
+#$ DESCRIPTION: -------
+#$ DESCRIPTION: This tune also works well on other lightweight 1303/1303.5/1204/1106 3" setups in the 4500-6000KV range.
+#$ DESCRIPTION: Extensive testing has been done across 39+ builds, however not every craft will fly well on this tune.
+#$ DESCRIPTION: -------
+#$ DESCRIPTION: !!!
+#$ DESCRIPTION: Strongly recommend a full chip erase reflash if using alternative tune presets is desired.  
+#$ DESCRIPTION: This tune will auto-select profiles based on battery voltage at plugin for 2S and 3S packs with default selections. 
+#$ DESCRIPTION: This preset requires 12-pole motors by default.  In the unlikely case your motors actually have 14 MAGNETS, de-select this option.
+#$ DESCRIPTION: !!!
+#$ WARNING: Use at your own risk.  Some 13A ESCs may experience failures on 3S batteries.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/239
+
+# FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+
+#$ OPTION_GROUP BEGIN: Tune Profiles
+
+#$ OPTION BEGIN (CHECKED): Apply 3S Auto-Select Tune on Profile 3
+# master
+
+set dshot_idle_value = 475
+# Fallback if dynamic idle does not work or is disabled
+
+set thrust_linear = 20
+
+# 3S Auto-Select Tune on Profile #3
+profile 2
+set anti_gravity_gain = 4400
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 33
+
+set p_pitch = 54
+set i_pitch = 72
+set d_pitch = 44
+set f_pitch = 99
+set p_roll = 49
+set i_roll = 66
+set f_roll = 90
+set p_yaw = 49
+set i_yaw = 66
+set f_yaw = 90
+set d_min_pitch = 33
+set d_max_advance = 0
+set auto_profile_cell_count = 3
+set feedforward_boost = 8
+set throttle_boost = 5
+set simplified_i_gain = 75
+set simplified_pi_gain = 110
+set simplified_feedforward_gain = 75
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 110
+simplified_tuning apply
+
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply 2S Auto-Select Tune on Profile 2
+
+set dshot_idle_value = 475
+# Fallback if dynamic idle does not work or is disabled
+
+set thrust_linear = 20
+
+# 2S Tune on Profile #2
+profile 1
+set anti_gravity_gain = 4400
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_cutoff = 37
+
+set p_pitch = 82
+set i_pitch = 110
+set d_pitch = 82
+set f_pitch = 165
+set p_roll = 78
+set i_roll = 105
+set d_roll = 78
+set f_roll = 157
+set p_yaw = 78
+set i_yaw = 105
+set f_yaw = 157
+set d_min_roll = 62
+set d_min_pitch = 66
+set d_max_advance = 0
+set auto_profile_cell_count = 2
+set feedforward_boost = 18
+set throttle_boost = 12
+set simplified_master_multiplier = 175
+set simplified_i_gain = 75
+set simplified_d_gain = 120
+set simplified_dmax_gain = 75
+set simplified_feedforward_gain = 75
+set simplified_pitch_d_gain = 105
+simplified_tuning apply
+
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Filters and RPM Features
+
+#$ OPTION BEGIN (UNCHECKED): Apply Default non-RPM Filters
+#$ INCLUDE: presets/4.3/filters/default_no_rpm_clean.txt
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Apply Matching RPM Filters (Strongly Recommended)
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+set gyro_lpf1_static_hz = 400
+set gyro_lpf2_static_hz = 800
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 640
+set gyro_lpf1_dyn_min_hz = 400
+set gyro_lpf1_dyn_max_hz = 800
+set simplified_gyro_filter_multiplier = 160
+
+set rpm_filter_harmonics = 2
+set rpm_filter_q = 750
+set rpm_filter_min_hz = 115
+set rpm_filter_fade_range_hz = 100
+
+profile 2
+set dterm_lpf1_dyn_min_hz = 120
+set dterm_lpf1_dyn_max_hz = 240
+set dterm_lpf1_dyn_expo = 8
+set dterm_lpf1_static_hz = 120
+set dterm_lpf2_static_hz = 240
+set yaw_lowpass_hz = 125
+set simplified_dterm_filter_multiplier = 160
+simplified_tuning apply
+
+profile 1
+set dterm_lpf1_dyn_min_hz = 120
+set dterm_lpf1_dyn_max_hz = 240
+set dterm_lpf1_static_hz = 120
+set dterm_lpf2_static_hz = 240
+set simplified_dterm_filter_multiplier = 160
+set yaw_lowpass_hz = 125
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Set Motor Poles = 12
+
+set motor_poles = 12
+
+#$ OPTION END
+
+#$ OPTION BEGIN: (CHECKED) Use Dynamic Idle (Requires Correct Motor Pole Count)
+profile 2
+set dyn_idle_min_rpm = 24
+profile 1
+set dyn_idle_min_rpm = 24
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Features and TPA
+
+#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation = 88
+
+profile 2
+set vbat_sag_compensation = 88
+profile 1
+set vbat_sag_compensation = 88
+
+#$ OPTION END
+
+
+#$ OPTION BEGIN (CHECKED): Apply TPA Settings to all rateprofiles (Will Select RateProfile #1)
+rateprofile 0
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+
+rateprofile 1
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+
+rateprofile 2
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+
+rateprofile 3
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+
+rateprofile 4
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+
+rateprofile 5
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+
+rateprofile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Apply TPA Settings to current rateprofile only
+set tpa_rate = 72
+set tpa_breakpoint = 1350
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
Official repo version of the Tehllama Multivoltage Tune Preset for the SWPR Spec GTB339 (or similar Mamba 1105 5500KV setups).

This has been tested on GEPRC and BetaFPV 1105 motors, RCINPower 1204 Motors, and even FPVCycle 1303 motors, and works remarkably well.  Frames tested include the GTB 339 Cube frame, Babytooth, TP3, Talon BirdOfPrey, Armattan Gecko, BetaFPV XKnight, and TwigXL.

The profile auto-select has been invaluable for me on rigs that get used as spec and open class racers, the flexibility and stupid-proofing of profile selection has been a massive help.
The multi-voltage filters are a bit of a singular package, but have been extensively tested on a lot of builds, from multiple builders.

