### PR TITLE
Create ExpressLRS Betalight Passthrough Preset

### DIFF
--- a/presets/4.3/other/ELRS_Passthrough.txt
+++ b/presets/4.3/other/ELRS_Passthrough.txt
@@ -1,0 +1,16 @@
+#$ TITLE: ExpressLRS Passthrough Betaflight Settings
+#$ FIRMWARE_VERSION: 3.5
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ STATUS: OFFICIAL
+#$ CATEGORY: OTHER
+#$ KEYWORDS: ELRS, Passthrough, Configure, utility
+#$ AUTHOR: Daniel Appel / Tehllama
+#$ DESCRIPTION: This is a simplified way of ensuring that Betaflight is correctly configured to enable ExpressLRS to perform receiver flashing via Passthrough.
+#$ DESCRIPTION: Backing up flight controller settings is strongly recommended. After completing serial passthrough flashing, configuration should be restored from the backup file.
+#$ WARNING: Please back up flight controller settings using the "Save Backup" button.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/242
+
+feature -TELEMETRY
+set serialrx_inverted = off
+set serialrx_halfduplex = off


### PR DESCRIPTION
Probably the laziest preset ever... but just a quick utility preset that puts the serialrx_halfduplex and serialrx_inverted to default (off) values, and disables telemetry.