### PR TITLE
Renaming default_.... presets that are not really defaults to basic_...

### DIFF
--- a/presets/4.3/filters/basic_no_rpm_clean.txt
+++ b/presets/4.3/filters/basic_no_rpm_clean.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: filter, filters, filtering, clean, no rpm, basic, default, betaflight
+#$ KEYWORDS: filter, filters, filtering, clean, no rpm, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.  
 #$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.  

--- a/presets/4.3/filters/basic_no_rpm_noisy.txt
+++ b/presets/4.3/filters/basic_no_rpm_noisy.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: filter, filters, filtering, noisy, no rpm, basic, default, betaflight
+#$ KEYWORDS: filter, filters, filtering, noisy, no rpm, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.
 #$ DESCRIPTION: If motors get hot, try a filter set for very noisy motors, or try lowering the D filter slider.

--- a/presets/4.3/filters/basic_no_rpm_normal.txt
+++ b/presets/4.3/filters/basic_no_rpm_normal.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: filter, filters, filtering, normal, no rpm, basic, default, betaflight
+#$ KEYWORDS: filter, filters, filtering, normal, no rpm, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Intended for a well maintained build in good condition.
 #$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors, or try lowering the D filter slider.

--- a/presets/4.3/filters/basic_no_rpm_very_clean.txt
+++ b/presets/4.3/filters/basic_no_rpm_very_clean.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: no rpm, filter, filters, filtering, very clean, very, clean, basic, default, betaflight
+#$ KEYWORDS: no rpm, filter, filters, filtering, very clean, very, clean, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!
 #$ DESCRIPTION: Intended only for rock hard frames, motors with good bearings and true shafts, and perfectly balanced props.

--- a/presets/4.3/filters/basic_no_rpm_very_noisy.txt
+++ b/presets/4.3/filters/basic_no_rpm_very_noisy.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: filter, filters, very noisy, very, noisy, no rpm, basic, default, betaflight
+#$ KEYWORDS: filter, filters, very noisy, very, noisy, no rpm, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Intended for slightly beaten up, or larger (10" and above), builds.
 #$ DESCRIPTION: If motors get hot, they may simply be being asked to do too much.

--- a/presets/4.3/filters/basic_rpm_clean.txt
+++ b/presets/4.3/filters/basic_rpm_clean.txt
@@ -2,11 +2,11 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: rpm, DShot telemetry, filter, filters, clean, basic, default, betaflight
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, clean, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Required RPM filtering.  Ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: WARNING: May cause motor overheating!
-#$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.  
+#$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.
 #$ DESCRIPTION: If motors get hot, try a filter set for normal or noisy motors.
 #$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
 

--- a/presets/4.3/filters/basic_rpm_noisy.txt
+++ b/presets/4.3/filters/basic_rpm_noisy.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: rpm, DShot telemetry, filter, filters, noisy, basic, default, betaflight
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, noisy, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.

--- a/presets/4.3/filters/basic_rpm_normal.txt
+++ b/presets/4.3/filters/basic_rpm_normal.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: rpm, DShot telemetry, filter, filters, normal, basic, default, betaflight
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, normal, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Intended for a well maintained build in good condition with RPM filtering.
 #$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!

--- a/presets/4.3/filters/basic_rpm_very_clean.txt
+++ b/presets/4.3/filters/basic_rpm_very_clean.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: rpm, filter, filters, filtering, very clean, very, clean, basic, default, betaflight
+#$ KEYWORDS: rpm, filter, filters, filtering, very clean, very, clean, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!

--- a/presets/4.3/filters/basic_rpm_very_noisy.txt
+++ b/presets/4.3/filters/basic_rpm_very_noisy.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: rpm, filter, filters, filtering, very, noisy, very noisy, hot, basic, default, betaflight
+#$ KEYWORDS: rpm, filter, filters, filtering, very, noisy, very noisy, hot, basic, betaflight
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: WARNING: Requires RPM filtering - ensure that DShot Telemetry is working properly!
 #$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.
@@ -21,7 +21,7 @@ set gyro_lpf1_dyn_min_hz = 0
 set gyro_lpf1_dyn_max_hz = 250
 set gyro_lpf1_static_hz = 0
 set gyro_lpf2_static_hz = 125
- 
+
 # -- Gyro Sliders (on by default) --
 # only lpf2 is active
 set simplified_gyro_filter_multiplier = 25

--- a/presets/4.3/other/Tehllama_GTB339_3in_SWPR-Spec_2S-3S_Race_TUNE_OTHER.txt
+++ b/presets/4.3/other/Tehllama_GTB339_3in_SWPR-Spec_2S-3S_Race_TUNE_OTHER.txt
@@ -108,7 +108,7 @@ simplified_tuning apply
 #$ OPTION_GROUP BEGIN: Filters and RPM Features
 
 #$ OPTION BEGIN (UNCHECKED): Apply Default non-RPM Filters
-#$ INCLUDE: presets/4.3/filters/default_no_rpm_clean.txt
+#$ INCLUDE: presets/4.3/filters/basic_no_rpm_clean.txt
 #$ OPTION END
 
 #$ OPTION BEGIN (CHECKED): Apply Matching RPM Filters (Strongly Recommended)

--- a/presets/4.3/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.3/tune/ctzsnooze_5in_4S_race.txt
@@ -92,11 +92,11 @@ set dyn_idle_p_gain = 40
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): RPM enabled, noisy build
-#$ INCLUDE: presets/4.3/filters/default_rpm_noisy.txt
+#$ INCLUDE: presets/4.3/filters/basic_rpm_noisy.txt
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): NON-RPM ESCs, normal build
-#$ INCLUDE: presets/4.3/filters/default_no_rpm_normal.txt
+#$ INCLUDE: presets/4.3/filters/basic_no_rpm_normal.txt
 #$ OPTION END
 
 #$ OPTION_GROUP END

--- a/presets/4.3/tune/defaults.txt
+++ b/presets/4.3/tune/defaults.txt
@@ -1,4 +1,4 @@
-#$ TITLE:  Tune defaults for Basic 4.3 TUNES
+#$ TITLE:  TUNE defaults
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
 #$ STATUS: OFFICIAL

--- a/presets/4.3/tune/reset_all.txt
+++ b/presets/4.3/tune/reset_all.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: defaults, reset, tune, pid, expert, default
+#$ KEYWORDS: reset, tune, pid, expert
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Checked tune related parameters will be reset to defaults.
 #$ DESCRIPTION: Un-check the parameters you want to keep at current values.

--- a/presets/4.3/tune/reset_some.txt
+++ b/presets/4.3/tune/reset_some.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: defaults, reset, tune, default, some, partial
+#$ KEYWORDS: reset, tune, some, partial
 #$ AUTHOR: Betaflight
 #$ DESCRIPTION: Check the tune parameters that you want to reset to defaults.
 #$ DESCRIPTION: Un-checked parameters will remain at current values.

--- a/presets/4.3/tune/whoop_justice.txt
+++ b/presets/4.3/tune/whoop_justice.txt
@@ -106,17 +106,17 @@ set dshot_idle_value = 600
 # Filter options
 
 #$ OPTION BEGIN (UNCHECKED): FILTER: RPM enabled, normal build
-#$ INCLUDE: presets/4.3/filters/default_rpm_normal.txt
+#$ INCLUDE: presets/4.3/filters/basic_rpm_normal.txt
 set dyn_idle_min_rpm = 50
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): FILTER: RPM enabled, noisy build
-#$ INCLUDE: presets/4.3/filters/default_rpm_noisy.txt
+#$ INCLUDE: presets/4.3/filters/basic_rpm_noisy.txt
 set dyn_idle_min_rpm = 50
 #$ OPTION END
 
 #$ OPTION BEGIN (UNCHECKED): FILTER: NON-RPM ESCs, normal build
-#$ INCLUDE: presets/4.3/filters/default_no_rpm_normal.txt
+#$ INCLUDE: presets/4.3/filters/basic_no_rpm_normal.txt
 #$ OPTION END
 
 #$ OPTION_GROUP END


### PR DESCRIPTION
This change is nothing but removing a few "default" keywords from presets that are not defaults, and renaming some presets from defaults, that do not really default.

At this point i was asked a few times: how i can go back to defaults filters/tunes. They search for defaults and stumbled on 10 different filter/tune presets that are not really defaults.

Sometimes it might be misleading when people search for "defaults" and they are being shown presets that are not really defaults.
So i think when someone looks for "defaults" we should only show real defaults.
If someone looking for generic tunes, he can search for "basic" or something like that.