### PR TITLE
add 4.4 preset for HDZERO vtxs including MSP VTX setup 

### DIFF
--- a/presets/4.4/vtx/HDZero.txt
+++ b/presets/4.4/vtx/HDZero.txt
@@ -1,0 +1,123 @@
+#$ TITLE: HDZero VTXs
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, HDzero, divimath, SA 2.1, digital, whoop, whoop lite, race v1, race v2, freestyle, tx5m.1, MSP VTX
+#$ AUTHOR: sugarK
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <img src="https://static.wixstatic.com/media/967e02_82348b3d176249aea0926d07a2de0257~mv2_d_5559_3125_s_4_2.png" width="300px" height="90" style="object-fit: cover; margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION: 
+#$ DESCRIPTION: # VTX tables and Canvas mode setup
+#$ DESCRIPTION: ## for all HDzero digital systems plus the new MSP VTX setup 
+#$ DESCRIPTION: Information about MSP VTX can be found here [MSP VTX](https://github.com/betaflight/betaflight/pull/11705)
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
+#$ DESCRIPTION: <br><br>
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/297
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+
+# vtxtable
+vtxtable bands 6
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY    0    0    0    0    0    0    0    0
+vtxtable band 2 BOSCAM_B B FACTORY    0    0    0    0    0    0    0    0
+vtxtable band 3 BOSCAM_E E FACTORY    0    0    0    0    0    0    0    0
+vtxtable band 4 FATSHARK F FACTORY    0 5760    0 5800    0    0    0    0
+vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 IMD6     I CUSTOM     0    0    0    0    0    0    0    0
+
+#$ OPTION BEGIN (UNCHECKED): all VTXs except unlocked Freestyle and TX5M.1
+vtxtable powerlevels 3
+vtxtable powervalues 14 23 0
+vtxtable powerlabels 25 200 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): unlocked Freestyle
+vtxtable powerlevels 5
+vtxtable powervalues 14 23 27 30 0
+vtxtable powerlabels 25 200 500 MAX 0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): TX5M.1
+vtxtable powerlevels 4
+vtxtable powervalues 14 23 27 0
+vtxtable powerlabels 25 200 500 0
+#$ OPTION END
+
+
+#$ OPTION_GROUP BEGIN: use displayport and MSP VTX on uart 1
+#$ OPTION BEGIN (UNCHECKED): use displayport only on uart 1 
+serial 0 1 115200 57600 0 115200
+set displayport_msp_serial = 0
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): use displayport and MSP VTX on uart 1 
+serial 0 131073 115200 57600 0 115200
+set displayport_msp_serial = 0
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: use displayport and MSP VTX on uart 2
+#$ OPTION BEGIN (UNCHECKED): use displayport only on uart 2
+serial 1 1 115200 57600 0 115200
+set displayport_msp_serial = 1
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): use displayport and MSP VTX on uart 2 
+serial 1 131073 115200 57600 0 115200
+set displayport_msp_serial = 1
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: use displayport and MSP VTX on uart 3
+#$ OPTION BEGIN (UNCHECKED): use displayport only on uart 3
+serial 2 1 115200 57600 0 115200
+set displayport_msp_serial = 2
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): use displayport and MSP VTX on uart 3 
+serial 2 131073 115200 57600 0 115200
+set displayport_msp_serial = 2
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: use displayport and MSP VTX on uart 4
+#$ OPTION BEGIN (UNCHECKED): use displayport only on uart 4
+serial 3 1 115200 57600 0 115200
+set displayport_msp_serial = 3
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): use displayport and MSP VTX on uart 4
+serial 3 131073 115200 57600 0 115200
+set displayport_msp_serial = 3
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: use displayport and MSP VTX on uart 5
+#$ OPTION BEGIN (UNCHECKED): use displayport only on uart 5
+serial 4 1 115200 57600 0 115200
+set displayport_msp_serial = 4
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): use displayport and MSP VTX on uart 5 
+serial 4 131073 115200 57600 0 115200
+set displayport_msp_serial = 4
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: use displayport and MSP VTX on uart 6
+#$ OPTION BEGIN (UNCHECKED): use displayport only on uart 6
+serial 5 1 115200 57600 0 115200
+set displayport_msp_serial = 5
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): use displayport and MSP VTX on uart 6 
+serial 5 131073 115200 57600 0 115200
+set displayport_msp_serial = 5
+#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION BEGIN (CHECKED): map to displayport 
+set osd_displayport_device = MSP
+#$ OPTION END


### PR DESCRIPTION
added a 4.4 preset for the range of HDZERO vtxs that includes the ability to setup up the MSP VTX serial settings from the preset...  


more information about the MSP VTX settings and use in this PR https://github.com/betaflight/betaflight/pull/11705

