### PR TITLE
added Street League preset tune and motor output limit

### DIFF
--- a/presets/4.3/other/Street_League_motor_outputs.txt
+++ b/presets/4.3/other/Street_League_motor_outputs.txt
@@ -1,0 +1,141 @@
+#$ TITLE: Street League Motor Output Limit Settings
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Motor, output limit, Street League, StreetLeague, Street, League, LeadFingers, Throttle cap
+#$ AUTHOR: LeadFingers
+#$ PARSER: MARKED
+#$ DESCRIPTION: Street League Spec Drone Racing Anti-NSB Presets
+#$ DESCRIPTION: Use this tool to help make your quad Street Legal
+#$ DESCRIPTION: 
+#$ DESCRIPTION: The pre checked boxes will set your throttle limit to 75% SCALED on all 6 profiles and leave your quad on profile 1 and set your Throttle Boost settings to default
+#$ DESCRIPTION: 
+#$ DESCRIPTION: Choose your motor or KV and this will set your motor output limit on all 3 PID profiles and set the quad to profile 1
+#$ DESCRIPTION: 
+#$ DESCRIPTION: Note for ECO II Users:
+#$ DESCRIPTION: Because of the KV variance of these motors the motor output limit has been set conservatively, to find the max motor output limit that you can use with your individual motors visit our discord
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 
+#$ DESCRIPTION: Join our Discord!
+#$ DESCRIPTION: [Street League Spec Discord](https://discord.gg/rqGfKBbYbP)
+#$ DISCLAIMER: 
+#$ DISCUSSION: [Pull Request](https://github.com/betaflight/firmware-presets/pull/256)
+#$ FORCE_OPTIONS_REVIEW: True
+
+#$ OPTION_GROUP BEGIN: Universal anti-NSB settings
+
+#$ OPTION BEGIN (CHECKED): Set my Street League Spec throttle limit
+rateprofile 0
+set throttle_limit_type = scale
+set throttle_limit_percent = 75
+rateprofile 1
+set throttle_limit_type = scale
+set throttle_limit_percent = 75
+rateprofile 2
+set throttle_limit_type = scale
+set throttle_limit_percent = 75
+rateprofile 3
+set throttle_limit_type = scale
+set throttle_limit_percent = 75
+rateprofile 4
+set throttle_limit_type = scale
+set throttle_limit_percent = 75
+rateprofile 5
+set throttle_limit_type = scale
+set throttle_limit_percent = 75
+rateprofile 0 
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Set my throttle boost settings to default
+profile 0
+set throttle_boost = 5
+set throttle_boost_cutoff = 15
+profile 1
+set throttle_boost = 5
+set throttle_boost_cutoff = 15
+profile 2
+set throttle_boost = 5
+set throttle_boost_cutoff = 15
+profile 0
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Select your specific motor if it is listed
+
+#$ OPTION BEGIN (UNCHECKED): Brother Hobby Avenger 2510 1250KV / DRSL motors
+profile 0
+set motor_output_limit = 95
+profile 1
+set motor_output_limit = 95
+profile 2
+set motor_output_limit = 95
+profile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Hyperlight 2807.5 1322KV
+profile 0
+set motor_output_limit = 90
+profile 1
+set motor_output_limit = 90
+profile 2
+set motor_output_limit = 90
+profile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): EMAX ECO II 2807 1300KV
+profile 0
+set motor_output_limit = 89
+profile 1
+set motor_output_limit = 89
+profile 2
+set motor_output_limit = 89
+profile 0
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Select your KV if your motor is not listed
+
+#$ OPTION BEGIN (UNCHECKED): Generic 1300KV motor
+profile 0
+set motor_output_limit = 91
+profile 1
+set motor_output_limit = 91
+profile 2
+set motor_output_limit = 91
+profile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Generic 1350KV motor
+profile 0
+set motor_output_limit = 88
+profile 1
+set motor_output_limit = 88
+profile 2
+set motor_output_limit = 88
+profile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Generic 1380KV motor
+profile 0
+set motor_output_limit = 86
+profile 1
+set motor_output_limit = 86
+profile 2
+set motor_output_limit = 86
+profile 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Generic 1500KV motor
+profile 0
+set motor_output_limit = 78
+profile 1
+set motor_output_limit = 78
+profile 2
+set motor_output_limit = 78
+profile 0
+#$ OPTION END
+
+#$ OPTION_GROUP END

--- a/presets/4.3/tune/Street_League_LeadFingers.txt
+++ b/presets/4.3/tune/Street_League_LeadFingers.txt
@@ -1,0 +1,58 @@
+#$ TITLE: Street League LeadFingers PIDtoolbox tune
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Street League, StreetLeague, Street, League, LeadFingers, PIDtoolbox, 7"
+#$ AUTHOR: LeadFingers
+
+#$ DESCRIPTION: LeadFingers tune for Street League quads
+#$ DESCRIPTION: ESC must be bi-directional Dshot ready
+#$ WARNING: **DO NOT** Flash this preset to a quad that is not Street League Spec
+#$ DISCUSSION: https://discord.gg/rqGfKBbYbP
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Undo some default things --
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+set dshot_bidir = ON
+
+# -- Filter Settings --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 200
+set dyn_notch_q = 400
+set dyn_notch_min_hz = 110
+set dyn_notch_max_hz = 400
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set simplified_gyro_filter = OFF
+set rpm_filter_harmonics = 1
+set rpm_filter_q = 1000
+set dterm_lpf1_static_hz = 0
+
+# -- PID Settings --
+set simplified_master_multiplier = 180
+set simplified_i_gain = 50
+set simplified_d_gain = 185
+set simplified_pi_gain = 150
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 90
+set simplified_pitch_d_gain = 115
+set simplified_pitch_pi_gain = 105
+simplified_tuning apply
+
+# -- spec settings --
+set throttle_boost = 5
+set throttle_boost_cutoff = 15
+
+#$ OPTION_GROUP BEGIN: Select Dshot 300 or 600
+
+#$ OPTION BEGIN (UNCHECKED): Dshot 300
+set motor_pwm_protocol = DSHOT300
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dshot 600
+set motor_pwm_protocol = DSHOT600
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
adds a Street League spec Motor output and throttle limit setting to the "other" preset
adds a LeadFingers PidToolbox tune for Street League quads.