### PR TITLE
Karate Race 6S polishing

### DIFF
--- a/presets/4.3/tune/karate_race.txt
+++ b/presets/4.3/tune/karate_race.txt
@@ -4,27 +4,45 @@
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: karate, 6S, race, world champion, 5 inch, 5", sugarK, limon, ctzsnooze, karateBrot
 #$ AUTHOR: sugarK
-#$ DESCRIPTION: This 6s racing tune was developed with the help of @ctzsnooze around @karatebrot’s RPM crossfade code allowing a pretty aggressive filter array which is the karate array.
-#$ DESCRIPTION: This tune works well on any quality airframes and has been flown on the Viper racer (where it was developed ) BMS Js1, 533 switchback, HGLRC wind and of course @limons Open racer.
-#$ DESCRIPTION: It should also work on other quality racing frames but use at your own risk as it is an aggressive tune. This tune so far has won a good number of events including the 2021 IO.
-#$ DESCRIPTION:
-#$ DESCRIPTION: Things to note: YOU HAVE TO USE RPM FILTERING WITH THIS TUNE, failure to do so might result in fire and regarding Dshot600,  if your setup has errors in the motor tab using bidirectional Dshot then change to 8k/4k and dshot300.
-#$ DESCRIPTION: Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc. To test arm the quad with props on, it should sound clean with no grinding, if it passes that then hover test and check motor temps.
-#$ DESCRIPTION:  If any thing is off don't fly it!!
-#$ DESCRIPTION:
-#$ DESCRIPTION: SECOND NOTE.... Radio links.. 1. Make sure your radio system is totally up to date using either Edgetx or Opentx and your ADC in the hardware page is OFF 2. Go to the radio presets and apply the correct setup for your system and link speed.
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174759844-ffd85f42-1f1c-42bf-9032-d9f96d4d9619.svg" width="100px" style="display: block; float: right;"/>
+#$ DESCRIPTION: 
+#$ DESCRIPTION: # Karate Race 6S 5"
+#$ DESCRIPTION: This 6S racing tune was developed with the help of **@ctzsnooze** around **@KarateBrot**'s [RPM Crossfade code](https://github.com/betaflight/betaflight/pull/10757) allowing for a pretty aggressive filter tune, which is called the [Karate Array](https://github.com/betaflight/firmware-presets/blob/master/presets/4.3/filters/karate_array.txt).
+#$ DESCRIPTION: 
+#$ DESCRIPTION: This tune works well on any quality airframes and has been flown on the Viper racer (where it was developed), BMS Js1, 533 Switchback, HGLRC Wind and of course **@limon**'s Open Racer.
+#$ DESCRIPTION: 
+#$ DESCRIPTION: It should also work on other quality racing frames but use at your own risk as it is an aggressive tune. This tune so far has won a good number of events, including the **2021 MultiGP International Open**.
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ### Things to note: 
+#$ DESCRIPTION: - **YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!** Failure to do so might result in fire 🔥 
+#$ DESCRIPTION: - Regarding DShot600: if your setup has errors in the motor tab using bidirectional Dshot, change to **8k/4k and DShot300**
+#$ DESCRIPTION: - Also this should be **applied to a clean flash** after you've setup your rates, swtiches, vtx tables etc. To test arm the quad with props on, it should sound clean with no grinding, if it passes that then hover test and check motor temps.
+#$ DESCRIPTION: - **If anything is off, don't fly it!!**
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ### Second note.... Radio links: 
+#$ DESCRIPTION: 1. Make sure your radio system is totally up to date using either EdgeTX or OpenTX and your **ADC Filter in the hardware page is OFF**
+#$ DESCRIPTION: 2. Go to the radio presets and apply the correct setup for your system and link speed
+
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/41
+
 #$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
 #$ INCLUDE: presets/4.3/tune/defaults.txt
 #$ INCLUDE: presets/4.3/filters/defaults.txt
-
-
 
 # -- Gyro lowpass filters --
 set gyro_lpf1_static_hz = 0
 set gyro_lpf1_dyn_min_hz = 500
 set gyro_lpf1_dyn_max_hz = 1000
 set simplified_gyro_filter = OFF
+
+#$ OPTION BEGIN (UNCHECKED): Bosh (BMI) gyro - experimantal
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+#$ OPTION END
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 2
@@ -45,7 +63,7 @@ set thrust_linear = 0
 set throttle_boost = 2
 
 # -- Antigravity --
-set anti_gravity_gain = 5500
+set anti_gravity_gain = 3000
 
 # -- iTerm  --
 set iterm_relax_cutoff = 20
@@ -80,125 +98,146 @@ set tpa_rate = 70
 set tpa_breakpoint = 1250
 
 #$ OPTION BEGIN (CHECKED): Dshot600
-set dshot_bidir = ON
-set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set motor_pwm_protocol = DSHOT600
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): Dshot300
-set dshot_bidir = ON
-set motor_pwm_protocol = Dshot300
+    set dshot_bidir = ON
+    set motor_pwm_protocol = Dshot300
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): Dynamic idle for 2000kv 6s
-#dynamic idle for 6s 2000kv
-set dyn_idle_min_rpm = 40
-set dyn_idle_p_gain = 35
+    #dynamic idle for 6s 2000kv
+    set dyn_idle_min_rpm = 40
+    set dyn_idle_p_gain = 35
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): Spicy tune 
 
-#spicy tune use with care
-# -- Gyro Dynamic Notches --
-set dyn_notch_count = 1
-set dyn_notch_q = 600
-set dyn_notch_min_hz = 250
-set dyn_notch_max_hz = 650
+    #spicy tune use with care
+    # -- Gyro Dynamic Notches --
+    set dyn_notch_count = 1
+    set dyn_notch_q = 600
+    set dyn_notch_min_hz = 250
+    set dyn_notch_max_hz = 650
 
-# -- Dterm filtering --
-set dterm_lpf1_dyn_expo = 10
+    # -- Dterm filtering --
+    set dterm_lpf1_dyn_expo = 10
 
-# -- RPM filtering --
-set rpm_filter_harmonics = 2
-set rpm_filter_min_hz = 150
+    # -- RPM filtering --
+    set rpm_filter_harmonics = 2
+    set rpm_filter_min_hz = 150
 
-# -- PID values --
-set p_pitch = 42
-set i_pitch = 85
-set d_pitch = 42
-set f_pitch = 135
-set p_roll = 37
-set i_roll = 80
-set d_roll = 36
-set f_roll = 120
-set p_yaw = 45
-set i_yaw = 80
-set d_yaw = 0
-set f_yaw = 80
+    # -- PID values --
+    set p_pitch = 42
+    set i_pitch = 85
+    set d_pitch = 42
+    set f_pitch = 135
+    set p_roll = 37
+    set i_roll = 80
+    set d_roll = 36
+    set f_roll = 120
+    set p_yaw = 45
+    set i_yaw = 80
+    set d_yaw = 0
+    set f_yaw = 80
 
-set d_min_roll = 26
-set d_min_pitch = 26
-set d_max_gain = 25
-set d_max_advance = 0
-set simplified_pids_mode = OFF
+    set d_min_roll = 26
+    set d_min_pitch = 26
+    set d_max_gain = 25
+    set d_max_advance = 0
+    set simplified_pids_mode = OFF
 #$ OPTION END
 
 
-#$ OPTION BEGIN (UNCHECKED): Limons Super Spicy Dmin
-set d_min_roll = 30
-set d_min_pitch = 30
+#$ OPTION BEGIN (UNCHECKED): Limons Super Spicy TPA
+    set tpa_rate = 85
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): Noisy airframe (can be used with Spicy)
 
-# -- Gyro lowpass filters --
-set gyro_lpf1_static_hz = 0
-set gyro_lpf2_static_hz = 0
-set gyro_lpf1_dyn_min_hz = 0
-set gyro_lpf1_dyn_max_hz = 0
+    # -- Gyro lowpass filters --
+    set gyro_lpf1_static_hz = 0
+    set gyro_lpf2_static_hz = 0
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
 
-# -- Dterm filtering --
-set dterm_lpf1_dyn_expo = 10
-set dterm_lpf1_type = BIQUAD
+    # -- Dterm filtering --
+    set dterm_lpf1_dyn_expo = 10
+    set dterm_lpf1_type = BIQUAD
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Tracer/ELRS 250Hz
+#$ OPTION_GROUP BEGIN: Some popular RC Links
 
-# Tracer/ELRS 250Hz
-feature RX_SERIAL
-set serialrx_provider = CRSF
-set feedforward_averaging = OFF
-set feedforward_smooth_factor = 35
-set feedforward_jitter_factor = 5
-#$ OPTION END
+    #$ OPTION BEGIN (UNCHECKED): Tracer/ELRS 250Hz
+        # Tracer/ELRS 250Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
 
-#$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
 
-# ELRS 500Hz
-feature RX_SERIAL
-set serialrx_provider = CRSF
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
-set feedforward_jitter_factor = 5
-#$ OPTION END
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Ghost 250Hz
+    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
+        # ERLS 500Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
 
-# Ghost 250Hz
-feature RX_SERIAL
-set serialrx_provider = GHST
-set feedforward_averaging = OFF
-set feedforward_smooth_factor = 35
-set feedforward_jitter_factor = 5
-#$ OPTION END
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 3
+        set feedforward_boost = 18
 
-#$ OPTION BEGIN (UNCHECKED): Ghost 500Hz
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
 
-# Ghost 500Hz
-feature RX_SERIAL
-set serialrx_provider = GHST
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
-set feedforward_jitter_factor = 5
-#$ OPTION END
+    #$ OPTION BEGIN (UNCHECKED): Ghost 250Hz
+        # Ghost 250Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = GHST
 
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 500Hz
+        # Ghost 500Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 3
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+#$ OPTION_GROUP END
 
 #$ OPTION BEGIN (UNCHECKED): sugarK's rates
-set thr_mid = 25
-set thr_expo = 65
-set roll_expo = 54
-set pitch_expo = 54
-set yaw_expo = 54
-set roll_srate = 40
-set pitch_srate = 40
-set yaw_srate = 42
+    set thr_mid = 25
+    set thr_expo = 65
+    set roll_expo = 54
+    set pitch_expo = 54
+    set yaw_expo = 54
+    set roll_srate = 40
+    set pitch_srate = 40
+    set yaw_srate = 42
 #$ OPTION END


### PR DESCRIPTION
1. Added experimental BOSH option
2. Reduced AG gain to 3.0
3. Adding corresponding rc_smoothing to the RC_LINK options
4. Replaced limon's spicy D gain with Spicy TPA
5. Added options_group for RC_LINKS for better look
6. Added indentation to the code

Original Karate PR:
https://github.com/betaflight/firmware-presets/pull/41