### PR TITLE
allow for later node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
 	"author" : "The Betaflight open source project.",
 	"license" : "GPL-3.0",
 	"engines" : {
-		"node" : "10.x"
+		"node" : ">=10.x"
 	}
 }


### PR DESCRIPTION
allows people to run the scripts, without having a diverging package.json or a stoneage node version