### PR TITLE
Create Tehllama Llama 5in Race (Betaflight 4.4) Preset [Unified Multivoltage 3/4/5/6-S Tune for 1600-2750KV]

### DIFF
--- a/presets/4.4/other/Tehllama_5in_Race_Multivoltage.txt
+++ b/presets/4.4/other/Tehllama_5in_Race_Multivoltage.txt
@@ -1,0 +1,694 @@
+#$ TITLE: Tehllama 5" Race Multivoltage
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 533, Freedom, FreedomSpec, Tune, Spec, Race, Llama, MultiVoltage, Texas, BMS, 3S, 5in, AutoSelect, MM, Omni
+#$ AUTHOR: Daniel Appel / Tehllama
+#$ DESCRIPTION: This is a multi-voltage tune built for 5in Race Builds in the 400-575g AUW range. 
+#$ DESCRIPTION: Use the Options to select KV - 1600-2750KV are supported for the entire 3S-6S voltage range
+#$ DESCRIPTION: ALL FOUR Tune Profiles are used, with tunes Auto-Selected for 6S, 5S, 4S, and 3S (respectively) 
+#$ DESCRIPTION:
+#$ DESCRIPTION: Select the Motor KV Range from the Drop-Down Menu that most closely matches your craft
+#$ DESCRIPTION: Default is for ~1950KV motors, for example Freedom Spec 2207 1960KV 533/XNOVA Motors
+#$ DESCRIPTION: Special Thanks to Stephen 'Supafly' Wright for Master Slider Calculator assistance
+#$ DESCRIPTION: 
+#$ DESCRIPTION: This tune works best with bidirectional DShot enabled, running RPM and Dynamic Idle Features
+#$ DESCRIPTION: This tune expects ESCs configured to 48kHz PWM Frequency, 23°-27°/MedHigh timing and 0.38 Rampup
+#$ DESCRIPTION: Using more aggressive ESC settings is NOT advised if using higher cell count batteries
+#$ DESCRIPTION: 
+#$ DESCRIPTION: This tune will auto-select profiles based on battery voltage at plugin.
+#$ DESCRIPTION: When 3S packs are plugged in, this will auto-select an aggressive spec racing tune on Profile 3
+#$ DESCRIPTION: At higher motor KV, MotorOutput Limiting is used to scale these to Freedom Spec RPM 
+#$ DESCRIPTION: 3S batteries on craft with <1950KV motors experience very reduced performance
+#$ DESCRIPTION: 
+#$ DESCRIPTION: 6S, 5S, and 4S will run conservative open race tunes 
+#$ DESCRIPTION: Small motor output limits are applied for EXTREME Battery-KV combinations
+#$ DESCRIPTION: Combinations that spin 5" propellers in transonic regimes (i.e. 6S >2200KV and 5S >2650KV)
+#$ DESCRIPTION: 
+#$ DESCRIPTION: !!! Strongly recommend a full chip erase reflash if alternative tunes are desired after installing this preset!!!
+#$ DESCRIPTION: Extensive testing has been done across 83+ builds, however not every craft will run best on this tune.
+#$ WARNING: Use at your own risk.  Verify Correct ESC Settings are used.  
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/301
+
+## Filters - Choose RPM Enabled (Spicy or Non-Spicy) or non-RPM (Super-Safe)
+## Filters - by Profile x4 (Enables 6S, 5S, 4S, and 3S Spec Tune)
+## Tune - TPA, iTerm, dMin, boost, & AutoCellSelect Parameters
+## Tune - PI, D, I, Dmax, pitch PI/D, FF Offsets
+## KV Selection - Set MM Slider for ALL profiles
+## KV Selection - Set Motor Output Limits where applicable by profile
+## Feature Selection - VBatSagComp, MaxCellVoltage
+
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ OPTION_GROUP BEGIN: Filters
+    #$ OPTION BEGIN (CHECKED): Apply RPM Enabled SAFE Filters to ALL profiles (Requires Bidirectional DShot)
+		profile 0
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set dterm_lpf1_dyn_min_hz = 101
+			set dterm_lpf1_dyn_max_hz = 266
+			set dterm_lpf1_dyn_expo = 10
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 202
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 135
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		profile 1
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set dterm_lpf1_dyn_min_hz = 101
+			set dterm_lpf1_dyn_max_hz = 255
+			set dterm_lpf1_dyn_expo = 9
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 202
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 135
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		profile 2
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set dterm_lpf1_dyn_min_hz = 101
+			set dterm_lpf1_dyn_max_hz = 244
+			set dterm_lpf1_dyn_expo = 8
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 202
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 135
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		profile 3
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set dterm_lpf1_dyn_min_hz = 101
+			set dterm_lpf1_dyn_max_hz = 233
+			set dterm_lpf1_dyn_expo = 5
+			set dterm_lpf1_static_hz = 202
+			set dterm_lpf2_static_hz = 
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 135
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		# Filter Master
+			set dyn_notch_count = 3
+			set dyn_notch_q = 333
+			set dyn_notch_min_hz = 98
+			set dyn_notch_max_hz = 674
+			set simplified_gyro_filter_multiplier = 135
+			simplified_tuning apply
+		# RPM Filtering Enable
+			set dshot_bidir = ON
+			set rpm_filter_harmonics = 3
+			set rpm_filter_q = 600
+			set rpm_filter_min_hz = 111
+			set rpm_filter_fade_range_hz = 50
+	#$ OPTION END
+
+	#$ OPTION BEGIN (UNCHECKED): Apply RPM Enabled SPICY Filters to ALL profiles (Requires Bidirectional DShot)
+		profile 0
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 145
+			set dterm_lpf1_dyn_min_hz = 111
+			set dterm_lpf1_dyn_max_hz = 288
+			set dterm_lpf1_dyn_expo = 10
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 222
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		profile 1
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 145
+			set dterm_lpf1_dyn_min_hz = 111
+			set dterm_lpf1_dyn_max_hz = 266
+			set dterm_lpf1_dyn_expo = 9
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 195
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		profile 2
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 145
+			set dterm_lpf1_dyn_min_hz = 111
+			set dterm_lpf1_dyn_max_hz = 266
+			set dterm_lpf1_dyn_expo = 8
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 222
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		profile 3
+			#$ INCLUDE: presets/4.3/filters/defaults.txt
+			set yaw_lowpass_hz = 111
+			set simplified_dterm_filter_multiplier = 145
+			set dterm_lpf1_dyn_min_hz = 111
+			set dterm_lpf1_dyn_max_hz = 288
+			set dterm_lpf1_dyn_expo = 5
+			set dterm_lpf1_static_hz = 0
+			set dterm_lpf2_static_hz = 222
+			set simplified_dterm_filter = OFF
+			simplified_tuning apply
+		# Filter Master
+			set dyn_notch_count = 2
+			set dyn_notch_q = 444
+			set dyn_notch_min_hz = 98
+			set dyn_notch_max_hz = 674
+			set simplified_gyro_filter_multiplier = 145
+			simplified_tuning apply
+		# RPM Filter Enabled
+			set dshot_bidir = ON
+			set rpm_filter_harmonics = 2
+			set rpm_filter_q = 750
+			set rpm_filter_min_hz = 133
+			set rpm_filter_fade_range_hz = 111
+	#$ OPTION END
+
+	#$ OPTION BEGIN (UNCHECKED): Use Non-RPM Filters on All Profiles (Not Recommended)
+		profile 0
+			#$ INCLUDE: presets/4.3/filters/basic_no_rpm_clean.txt
+			set yaw_lowpass_hz = 99
+		profile 1
+			#$ INCLUDE: presets/4.3/filters/basic_no_rpm_clean.txt
+			set yaw_lowpass_hz = 99
+		profile 2
+			#$ INCLUDE: presets/4.3/filters/basic_no_rpm_clean.txt
+			set yaw_lowpass_hz = 99
+		profile 3
+			#$ INCLUDE: presets/4.3/filters/basic_no_rpm_clean.txt
+			set yaw_lowpass_hz = 99
+		# Filter Master
+			set dyn_notch_min_hz = 77
+			set simplified_gyro_filter_multiplier = 90
+			simplified_tuning apply
+	#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Tune
+	#$ OPTION BEGIN (CHECKED): Llama Freedom Tune (Safer)
+		profile 0
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 4
+			set d_max_advance = 0
+			set auto_profile_cell_count = 6
+			set feedforward_boost = 8
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 65
+			set simplified_i_gain = 85
+			set simplified_pi_gain = 125
+			set simplified_dmax_gain = 85
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 72
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+		profile 1
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 7
+			set d_max_advance = 0
+			set auto_profile_cell_count = 5
+			set feedforward_boost = 12
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 80
+			set simplified_i_gain = 85
+			set simplified_pi_gain = 125
+			set simplified_dmax_gain = 85
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 72
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+		profile 2
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 9
+			set d_max_advance = 0
+			set auto_profile_cell_count = 4
+			set feedforward_boost = 15
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 100
+			set simplified_i_gain = 85
+			set simplified_d_gain = 105
+			set simplified_pi_gain = 125
+			set simplified_dmax_gain = 85
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 72
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+		profile 3
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 12
+			set d_max_advance = 0
+			set auto_profile_cell_count = 3
+			set feedforward_boost = 18
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 135
+			set simplified_i_gain = 85
+			set simplified_d_gain = 110
+			set simplified_pi_gain = 125
+			set simplified_dmax_gain = 85
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 72
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+	#$ OPTION END
+
+	#$ OPTION BEGIN (UNCHECKED): Llama Spicy Tune (Aggressive)
+		profile 0
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 4
+			set d_max_advance = 0
+			set auto_profile_cell_count = 6
+			set feedforward_boost = 8
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 65
+			set simplified_i_gain = 90
+			set simplified_pi_gain = 135
+			set simplified_d_gain = 110
+			set simplified_dmax_gain = 80
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 75
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+		profile 1
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 7
+			set d_max_advance = 0
+			set auto_profile_cell_count = 5
+			set feedforward_boost = 12
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 80
+			set simplified_i_gain = 90
+			set simplified_pi_gain = 135
+			set simplified_d_gain = 110
+			set simplified_dmax_gain = 80
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 75
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+		profile 2
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 9
+			set d_max_advance = 0
+			set auto_profile_cell_count = 4
+			set feedforward_boost = 15
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 100
+			set simplified_i_gain = 90
+			set simplified_d_gain = 115
+			set simplified_pi_gain = 135
+			set simplified_dmax_gain = 80
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 75
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+		profile 3
+			#$ INCLUDE: presets/4.4/tune/defaults.txt
+			set anti_gravity_gain = 44
+			set iterm_rotation = ON
+			set iterm_relax = RPY
+			set iterm_relax_cutoff = 33
+			set throttle_boost = 12
+			set d_max_advance = 0
+			set auto_profile_cell_count = 3
+			set feedforward_boost = 18
+			# Overwrite Master_Multiplier in Motor KV Selection Tab
+			set simplified_master_multiplier = 135
+			set simplified_i_gain = 90
+			set simplified_d_gain = 125
+			set simplified_pi_gain = 140
+			set simplified_dmax_gain = 75
+			set simplified_feedforward_gain = 160
+			set simplified_pitch_d_gain = 105
+			set simplified_pitch_pi_gain = 105
+			set tpa_rate = 75
+			set tpa_breakpoint = 1250
+			simplified_tuning apply
+	#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Features
+	#$ OPTION BEGIN (CHECKED): Enable Dynamic Idle for ALL Profiles (Requires Bidirectional DShot)
+		profile 0
+			set dyn_idle_min_rpm = 22
+			set dyn_idle_p_gain = 42
+			set dyn_idle_i_gain = 42
+			set dyn_idle_d_gain = 42
+		profile 1
+			set dyn_idle_min_rpm = 22
+			set dyn_idle_p_gain = 42
+			set dyn_idle_i_gain = 42
+			set dyn_idle_d_gain = 42
+		profile 2
+			set dyn_idle_min_rpm = 22
+			set dyn_idle_p_gain = 42
+			set dyn_idle_i_gain = 42
+			set dyn_idle_d_gain = 42
+		profile 3
+			set dyn_idle_min_rpm = 22
+			set dyn_idle_p_gain = 42
+			set dyn_idle_i_gain = 42
+			set dyn_idle_d_gain = 42
+	#$ OPTION END
+	
+	#$ OPTION BEGIN (CHECKED): Set Max Cell Voltage to 4.38V
+		set vbat_max_cell_voltage = 438
+	#$ OPTION END
+	
+	#$ OPTION BEGIN (UNCHECKED): Set VBat Sag Compensation for 4/5/6S to 82
+		profile 0
+			set vbat_sag_compensation = 82
+		profile 1
+			set vbat_sag_compensation = 82
+		profile 2
+			set vbat_sag_compensation = 82
+	#$ OPTION END
+	
+	#$ OPTION BEGIN (CHECKED): Disable VBat Sag Compensation on 3S (Freedom Spec)
+		profile 3
+			set vbat_sag_compensation = 0
+	#$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Motor KV Selection (Defaults to ~1950KV)
+	#$ OPTION BEGIN (UNCHECKED): ~1600KV Motors
+		profile 0
+			set simplified_master_multiplier = 80
+		profile 1
+			set simplified_master_multiplier = 95
+		profile 2
+			set simplified_master_multiplier = 120
+		profile 3
+			set simplified_master_multiplier = 140
+			simplified_tuning apply
+	#$ OPTION END	
+	#$ OPTION BEGIN (UNCHECKED): ~1700KV Motors
+		profile 0
+			set simplified_master_multiplier = 75
+		profile 1
+			set simplified_master_multiplier = 95
+		profile 2
+			set simplified_master_multiplier = 120
+		profile 3
+			set simplified_master_multiplier = 140
+			simplified_tuning apply
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~1750KV Motors
+		profile 0
+			set simplified_master_multiplier = 75
+		profile 1
+			set simplified_master_multiplier = 90
+		profile 2
+			set simplified_master_multiplier = 110
+		profile 3
+			set simplified_master_multiplier = 140
+			simplified_tuning apply
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~1800KV Motor
+		profile 0
+			set simplified_master_multiplier = 70
+		profile 1
+			set simplified_master_multiplier = 85
+		profile 2
+			set simplified_master_multiplier = 110
+		profile 3
+			set simplified_master_multiplier = 140
+			simplified_tuning apply
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~1850KV Motors
+		profile 0
+			set simplified_master_multiplier = 70
+		profile 1
+			set simplified_master_multiplier = 85
+		profile 2
+			set simplified_master_multiplier = 105
+		profile 3
+			set simplified_master_multiplier = 140
+			simplified_tuning apply
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~1900KV Motors
+		profile 0
+			set simplified_master_multiplier = 65
+		profile 1
+			set simplified_master_multiplier = 80
+		profile 2
+			set simplified_master_multiplier = 100
+		profile 3
+			set simplified_master_multiplier = 140
+			simplified_tuning apply
+	#$ OPTION END
+	#$ OPTION BEGIN (CHECKED): ~1950KV Motors
+		profile 0
+			set simplified_master_multiplier = 65
+		profile 1
+			set simplified_master_multiplier = 80
+		profile 2
+			set simplified_master_multiplier = 100
+		profile 3
+			set simplified_master_multiplier = 135
+			simplified_tuning apply
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2000KV Motors
+		profile 0
+			set simplified_master_multiplier = 65
+		profile 1
+			set simplified_master_multiplier = 80
+		profile 2
+			set simplified_master_multiplier = 100
+		profile 3
+			set simplified_master_multiplier = 130
+			simplified_tuning apply
+			set motor_output_limit = 98
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2050KV Motors
+		profile 0
+			set simplified_master_multiplier = 60
+		profile 1
+			set simplified_master_multiplier = 75
+		profile 2
+			set simplified_master_multiplier = 95
+		profile 3
+		set simplified_master_multiplier = 130
+		simplified_tuning apply	
+		set motor_output_limit = 96
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2100KV Motors
+		profile 0
+			set simplified_master_multiplier = 60
+		profile 1
+			set simplified_master_multiplier = 75
+		profile 2
+			set simplified_master_multiplier = 95
+		profile 3
+			set simplified_master_multiplier = 125
+			simplified_tuning apply
+			set motor_output_limit = 94
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2150KV Motors
+		profile 0
+			set simplified_master_multiplier = 55
+		profile 1
+			set simplified_master_multiplier = 70
+		profile 2
+			set simplified_master_multiplier = 90
+		profile 3
+			set simplified_master_multiplier = 120
+			simplified_tuning apply
+			set motor_output_limit = 92
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2200KV Motors
+		profile 0
+			set simplified_master_multiplier = 55
+		profile 1
+			set simplified_master_multiplier = 70
+		profile 2
+			set simplified_master_multiplier = 90
+		profile 3
+			set simplified_master_multiplier = 120
+			simplified_tuning apply
+			set motor_output_limit = 90
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2250KV Motors
+		profile 0
+			set simplified_master_multiplier = 55
+			set motor_output_limit = 97
+		profile 1
+			set simplified_master_multiplier = 70
+		profile 2
+			set simplified_master_multiplier = 85
+		profile 3
+			set simplified_master_multiplier = 120
+			simplified_tuning apply
+			set motor_output_limit = 88
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2300KV Motors
+		profile 0
+			set simplified_master_multiplier = 55
+			set motor_output_limit = 94
+		profile 1
+			set simplified_master_multiplier = 70
+		profile 2
+			set simplified_master_multiplier = 85
+		profile 3
+			set simplified_master_multiplier = 115
+			simplified_tuning apply
+			set motor_output_limit = 86
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2350KV Motors
+		profile 0
+			set simplified_master_multiplier = 55
+			set motor_output_limit = 92
+		profile 1
+			set simplified_master_multiplier = 65
+		profile 2
+			set simplified_master_multiplier = 85
+		profile 3
+			set simplified_master_multiplier = 110
+			simplified_tuning apply
+			set motor_output_limit = 84
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2400KV Motors
+		profile 0
+			set simplified_master_multiplier = 50
+			set motor_output_limit = 90
+		profile 1
+			set simplified_master_multiplier = 65
+		profile 2
+			set simplified_master_multiplier = 80
+		profile 3
+			set simplified_master_multiplier = 110
+			simplified_tuning apply
+			set motor_output_limit = 82
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2450KV Motors
+		profile 0
+			set simplified_master_multiplier = 50
+			set motor_output_limit = 88
+		profile 1
+			set simplified_master_multiplier = 65
+		profile 2
+			set simplified_master_multiplier = 80
+		profile 3
+			set simplified_master_multiplier = 105
+			simplified_tuning apply
+			set motor_output_limit = 80
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2500KV Motors
+		rofile 0
+			set simplified_master_multiplier = 50
+			set motor_output_limit = 86
+		profile 1
+			set simplified_master_multiplier = 60
+		profile 2
+			set simplified_master_multiplier = 80
+		profile 3
+			set simplified_master_multiplier = 105
+			simplified_tuning apply
+			set motor_output_limit = 79
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2550KV Motors
+		profile 0
+			set simplified_master_multiplier = 50
+			set motor_output_limit = 85
+		profile 1
+			set simplified_master_multiplier = 60
+		profile 2
+			set simplified_master_multiplier = 75
+		profile 3
+			set simplified_master_multiplier = 105
+			simplified_tuning apply
+			set motor_output_limit = 77
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2600KV Motors
+		profile 0
+			set simplified_master_multiplier = 50
+			set motor_output_limit = 83
+		profile 1
+			set simplified_master_multiplier = 60
+		profile 2
+			set simplified_master_multiplier = 75
+		profile 3
+			set simplified_master_multiplier = 100
+			simplified_tuning apply
+			set motor_output_limit = 76
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2650KV Motors
+		profile 0
+			set simplified_master_multiplier = 45
+			set motor_output_limit = 81
+		profile 1
+			set simplified_master_multiplier = 60
+			set motor_output_limit = 98
+		profile 2
+			set simplified_master_multiplier = 75
+		profile 3
+			set simplified_master_multiplier = 100
+			simplified_tuning apply
+			set motor_output_limit = 74
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2700KV Motors
+		profile 0
+			set simplified_master_multiplier = 45
+			set motor_output_limit = 80
+		profile 1
+			set simplified_master_multiplier = 55
+			set motor_output_limit = 96
+		profile 2
+			set simplified_master_multiplier = 70
+		profile 3
+			set simplified_master_multiplier = 95
+			simplified_tuning apply
+			set motor_output_limit = 73
+	#$ OPTION END
+	#$ OPTION BEGIN (UNCHECKED): ~2750KV Motors
+		profile 0
+			set simplified_master_multiplier = 45
+			set motor_output_limit = 78
+		profile 1
+			set simplified_master_multiplier = 55
+			set motor_output_limit = 96
+		profile 2
+			set simplified_master_multiplier = 70
+		profile 3
+			set simplified_master_multiplier = 95
+			simplified_tuning apply
+			set motor_output_limit = 72
+	#$ OPTION END
+#$ OPTION_GROUP END
+	


### PR DESCRIPTION
Preset for Betaflight 4.4 (Tested using the 2022.10.14 Nightly)

Once user sets Motor KV, Filter Flavor (non-RPM, Safe, Spicy), Feature Selection...
 this will automatically set up an array of 3S, 4S, 5S, and 6S tunes based on motor KV with matching filters.
 Master Slider increments are locked to 0.05 increments, and end user adjustable after flashing preset

// Key Update Milestones
 - Will update on feature freeze date
 - Will update on all namespace changes related to Tune profiles or Filtering
 - Will update on Release Candidate 0
 - Will review on all release candidates

// Dependency Chains Identified [This is why the error checker will throw errors until these items are present in MASTER
/// See Pull Request #300 
 - * presets/4.4/tune/defaults.txt 
 !!! This file requires an update due to Antigravity Changes !!!
Existing file - can directly port into the 4.4 folder, and replace the Antigravity block with the following:
-- Antigravity (default) --
set anti_gravity_gain = 80
set anti_gravity_cutoff_hz = 5
set anti_gravity_p_gain = 100

#-- && Filter Defaults
/// See Pull Request #302 
 - Relies on an update to the following files:
 - * presets/4.4/filters/defaults.txt and presets/4.4/filters/basic_no_rpm_*****.txt
  (Existing - can directly port the 4.3 Default Filters - just add ', 4.4' to the VERSION text so node.js can parse it
// Can create additional pull requests to support these

This is a progression of the existing trio of Llama 5in Race Presets - Merged into a single preset, with Spicy/NonSpicy/nonRPM versions enabled for Filter and Tune

The really long list of Motor KV options provides Master Slider scaling for all four voltages, applies motor_output limiting to emulate Freedom_Spec with 3S packs at 2000KV and above, and also applies motor output limiting on 6S and 5S high KV setups which would exceed 48,000RPM at realistic voltages (transonic tip speeds that damage batteries and do not add thrust).

Optional Features section includes MaxCellVoltage options (For Freedom Spec, allows for 4.35V/cell charging without OSD errors)
Disables VBat_Sag_Compensation for FreedomSpec by default (this can be removed to keep this as a valid 'tune' preset, but this is an edge case.
Dynamic Idle is enabled by default, but still requires bidirectional DShot, as do the RPM Filter Enabled (Safe/Spicy) versions