### PR TITLE
Added Foxeer Reaper Extreme VTX table

### DIFF
--- a/presets/4.3/vtx/Foxeer_Reaper_Extreme.txt
+++ b/presets/4.3/vtx/Foxeer_Reaper_Extreme.txt
@@ -1,0 +1,34 @@
+#$ TITLE: Foxeer 5.8G Reaper Extreme 2.5W
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: vtx, vtx table, IRC, tramp, HV, nano, Foxeer, Extreme, 2.5W, 2500mW
+#$ AUTHOR: Foxeer Harvey
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: VTX table for Foxeer 5.8G Reaper Extreme 2.5W
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://www.foxeer.com/foxeer-5-8g-reaper-extreme-2-5w-40ch-vtx-g-444"><img src="https://user-images.githubusercontent.com/2925027/187288242-62f1dc0b-799b-4807-9ef4-4ce6fd50ec8f.png" width="450px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Note this table is as provided by the manufacturer.
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
+#$ DESCRIPTION: ----------
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+#$ DISCUSSION:  https://github.com/betaflight/firmware-presets/pull/280
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+# vtxtable
+vtxtable bands 5
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable powerlevels 5
+vtxtable powervalues 25 200 500 1500 2500
+vtxtable powerlabels 25 200 500 1.5 2.5

--- a/presets/4.3/vtx/Unify_Pro_HV_800mw_Unify_Pro_V3_SA_2_0.txt
+++ b/presets/4.3/vtx/Unify_Pro_HV_800mw_Unify_Pro_V3_SA_2_0.txt
@@ -5,7 +5,7 @@
 #$ STATUS: COMMUNITY
 #$ KEYWORDS:  vtx, vtx table, tbs, unify pro, HV, SA 2.0
 #$ AUTHOR: sugarK
-#$ DESCRIPTION: VTX table for both the TBS Unify Pro HV 800mw and TBS Unify Pro V3 (5v) SA 2.0. Note this table is as provided by the manufacture.
+#$ DESCRIPTION: VTX table for both the TBS Unify Pro HV 800mw and TBS Unify Pro V3 (5v) SA 2.0. Note this table is as provided by the manufacturer.
 #$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations. 
 #$ DESCRIPTION: ----------
 #$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.


### PR DESCRIPTION
VTX link:
https://www.foxeer.com/foxeer-5-8g-reaper-extreme-2-5w-40ch-vtx-g-444

The manufacturer didn't provide regulatory domains, so there we go, as is.