### PR TITLE
Creating Preset for Toothpick 3 on 3s

### DIFF
--- a/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
@@ -1,0 +1,225 @@
+#$ TITLE:  FPVCycle Toothpick 3 3s | mouseFPV
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle TP3, Toothpick, 3s, 3 inch
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for Toothpick 3
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * These gains will be high if your filtering is inadequate. Frame is noisey below 150hz
+#$ DESCRIPTION: * FOR SIDE MOUNT LIPOS ONLY, Experimental option for front-back lipos
+#$ DESCRIPTION: * Lipo Orientation very important
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually). 
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3"
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **Front-Back Lipo:** The FPVCycle TP3 frame has a side mount lipo. Try this if you choose to mount the lipo front to back. Experimental.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ##  Build Specs This Was Created on:
+#$ DESCRIPTION: * **Frame:** FPVCycle TP3
+#$ DESCRIPTION: * **Motors:** FPVCycle 13mm 5000kv 3s
+#$ DESCRIPTION: * **FC/ESC:** Flywoo GOKU GNF411 40a
+#$ DESCRIPTION: * **AUW:** 103g
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION: 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/269
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ FORCE_OPTIONS_REVIEW: TRUE
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 130
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 70
+set simplified_dmax_gain = 000
+set simplified_i_gain = 80
+set simplified_pitch_d_gain = 75
+set simplified_pitch_pi_gain = 80
+set simplified_master_multiplier = 135
+simplified_tuning apply
+
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Antigravity --
+set anti_gravity_gain = 3500
+
+# -- Thrust linear (off, default) --
+set thrust_linear = 20
+
+# -- DShot Idle (default)--
+# Commonly set lower when dynamic idle is active.
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set simplified_gyro_filter = on
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 325
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 600
+
+# -- Dterm filtering --
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+
+
+# This is where the author includes options that require input from the User
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+
+#$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+# -- Filter Settings --
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Filters --
+
+# enable dshot rpm telemetry
+set motor_pwm_protocol = DSHOT600
+set dshot_bidir = ON
+set motor_poles = 12
+
+# -- Gyro lowpass filters --
+set simplified_gyro_filter = on
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 550
+
+# -- RPM filtering --
+set rpm_filter_q = 500
+set rpm_filter_min_hz = 100
+set rpm_filter_fade_range_hz = 50
+set rpm_filter_harmonics = 3
+
+# -- Dterm filtering --
+set simplified_dterm_filter = on
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+#$ OPTION END
+
+
+#$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+# -- Filter Settings --
+
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Filters --
+
+# enable dshot rpm telemetry
+set motor_pwm_protocol = DSHOT300
+set dshot_bidir = ON
+set motor_poles = 12
+
+# -- Gyro lowpass filters --
+
+set simplified_gyro_filter = on
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 550
+
+# -- RPM filtering --
+set rpm_filter_q = 500
+set rpm_filter_min_hz = 100
+set rpm_filter_fade_range_hz = 50
+set rpm_filter_harmonics = 3
+
+# -- Dterm filtering --
+set simplified_dterm_filter = on
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+#$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+
+#$ OPTION BEGIN (CHECKED): Dynamic Idle
+set dyn_idle_min_rpm = 30
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
+set vbat_sag_compensation = 100
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Front-Back Lipo (experimental, flips pitch/roll gains)
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 130
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 70
+set simplified_dmax_gain = 000
+set simplified_i_gain = 95
+set simplified_pitch_d_gain = 105
+set simplified_pitch_pi_gain = 115
+set simplified_master_multiplier = 115
+simplified_tuning apply
+
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
This is a preset for 3" toothpick builds. 

Offers SDFT filters in the main preset, and has options for RPMf on f4 or f7, and those set dshot accordingly. We also have a dyn_idle option that does not set dshot or bi-directional, so it will fail silently/gracefully if those aren't on (the value just wont do anything. 

The TP3 is a fully symmetrical machine, true x with even mass distribution, other than the lipo. The lipo in this quad is side mount, so it goes against BF standard practice and actually has higher gains on roll than pitch because of this. However, similar frames that mount the lipo front to back, or an improper build of the tp3 with the lipo going front to back would need the pid values "flipped" about pitch and roll, such that gains were higher on pitch. There is an option that flips the pid values (via the sliders, but the sliders are not really "flipped") for pitch and roll to accomplish this.

will update description with this PR in a moment.

