### PR TITLE
Create mouseFPV preset for Braced digipick/toothpicks

### DIFF
--- a/presets/4.3/tune/mouseFPV_Digipick_braced.txt
+++ b/presets/4.3/tune/mouseFPV_Digipick_braced.txt
@@ -1,0 +1,299 @@
+#$ TITLE: Braced Toothpick/Digipick 3s/4s | mouseFPV
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle TP3, Digipick, Toothpick, 3s, 3 Inch, 4s, AOS T3, T3
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for Digital FPVCycle Toothpick 3 **with braces**
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * **NOT** APPROPRIATE FOR A TP3 Frame *Without* Carbon Braces/Trusses
+#$ DESCRIPTION: * Defaults to PIDS made for 3s
+#$ DESCRIPTION: * Only flash If you have a Braced TP3, an AOS-T3, or a toothpick frame with braces/trusses/additional arm struts.
+#$ DESCRIPTION: * FOR SIDE MOUNT LIPOS ONLY, Experimental options for front-back lipos
+#$ DESCRIPTION: * Lipo Orientation very important
+#$ DESCRIPTION: * My filters are strongly encouraged. These gains will be high if your filtering is inadequate. Frame is noisy below 150hz.
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## Goals:
+#$ DESCRIPTION: * The toothpick class of frames has a small weight window before things get out of control. The target weight is usually about 100g.
+#$ DESCRIPTION: * When you go digital and add weight to the quad, things get a bit unstable. You would usually increase the PID's to make up for this, however a normal toothpick frame cannot handle this.
+#$ DESCRIPTION: * If you brace the arms, or the frame has a design that incorporates a trussed arm system, you can push the gains much higher and get a far better flying craft.
+#$ DESCRIPTION: * This tune is made to specifically push the pids beyond the boundary of what most "standard" arm toothpick class quads would normally handle.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ###  Filters:
+#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually). 
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### Additional Options:
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3"
+#$ DESCRIPTION: * **Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **86% Motor Limit:** Sets a motor limit for 5000kv motors on 4s
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### PID Options (Default/None is Standard Lipo 3s):
+#$ DESCRIPTION: * **Standard Lipo 4s:** Applies Pids made for the additional weight and power of 4s. Strongly Recommend a Motor Limit if over 4000kv
+#$ DESCRIPTION: * **Front-Back Lipo 3s:** The FPVCycle TP3 frame has a side mount lipo. Try this if you choose to mount the lipo front to back for 3s pids. Experimental.
+#$ DESCRIPTION: * **Front-Back Lipo 4s:** The FPVCycle TP3 frame has a side mount lipo. Try this if you choose to mount the lipo front to back for 4s pids. Experimental.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### Auto Profiles:
+#$ DESCRIPTION: * **Auto Switch 3s Profile:** Will Activate the chosen PID Profile when plugging in 3s lipo. Choose this with 3s settings.
+#$ DESCRIPTION: * **Auto Switch 4s Profile:** Will Activate the chosen PID Profile when plugging in 4s lipo. Choose this with 4s settings.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created On (3s):
+#$ DESCRIPTION: * **Frame:** FPVCycle TP3 With Braces
+#$ DESCRIPTION: * **Motors:** FPVCycle 13mm 5000kv 3s, no motor limit
+#$ DESCRIPTION: * **FC/ESC:** Flywoo GOKU GNF745 40a
+#$ DESCRIPTION: * **Lipo:** GNB 500mah 3s
+#$ DESCRIPTION: * **AUW:** 121g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created On (4s):
+#$ DESCRIPTION: * **Frame:** FPVCycle TP3 With Braces
+#$ DESCRIPTION: * **Motors:** FPVCycle 13mm 5000kv 4s, 86% motor limit
+#$ DESCRIPTION: * **FC/ESC:** Flywoo GOKU GNF745 40a
+#$ DESCRIPTION: * **Lipo:** Tattu 450mah 4s
+#$ DESCRIPTION: * **AUW:** 131g
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION: 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/274
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 125
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 55
+set simplified_dmax_gain = 000
+set simplified_i_gain = 75
+set simplified_pitch_d_gain = 80
+set simplified_pitch_pi_gain = 85
+set simplified_master_multiplier = 170
+simplified_tuning apply
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Antigravity --
+set anti_gravity_gain = 3500
+
+# -- Thrust linear  --
+set thrust_linear = 20
+
+# -- DShot Idle (default)--
+# Commonly set lower when dynamic idle is active.
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 400
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 550
+
+# -- Dterm filtering --
+set simplified_dterm_filter = on
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+        # -- End Defaults --
+        # -- Begin Mouse Tune --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = on
+        set simplified_gyro_filter_multiplier = 150
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 100
+        set dyn_notch_max_hz = 550
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 100
+        set rpm_filter_fade_range_hz = 60
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+        # -- End Defaults --
+        # -- Begin Mouse Tune --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DShot300
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = on
+        set simplified_gyro_filter_multiplier = 150
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 100
+        set dyn_notch_max_hz = 550
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 100
+        set rpm_filter_fade_range_hz = 60
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 30
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Battery Sag Compensation
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): 86% Motor Limit (4s)
+         # -- Motor Output Limit for 4s --
+        set motor_output_limit = 86
+     #$ OPTION END
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: PID Options (Choose One or None)
+
+    #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 130
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 55
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 75
+        set simplified_pitch_d_gain = 80
+        set simplified_pitch_pi_gain = 80
+        set simplified_master_multiplier = 150
+        simplified_tuning apply
+        
+    #$ OPTION END
+
+
+    #$ OPTION BEGIN (UNCHECKED): Front-Back Lipo 3s (experimental, flips pitch/roll)
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 125
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 55
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 75
+        set simplified_pitch_d_gain = 100
+        set simplified_pitch_pi_gain = 110
+        set simplified_master_multiplier = 150
+        simplified_tuning apply
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Front-Back Lipo 4s (experimental, flips pitch/roll)
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 145
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 55
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 75
+        set simplified_pitch_d_gain = 95
+        set simplified_pitch_pi_gain = 115
+        set simplified_master_multiplier = 125
+        simplified_tuning apply
+
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Auto Profiles (Choose One or None)
+    #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
+        set auto_profile_cell_count = 3
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Auto Switch 4s Profile
+        set auto_profile_cell_count = 4
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+


### PR DESCRIPTION
The toothpick class of frames has a small weight window before things get out of control. The target weight is usually about 100g
When you go digital and add weight to the quad, things get a bit unstable. You would usually increase the PID's to make up for this, however a normal toothpick frame cannot handle this.
If you brace the arms, or the frame has a design that incorporates a trussed arm system, you can push the gains much higher and get a far better flying craft
This tune is made to specifically push the pids beyond the boundary of what most "standard" arm toothpick class quads would normally handle.


I will update the discussion tag to have this pr# once it is created