### PR TITLE
Add gyro_hardware_lpf = NORMAL to filter defaults

### DIFF
--- a/presets/4.3/filters/defaults.txt
+++ b/presets/4.3/filters/defaults.txt
@@ -6,6 +6,8 @@
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Resets Filter settings to 4.3 defaults
 
+set gyro_hardware_lpf = NORMAL
+
 # -- Gyro lowpass filters --
 set gyro_lpf1_type = PT1
 set gyro_lpf1_dyn_min_hz = 250


### PR DESCRIPTION
Considering this PR:
https://github.com/betaflight/firmware-presets/pull/232

need to add 
`set gyro_hardware_lpf = NORMAL`
to filer **defaults** for 4.3