### PR TITLE
Create mouseFPV preset for FPVCycle Sonicare

### DIFF
--- a/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -1,0 +1,206 @@
+#$ TITLE:  FPVCycle Sonicare 6s Tune | mouseFPV 
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for FPVCycle Sonicare
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * This was tuned on a very light quad. If you are over 670g maybe try the Heavy Action Cam Option. YMMV.
+#$ DESCRIPTION: * 20mm and 25mm Stacks (as supported by this frame) may have inadequate capacitance. 1000uf 35v Cap on ESC leads *and* 200-470uf 35v on FC Vbatt rail recommended. 
+#$ DESCRIPTION: * Recommended 48k PWM.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). Enables gyro LPF 2.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"
+#$ DESCRIPTION: * **93% Motor Limit:** Simulates 1800-1900kv motors down closer to 1700kv
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **Heavy Action Camera:** Increases the Pids/Master Slider
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created on:
+#$ DESCRIPTION: * **Frame:** FPVCycle Sonicare
+#$ DESCRIPTION: * **Motors:** iFlight Xing2 2306 1755kv (6s)
+#$ DESCRIPTION: * **FC:** DarwinFPV Whoop Mount (MPU6000)
+#$ DESCRIPTION: * **ESC:** DarwinFPV Whoop Mount 45a
+#$ DESCRIPTION: * **Action Cam:** GoPro Hero 5 Session
+#$ DESCRIPTION: * **AUW:** 620-640g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION:
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/275
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 120
+set simplified_pi_gain = 100    
+set simplified_feedforward_gain = 60
+set simplified_dmax_gain = 000
+set simplified_i_gain = 090
+set simplified_pitch_d_gain = 105
+set simplified_pitch_pi_gain = 115
+set simplified_master_multiplier = 135
+simplified_tuning apply
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Thrust linear  --
+set thrust_linear = 20
+
+# -- DShot Idle --
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 3
+set dyn_notch_q = 375
+set dyn_notch_min_hz = 150
+set dyn_notch_max_hz = 600
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 14
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set gyro_lpf2_static_hz = 0
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 150
+        set rpm_filter_fade_range_hz = 75
+
+        # -- Dterm sliders --
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT300
+        set dshot_bidir = ON
+        set motor_poles = 14
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = ON
+        set simplified_gyro_filter_multiplier = 200
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 150
+        set rpm_filter_fade_range_hz = 75
+
+        # -- Dterm sliders --
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 20
+        set dyn_idle_p_gain = 45
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): 93% Motor Limit (Use this if its too spicy)
+        set motor_output_limit = 93
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Heavy Action Cam (Hero8/9/10)
+            set simplified_master_multiplier = 150
+            simplified_tuning apply
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+


### PR DESCRIPTION
The FPVCycle Sonicare is a new frame from FPVCycle. This frame has a unique wishbone arm design that uses 8 individual arm members to build the 4 arms. This quad has amazing resonance performance and very little low freq noise, meaning we can push the pids pretty far and reduce filtering significantly.

This tune loads the default tune and filters, then applies a non-rpm filtering setup as well as proper pids. There are options for ds300/600 RPM filtering setups that re-load the default filters, apply the proper dshot and filter settings. dshot300 assumes a 4k pidloop will be needed, and thus adds in an lpf2 on the gyro.

There is a dynamic idle option that does not enable dshot, so if things are not properly setup, it will set the value but it wont actually do anything.


