### PR TITLE
Removed feedforward_jitter_factor and feedforward_averaging froom TUNE

### DIFF
--- a/presets/4.3/other/Tehllama_5in_2350-2750KV-TexasSpec_3S-4S-5S_Race_TUNE_OTHER.txt
+++ b/presets/4.3/other/Tehllama_5in_2350-2750KV-TexasSpec_3S-4S-5S_Race_TUNE_OTHER.txt
@@ -10,7 +10,7 @@
 #$ DESCRIPTION: Strongly recommend a full chip erase reflash if alternative tunes are desired.
 #$ DESCRIPTION: Extensive testing has been done across 57+ builds, however not every craft will run best on this tune.
 #$ DESCRIPTION: This tune will auto-select profiles based on battery voltage at plugin by default, but only for 3S, 4S and 5S packs. 
-#$ WARNING: Use at your own risk.  NO 6-cell tune or throttle limit is provided with this tune.  Plugging in a 6S pack with 3S profile active will likely cause SERIOUS damage.  
+#$ WARNING: Use at your own risk.  NO 6-cell tune or throttle limit is provided with this tune.  Plugging in a 6S pack with 3S profile active will likely cause SERIOUS damage.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/236
 
 # FORCE_OPTIONS_REVIEW: TRUE
@@ -44,7 +44,6 @@ set d_min_roll = 28
 set d_min_pitch = 35
 set d_max_advance = 0
 set auto_profile_cell_count = 4
-set feedforward_jitter_factor = 12
 set feedforward_boost = 12
 set throttle_boost = 12
 
@@ -82,7 +81,6 @@ set d_min_pitch = 26
 set d_max_advance = 0
 set motor_output_limit = 92
 set auto_profile_cell_count = 5
-set feedforward_jitter_factor = 12
 set feedforward_boost = 8
 set throttle_boost = 5
 set feedforward_max_rate_limit = 103
@@ -121,7 +119,6 @@ set d_min_pitch = 35
 set d_max_advance = 0
 set motor_output_limit = 81
 set auto_profile_cell_count = 3
-set feedforward_jitter_factor = 12
 set feedforward_boost = 18
 set throttle_boost = 18
 set feedforward_max_rate_limit = 103

--- a/presets/4.3/tune/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
+++ b/presets/4.3/tune/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
@@ -47,10 +47,6 @@ set dterm_lpf2_static_hz = 140
 
 set anti_gravity_gain = 4000
 
-# -- Feedforward jitter reduction --
-
-set feedforward_jitter_factor = 12
-
 #$ OPTION BEGIN (CHECKED): RPM filtering
 
 set motor_pwm_protocol = DSHOT600

--- a/presets/4.3/tune/SupaflyFPV_Freestyle_6_and_EasyTune.txt
+++ b/presets/4.3/tune/SupaflyFPV_Freestyle_6_and_EasyTune.txt
@@ -47,10 +47,6 @@ set dterm_lpf2_static_hz = 140
 
 set anti_gravity_gain = 4000
 
-# -- Feedforward jitter reduction --
-
-set feedforward_jitter_factor = 12
-
 #$ OPTION BEGIN (CHECKED): RPM filtering
 
 set motor_pwm_protocol = DSHOT600

--- a/presets/4.3/tune/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
+++ b/presets/4.3/tune/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
@@ -47,10 +47,6 @@ set dterm_lpf2_static_hz = 140
 
 set anti_gravity_gain = 4000
 
-# -- Feedforward jitter reduction --
-
-set feedforward_jitter_factor = 12
-
 #$ OPTION BEGIN (CHECKED): RPM filtering
 
 set motor_pwm_protocol = DSHOT600

--- a/presets/4.3/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.3/tune/ctzsnooze_5in_4S_race.txt
@@ -58,9 +58,6 @@ set tpa_breakpoint = 1250
 # -- Feedforward --
 set feedforward_boost = 18
 set feedforward_max_rate_limit = 95
-set feedforward_jitter_factor = 5
-# -- Feedforward averaging (do not change)--
-set feedforward_jitter_factor = 5
 
 # -- PIDsum limits (default)--
 # -- Antigravity (default) --
@@ -110,18 +107,15 @@ set dyn_idle_p_gain = 40
 #$ OPTION_GROUP BEGIN: Choose your RC link speed!
 
 #$ OPTION BEGIN (UNCHECKED): 150Hz or less
+    #$ INCLUDE: presets/4.3/rc_link/generic/150hz_race.txt
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): 250Hz
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 40
-set feedforward_jitter_factor = 6
+    #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): 500Hz
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
-set feedforward_jitter_factor = 5
+    #$ INCLUDE: presets/4.3/rc_link/generic/500hz_race.txt
 #$ OPTION END
 
 #$ OPTION_GROUP END

--- a/presets/4.3/tune/defaults.txt
+++ b/presets/4.3/tune/defaults.txt
@@ -75,14 +75,6 @@ set feedforward_max_rate_limit = 90
 # -- Feedforward averaging (do not change)--
 # needs to be set according to RC link type and speed, not changed in the tune
 
-# -- Feedforward jitter reduction (default)--
-# depends on RC link and flying style - default is 7
-set feedforward_jitter_factor = 7
-
-# Note: feedforward_jitter_factor is related to both RC link and flying style.
-# It is overwritten by this default
-# The Preset author should provide feedforward_jitter_factor options to set jitter reduction appropriately for different kinds of RC links
-
 # -- PIDsum limits (default) --
 set pidsum_limit = 500
 set pidsum_limit_yaw = 400
@@ -205,14 +197,9 @@ set motor_pwm_rate = 480
 # -- Rates --
 # One ore more un-checked 'OPTION' elements that 'Include' external Rates preset files.
 
-# -- RC_Smoothing --
-# One ore more un-checked 'RC_SMOOTHING' elements that 'Include' external rc_smoothing preset files.
-
 # -- Filters --
-# One ore more un-checked 'FILTERS elements that 'Include' external Filter preset files.
+# One ore more un-checked or checked 'FILTERS elements that 'Include' external Filter preset files.
 # It may be good to initialise to a non-RPM filter set, then provide your preferred RPM aware filter set as a checked uption.
-
-
 
 # -- Throttle limit (default) --
 # For least full throttle noise, use SCALE and values around 95-96-97

--- a/presets/4.3/tune/fpvian_basher_freestyle.txt
+++ b/presets/4.3/tune/fpvian_basher_freestyle.txt
@@ -48,10 +48,6 @@ simplified_tuning apply
 set dyn_idle_min_rpm = 30
 #$ OPTION END
 
-#$ OPTION BEGIN (CHECKED): Feedforward Jitter Reduction to 13 for HD Recording
-set feedforward_jitter_factor = 13
-#$ OPTION END
-
 #$ OPTION BEGIN (CHECKED): Disable Throttle Boost
 set throttle_boost = 0
 #$ OPTION END

--- a/presets/4.3/tune/karate_freestyle_5_inch.txt
+++ b/presets/4.3/tune/karate_freestyle_5_inch.txt
@@ -1,7 +1,7 @@
 #$ TITLE: Freestyle 5" Karate Style
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL 
+#$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: karate, 6S,5 inch, 5", sugarK, limon, ctzsnooze, karateBrot, freestyle
 #$ AUTHOR: sugarK
 #$ DESCRIPTION: This is the sugarK freestyle tune, its been test over the last few months, on 5" quads by members of the UAVtech discord.. This is a starting point tune and has siders active so you can fine tune it easily. In saying that its still a pretty spicy tune and use at your own risk.
@@ -11,7 +11,7 @@
 #$ DESCRIPTION: Things to note.. YOU HAVE TO USE RPM FILTERING WITH THIS TUNE, failure to do so might result in fire and regarding Dshot600,  if your setup has errors in the motor tab using bidirectional Dshot then change to 8k/4k and dshot300.
 #$ DESCRIPTION: Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc. To test arm the quad with props on, it should sound clean with no grinding, if it passes that then hover test and check motor temps.
 #$ DESCRIPTION:  If any thing is off don't fly it!!
-#$ DESCRIPTION: 
+#$ DESCRIPTION:
 #$ DESCRIPTION: SECOND NOTE.... Radio links.. 1. Make sure your radio system is totally up to date using either Edgetx or Opentx and your ADC in the hardware page is OFF 2. Go to the radio presets and apply the correct setup for your system and link speed.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/95
 #$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
@@ -45,10 +45,6 @@ set simplified_pitch_d_gain = 95
 set simplified_pitch_pi_gain = 110
 simplified_tuning apply
 
-# -- Feedforward --
-set feedforward_averaging = 2_POINT
-set feedforward_jitter_factor = 12
-
 #$ OPTION BEGIN (CHECKED): Dshot600
 set dshot_bidir = ON
 set motor_pwm_protocol = DSHOT600
@@ -59,7 +55,7 @@ set dshot_bidir = ON
 set motor_pwm_protocol = Dshot300
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): dynamic idle 
+#$ OPTION BEGIN (UNCHECKED): Dynamic idle
 set dshot_idle_value = 450
 set dyn_idle_min_rpm = 35
 set dyn_idle_p_gain = 35

--- a/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
@@ -42,9 +42,6 @@ set tpa_rate = 70
 # -- Feedforward --
 set feedforward_boost = 15
 
-# -- Feedforward Jitter Reduction --
-set feedforward_jitter_factor = 14
-
 # -- Antigravity --
 set anti_gravity_gain = 3500
 

--- a/presets/4.3/tune/reset_all.txt
+++ b/presets/4.3/tune/reset_all.txt
@@ -77,9 +77,6 @@ set anti_gravity_gain = 3500
 #$ OPTION BEGIN (CHECKED): Feedforward
 set feedforward_boost = 18
 set feedforward_max_rate_limit = 95
-set feedforward_jitter_factor = 5
-set feedforward_jitter_factor = 7
-set feedforward_averaging = OFF
 #$ OPTION END
 
 #$ OPTION BEGIN (CHECKED): PID Sum Limit

--- a/presets/4.3/tune/reset_some.txt
+++ b/presets/4.3/tune/reset_some.txt
@@ -77,9 +77,6 @@ set anti_gravity_gain = 3500
 #$ OPTION BEGIN (UNCHECKED): Feedforward
 set feedforward_boost = 18
 set feedforward_max_rate_limit = 95
-set feedforward_jitter_factor = 5
-set feedforward_jitter_factor = 7
-set feedforward_averaging = OFF
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): PID Sum Limit
@@ -89,7 +86,7 @@ set iterm_limit = 400
 #$ OPTION END
 
 
-#  -- Miscellaneous settings -- 
+#  -- Miscellaneous settings --
 
 #$ OPTION BEGIN (UNCHECKED): Yaw spin recovery auto
 set yaw_spin_recovery = AUTO

--- a/presets/4.3/tune/tiny_karate.txt
+++ b/presets/4.3/tune/tiny_karate.txt
@@ -61,9 +61,6 @@ set simplified_feedforward_gain = 105
 set simplified_pitch_d_gain = 95
 simplified_tuning apply
 
-# -- Feedforward --
-set feedforward_jitter_factor = 5
-
 # -- TPA --
 set tpa_rate = 70
 set tpa_breakpoint = 1250

--- a/presets/4.3/tune/whoop_justice.txt
+++ b/presets/4.3/tune/whoop_justice.txt
@@ -74,7 +74,6 @@ set tpa_breakpoint = 1250
 # -- Feedforward --
 set feedforward_boost = 18
 set feedforward_max_rate_limit = 95
-set feedforward_jitter_factor = 5
 # -- Feedforward averaging (do not change)--
 
 # -- PIDsum limits (default)--
@@ -129,15 +128,11 @@ set dyn_idle_min_rpm = 50
 
 
 #$ OPTION BEGIN (UNCHECKED): RC_LINK 250Hz
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 40
-set feedforward_jitter_factor = 5
+    #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): RC_LINK 500Hz
-set feedforward_averaging = 2_POINT
-set feedforward_smooth_factor = 65
-set feedforward_jitter_factor = 4
+    #$ INCLUDE: presets/4.3/rc_link/generic/500hz_race.txt
 #$ OPTION END
 
 #$ OPTION_GROUP END


### PR DESCRIPTION
Both `feedforward_jitter_factor` and `feedforward_averaging` are parts of the RC_LINK category
so TUNEs don't need and can't set these values. Unless inside the RC_LINK options.
The final CLI outcome must be the same regardless of the order that user applies presets (RC_LINK + TUNE == TUNE + RC_LINK)

So i removed `feedforward_jitter_factor` from tune/defaults.txt
removed `feedforward_jitter_factor` and `feedforward_averaging` from the tunes
replaced old RC_LINK options in the tunes with the proper `#$ INCLUDE rc_link/....`

Please check the changes with care.