### PR TITLE
Create eachine_vtx.txt

### DIFF
--- a/presets/4.3/vtx/eachine_vtx.txt
+++ b/presets/4.3/vtx/eachine_vtx.txt
@@ -1,0 +1,60 @@
+#$ TITLE: Eachine VTX Tables
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: eachine, Eachine, nano, Nano, irc, IRC, tramp, TRAMP, Tramp, IRC Tramp, irc tramp, IRC TRAMP, tbs, sa, tbs sa, smartaudio, smart audio, Smart, Audio TBS
+#$ AUTHOR: KMfpv
+#$ DESCRIPTION: VTX Table for the Eachine VTX (SmartAudio & IRC Tramp)
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+#VTx table
+vtxtable bands 5
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY 5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B FACTORY 5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E FACTORY 5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F FACTORY 5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+
+#$ OPTION_GROUP BEGIN: choose your vtx
+
+#$ OPTION BEGIN (UNCHECKED): Eachine TX805 (SA 2.0)
+vtxtable powerlevels 4
+vtxtable powervalues 0 1 2 3
+vtxtable powerlabels 25 200 600 800
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Eachine TX806 leaf (SA 2.0)
+vtxtable powerlevels 5
+vtxtable powervalues 0 1 2 3 4
+vtxtable powerlabels 25 200 400 800 1W
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Eachine TX1200 (SA 2.0)
+vtxtable powerlevels 4
+vtxtable powervalues 0 1 2 3
+vtxtable powerlabels 25 200 600 1W2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Eachine Nano VTX (v1/v2/v3) (TRAMP)
+vtxtable powerlevels 4
+vtxtable powervalues 25 100 200 400
+vtxtable powerlabels 25 100 200 400
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Eachine ATX03s/VTX03S (SA 2.0)
+vtxtable powerlevels 4
+vtxtable powervalues 0 1 2 3
+vtxtable powerlabels 25 50 100 200
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Eachine TX06/xx65 AIO (SA 2.0)
+vtxtable powerlevels 1
+vtxtable powervalues 0
+vtxtable powerlabels 25
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
I think that's right now.
Added all the eachine smart audio and tramp vtx.
All the vtxtable have the factory bands and channels. Only difference is the protocol, the powerlevels and power labels. 