### PR TITLE
Adds default filter setup to SDFT, updates description, updates warning

### DIFF
--- a/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
@@ -2,22 +2,52 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
 #$ STATUS: EXPERIMENTAL
-#$ KEYWORDS: AOS, 4s
+#$ KEYWORDS: AOS, 4s, freestyle, sub 250
 #$ AUTHOR: mouseFPV
-#$ DESCRIPTION: Tune for AOS 3.5 with FPVCycle 16mm motors, <250g 4s
-#$ DESCRIPTION: Tuned at 95% Motor Limit
-#$ DESCRIPTION: May be approproiate for v2 frame and/or different motors/cell counts
-#$ DESCRIPTION: Tune/Filters are aggressive, and may not be approproiate for non trussed/braced frames
-#$ DESCRIPTION: Recommended 48k PWM
-#$ DESCRIPTION: If you use the filters and are on an F4, use a 4k PID Loop
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for AOS 3.5
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * May be appropriate for v2 frame and/or different motors/cell counts
+#$ DESCRIPTION: * Tune/Filters are aggressive, and may not be appropriate for non trussed/braced frames
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION: * Uses Multi-Dynamic notich by default. Options for RPM filtering which use Dshot. Using DShot on Unsupported ESC's is Dangerous. See Warning.
+#$ DESCRIPTION: * RPM Filtering is recommended
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). enables gyro LPF 2.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3.5"
+#$ DESCRIPTION: * **95% Motor Limit:** Takes some of the spice out of powerful motors on 4s
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created on:
+#$ DESCRIPTION: * **Frame:** AOS 3.5 V1
+#$ DESCRIPTION: * **Motors:** FPVCycle 16mm (4s 95% Motor Limit)
+#$ DESCRIPTION: * **FC/ESC:** Foxeer Reaper f7 AIO
+#$ DESCRIPTION: * **AUW:** 243g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION:
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/247
-#$ WARNING: Included Filters set motor poles to 12! Filters Require RPM filtering and DShot telemetry!
-#$ DISCLAIMER: Flash At Your Own Risk!
+#$ WARNING: If You Choose To Include RPM Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
 #$ FORCE_OPTIONS_REVIEW: TRUE
 #$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
 
 # ------- End Defaults --------
 # ----- Begin Mouse Tune-------
+
 
 # -- PID Sliders  --
 set simplified_pids_mode = RPY
@@ -45,43 +75,48 @@ set anti_gravity_gain = 3500
 # -- Thrust linear --
 set thrust_linear = 20
 
-# -- DShot Idle (default)--
+# -- DShot Idle --
 # Commonly set lower when dynamic idle is active.
 set dshot_idle_value = 400
 
-# -- Dyn Idle (off, default) --
-set dyn_idle_min_rpm = 0
+# -- Filters for non bi-directional setups as a base--
 
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set gyro_lpf2_static_hz = 0
+set simplified_gyro_filter = OFF
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 3
+set dyn_notch_q = 425
+set dyn_notch_min_hz = 150
+set dyn_notch_max_hz = 600
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 125
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-
-
 # This is where the author includes options that require input from the User
-
-#$ OPTION BEGIN (CHECKED): Dynamic Idle
-set dshot_bidir = ON
-set dshot_idle_value = 150
-set dyn_idle_min_rpm = 25
-set dyn_idle_p_gain = 50
-#$ OPTION END
-
-#$ OPTION BEGIN (UNCHECKED): 95% Motor Limit? (Use this if its too spicy)
-set motor_output_limit = 95
-#$ OPTION END
-
-#$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
-set vbat_sag_compensation = 100
-#$ OPTION END
 
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
 
-#$ OPTION BEGIN (Unchecked): Include RPM Filter (F7)?
+#$ OPTION BEGIN (CHECKED): RPM Filters (F7 & Up)?
 #$ INCLUDE: presets/4.3/filters/defaults.txt
 
 # ------- End Defaults --------
 # ----- Begin Mouse Tune-------
 
 # enable dshot rpm telemetry
+set motor_pwm_protocol = DSHOT600
 set dshot_bidir = ON
 set motor_poles = 12
 
@@ -105,25 +140,22 @@ set rpm_filter_min_hz = 125
 set rpm_filter_harmonics = 3
 
 # -- Dterm filtering --
-set dterm_lpf1_dyn_min_hz = 93
-set dterm_lpf1_dyn_max_hz = 187
-set dterm_lpf1_dyn_expo = 5
-set dterm_lpf1_static_hz = 93
-set dterm_lpf2_static_hz = 187
 set simplified_dterm_filter = on
 set simplified_dterm_filter_multiplier = 125
+simplified_tuning apply
 
 # -- Yaw lowpass --
 set yaw_lowpass_hz = 100
 #$ OPTION END
 
-#$ OPTION BEGIN (Unchecked): Include RPM Filter (F4)?
+#$ OPTION BEGIN (UNCHECKED): RPM Filters (F4)?
 #$ INCLUDE: presets/4.3/filters/defaults.txt
 
 # ------- End Defaults --------
 # ----- Begin Mouse Tune-------
 
 # enable dshot rpm telemetry
+set motor_pwm_protocol = DSHOT300
 set dshot_bidir = ON
 set motor_poles = 12
 
@@ -131,9 +163,9 @@ set motor_poles = 12
 set gyro_lpf1_static_hz = 0
 set gyro_lpf1_dyn_min_hz = 0
 set gyro_lpf1_dyn_max_hz = 0
-set gyro_lpf2_static_hz = 1000
 set simplified_gyro_filter_multiplier = 200
 set simplified_gyro_filter = on
+simplified_tuning apply
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 1
@@ -147,13 +179,9 @@ set rpm_filter_min_hz = 125
 set rpm_filter_harmonics = 3
 
 # -- Dterm filtering --
-set dterm_lpf1_dyn_min_hz = 93
-set dterm_lpf1_dyn_max_hz = 187
-set dterm_lpf1_dyn_expo = 5
-set dterm_lpf1_static_hz = 93
-set dterm_lpf2_static_hz = 187
 set simplified_dterm_filter = on
 set simplified_dterm_filter_multiplier = 125
+simplified_tuning apply
 
 
 # -- Yaw lowpass --
@@ -162,3 +190,22 @@ set yaw_lowpass_hz = 100
 
 
 #$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+
+#$ OPTION BEGIN (CHECKED): Dynamic Idle
+set dyn_idle_min_rpm = 25
+set dyn_idle_p_gain = 50
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 95% Motor Limit
+set motor_output_limit = 95
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
+set vbat_sag_compensation = 100
+#$ OPTION END
+
+#$ OPTION_GROUP END
+


### PR DESCRIPTION
Original preset pr: https://github.com/betaflight/firmware-presets/pull/247

This update brings my AOS 3.5 tune in line with my Incisor tune in terms of structure, methodology, and formatting, and brings forward feedback and lessons learned in that tune. 

We now load the default filters along with the default pids, then set filters that work without bidirectional dshot. no motor protocol is set in the base. 

We continue to have options for f4 and f7 rpm filters. They re-load default filters, set proper dshot protocol for MCU, enables bi-directional, then apply RPM filtering. the f4 uses dshot 300 and has gyro lfp2 at 1000hz and recommends 4k pidloop in the description. the f7 uses dshot600, has no gyro lpfs, and recommends n 8k pidloop. 

we also use the default dshot warning, and the dynamic idle option does not set bi-directional on, so that will sort of "fail gracefully/silently" if a user isn't choosing the RPM filters or otherwise doesn't have bi-directional dshot enabled.

Lastly, this cleans up some redundant commands (like setting dynamic idle value to 0 when the defaults already do that).