### PR TITLE
Foxeer Extreme VTX table fix: powerlevels to patch VTX firmware issue

### DIFF
--- a/presets/4.3/vtx/Foxeer_Reaper_Extreme.txt
+++ b/presets/4.3/vtx/Foxeer_Reaper_Extreme.txt
@@ -12,7 +12,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: <a href="https://www.foxeer.com/foxeer-5-8g-reaper-extreme-2-5w-40ch-vtx-g-444"><img src="https://user-images.githubusercontent.com/2925027/187288242-62f1dc0b-799b-4807-9ef4-4ce6fd50ec8f.png" width="450px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
 #$ DESCRIPTION:
-#$ DESCRIPTION: Note this table is as provided by the manufacturer.
+#$ DESCRIPTION: Powerlevels in this preset don't match with the powerlabels. This is expected for this VTX due to the peculiarity of it's firmware. As assured by the manufacturer, this VTX table will give the correct actual output power, and it will match with the powerlabels.
+#$ DESCRIPTION: Note this table is as provided by the manufacturer. End user is in charge of following his local region regulations.
 #$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
 #$ DESCRIPTION: ----------
 #$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
@@ -30,5 +31,5 @@ vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
 vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
 vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
 vtxtable powerlevels 5
-vtxtable powervalues 25 200 500 1500 2500
+vtxtable powervalues 25 100 200 400 600
 vtxtable powerlabels 25 200 500 1.5 2.5


### PR DESCRIPTION
Harvey from Foxeer verified the output levels with an actual VTX and confirmed with the VTX developers that the powerlevels should be as follows due to the "peculiarity" of the VTX firmware implementation:
![image](https://user-images.githubusercontent.com/2925027/188783099-24cba847-9e21-4aac-9a68-446e683557bd.png)

Original PR:
https://github.com/betaflight/firmware-presets/pull/280
