### PR TITLE
Update Llama Freedom (TUNE-Other) Preset: Remove VBat_Sag_Compensation from 3S Tune, Added KV Options

### DIFF
--- a/presets/4.3/other/Tehllama_5in_1900-2250KV_FreedomSpec_3S-5S-6S_Race_TUNE_OTHER.txt
+++ b/presets/4.3/other/Tehllama_5in_1900-2250KV_FreedomSpec_3S-5S-6S_Race_TUNE_OTHER.txt
@@ -122,6 +122,7 @@ set d_max_advance = 0
 set auto_profile_cell_count = 3
 set feedforward_boost = 18
 set throttle_boost = 12
+set vbat_sag_compensation = 0
 
 set simplified_master_multiplier = 135
 set simplified_i_gain = 85
@@ -217,17 +218,16 @@ set dyn_idle_i_gain = 42
 set dyn_idle_d_gain = 42
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation = 77 for ALL Profiles
+#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation = 77 for OPEN  Profiles
 profile 0
 set vbat_sag_compensation = 77
 profile 1
 set vbat_sag_compensation = 77
-profile 2
-set vbat_sag_compensation = 77
+
 
 #$ OPTION END
 
-#$ OPTION BEGIN (CHECKED): Apply TPA Settings to all rateprofiles
+#$ OPTION BEGIN (CHECKED): Apply TPA Settings to all rateprofiles (Selects Rateprofile #1)
 rateprofile 0
 set tpa_rate = 72
 set tpa_breakpoint = 1250
@@ -260,6 +260,10 @@ set tpa_rate = 72
 set tpa_breakpoint = 1250
 #$ OPTION END
 
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Motor Output Limiting using TexasSpec Calculator
+
 #$ OPTION BEGIN (UNCHECKED):  2000KV Motor Output Limit on 3S
 profile 2
 set motor_output_limit = 97
@@ -270,6 +274,11 @@ profile 2
 set motor_output_limit = 95
 #$ OPTION END
 
+#$ OPTION BEGIN (UNCHECKED):  2070KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 94
+#$ OPTION END
+
 #$ OPTION BEGIN (UNCHECKED):  2100KV Motor Output Limit on 3S
 profile 2
 set motor_output_limit = 93
@@ -278,6 +287,11 @@ set motor_output_limit = 93
 #$ OPTION BEGIN (UNCHECKED):  2150KV Motor Output Limit on 3S
 profile 2
 set motor_output_limit = 92
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED):  2222KV Motor Output Limit on 3S
+profile 2
+set motor_output_limit = 91
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED):  2250KV Motor Output Limit on 3S


### PR DESCRIPTION
Minor housekeeping change on the Llama Freedom preset.

I realized I retained vbat_sag_compensation on the 3S tune... which explains why I was consistently launching first, hardest, and showing up to the first gate last.   I are dumb.

Added a few KV options for the TexasSpec limiting, for the Championship motors and various XNova/BH 2222KV offerings

Arranged a couple more options to prepare this preset for BF4.4 down the road.
