### PR TITLE
Freedom Spec tune: fix anti gravity gain to 2000

### DIFF
--- a/presets/4.3/tune/freedom_spec_460g.txt
+++ b/presets/4.3/tune/freedom_spec_460g.txt
@@ -79,6 +79,9 @@ set feedforward_max_rate_limit = 100
 # -- Dyn Idle --
 set dyn_idle_min_rpm = 30
 
+# -- Antigravity --
+set anti_gravity_gain = 2000
+
 #$ OPTION BEGIN (UNCHECKED): Noisy frames
     set dyn_notch_count = 3
     set dyn_notch_min_hz = 100


### PR DESCRIPTION
Small fix,
default 3500 for AG gain is just way too high for 4.3 causing problems on fast throttle moves.
Making it 2000