### PR TITLE
BF4.4 Filter Presets :: Porting defaults, basic, and karate 4.3 tune presets to 4.4

### DIFF
--- a/presets/4.4/filters/basic_no_rpm_clean.txt
+++ b/presets/4.4/filters/basic_no_rpm_clean.txt
@@ -1,0 +1,46 @@
+#$ TITLE: 4.4 Filter settings for CLEAN build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, filtering, clean, no rpm, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.  
+#$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.  
+#$ DESCRIPTION: If motors get hot, try lowering the gyro or D filter sliders.   If motors remain hot despite strong filtering, it may not be a filtering problem.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_static_hz = 500
+set gyro_lpf2_static_hz = 500
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 100
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 350
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 67
+set dterm_lpf1_dyn_max_hz = 135
+set dterm_lpf1_static_hz = 135
+
+set dterm_lpf2_static_hz = 135
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 90
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_no_rpm_noisy.txt
+++ b/presets/4.4/filters/basic_no_rpm_noisy.txt
@@ -1,0 +1,45 @@
+#$ TITLE: 4.4 Filter settings for NOISY build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, filtering, noisy, no rpm, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.
+#$ DESCRIPTION: If motors get hot, try a filter set for very noisy motors, or try lowering the D filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 137
+set gyro_lpf1_dyn_max_hz = 275
+set gyro_lpf1_static_hz = 275
+set gyro_lpf2_static_hz = 275
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 55
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 5
+set dyn_notch_q = 325
+set dyn_notch_min_hz = 90
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 52
+set dterm_lpf1_dyn_max_hz = 105
+set dterm_lpf1_static_hz = 105
+
+set dterm_lpf2_static_hz = 105
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 70
+
+# -- Yaw lowpass --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_no_rpm_normal.txt
+++ b/presets/4.4/filters/basic_no_rpm_normal.txt
@@ -1,0 +1,45 @@
+#$ TITLE: 4.4 Filter settings for NORMAL build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, filtering, normal, no rpm, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for a well maintained build in good condition.
+#$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors, or try lowering the D filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 150
+set gyro_lpf1_dyn_max_hz = 300
+set gyro_lpf1_static_hz = 300
+set gyro_lpf2_static_hz = 300
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 60
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 5
+set dyn_notch_q = 350
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 60
+set dterm_lpf1_dyn_max_hz = 120
+set dterm_lpf1_static_hz = 120
+
+set dterm_lpf2_static_hz = 120
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 80
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_no_rpm_very_clean.txt
+++ b/presets/4.4/filters/basic_no_rpm_very_clean.txt
@@ -1,0 +1,47 @@
+#$ TITLE: 4.4 Filter settings for VERY CLEAN build WITHOUT RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: no rpm, filter, filters, filtering, very clean, very, clean, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!
+#$ DESCRIPTION: Intended only for rock hard frames, motors with good bearings and true shafts, and perfectly balanced props.
+#$ DESCRIPTION: If motors get hot, try a filter set for clean or normal motors, or try enabling gyro filter slider.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+# None
+set gyro_lpf1_dyn_min_hz = 400
+set gyro_lpf1_dyn_max_hz = 800
+set gyro_lpf1_static_hz = 800
+set gyro_lpf2_static_hz = 800
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 160
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 75
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_static_hz = 150
+
+set dterm_lpf2_static_hz = 150
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 100
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_no_rpm_very_noisy.txt
+++ b/presets/4.4/filters/basic_no_rpm_very_noisy.txt
@@ -1,0 +1,45 @@
+#$ TITLE: 4.4 Filter settings for VERY NOISY build WITH NO RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, very noisy, very, noisy, no rpm, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for slightly beaten up, or larger (10" and above), builds.
+#$ DESCRIPTION: If motors get hot, they may simply be being asked to do too much.
+#$ DESCRIPTION: May cause 5" or smaller quads to wobble due to lag.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# disable dshot rpm telemetry
+set dshot_bidir = OFF
+
+# -- Gyro filters --
+set gyro_lpf1_dyn_min_hz = 125
+set gyro_lpf1_dyn_max_hz = 250
+set gyro_lpf1_static_hz = 250
+set gyro_lpf2_static_hz = 250
+
+# -- Gyro Sliders --
+set simplified_gyro_filter_multiplier = 50
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 5
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 80
+
+# -- RPM filtering OFF --
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 45
+set dterm_lpf1_dyn_max_hz = 90
+set dterm_lpf1_static_hz = 90
+
+set dterm_lpf2_static_hz = 90
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 60
+
+# -- Yaw lowpass --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_rpm_clean.txt
+++ b/presets/4.4/filters/basic_rpm_clean.txt
@@ -1,0 +1,50 @@
+#$ TITLE: 4.4 Filter settings for CLEAN build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, clean, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Required RPM filtering.  Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: May cause motor overheating!
+#$ DESCRIPTION: Intended for solid frames, motors with good bearings and clean props.
+#$ DESCRIPTION: If motors get hot, try a filter set for normal or noisy motors.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 875Hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 875
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 875
+
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 175
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 300
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 650
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 78
+set dterm_lpf1_dyn_max_hz = 157
+set dterm_lpf1_static_hz = 157
+
+set dterm_lpf2_static_hz = 157
+
+# -- Dterm sliders 105 --
+set simplified_dterm_filter_multiplier = 105
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_rpm_noisy.txt
+++ b/presets/4.4/filters/basic_rpm_noisy.txt
@@ -1,0 +1,51 @@
+#$ TITLE: 4.4 Filter settings for NOISY build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, noisy, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: Intended for slightly beaten up, or larger (7" and above), builds.
+#$ DESCRIPTION: If motors get hot, try the filter Preset for very noisy motors.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 250hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 250
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 250
+ 
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 50
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 400
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 450
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 63
+set dterm_lpf1_dyn_max_hz = 127
+set dterm_lpf1_static_hz = 127
+
+set dterm_lpf2_static_hz = 127
+
+# -- Dterm sliders (both filters on by default) --
+set simplified_dterm_filter_multiplier = 85
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 75
+
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_rpm_normal.txt
+++ b/presets/4.4/filters/basic_rpm_normal.txt
@@ -1,0 +1,44 @@
+#$ TITLE: 4.4 Filter settings for NORMAL build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, DShot telemetry, filter, filters, normal, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Intended for a well maintained build in good condition with RPM filtering.
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: If motors get hot, try a filter set for noisy or very noisy motors.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 500hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 500
+
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 100
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering (default of 3 notches each at 500hz) --
+# forcing rpm_filter_q to 500 in case it was set to 300 when RPM filtering was off
+set dshot_bidir = ON
+set rpm_filter_q = 500
+
+# -- Dterm filtering (default) --
+# -- Dterm sliders (default) --
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_rpm_very_clean.txt
+++ b/presets/4.4/filters/basic_rpm_very_clean.txt
@@ -1,0 +1,51 @@
+#$ TITLE: 4.4 Filter settings for VERY CLEAN build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, filter, filters, filtering, very clean, very, clean, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: Likely to cause motor overheating on many builds!
+#$ DESCRIPTION: Intended only for rock hard frames, motors with good bearings and true shafts, and perfectly balanced props.
+#$ DESCRIPTION: If motors get hot, try a filter set for clean or normal motors.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# None
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 1000
+
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 200
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 500
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 750
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 82
+set dterm_lpf1_dyn_max_hz = 165
+set dterm_lpf1_static_hz = 165
+
+set dterm_lpf2_static_hz = 165
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 110
+
+
+# -- Yaw lowpass (default) --
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/basic_rpm_very_noisy.txt
+++ b/presets/4.4/filters/basic_rpm_very_noisy.txt
@@ -1,0 +1,52 @@
+#$ TITLE: 4.4 Filter settings for VERY NOISY build with RPM FILTERING.
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: rpm, filter, filters, filtering, very, noisy, very noisy, hot, basic, betaflight
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: WARNING: Requires RPM filtering - ensure that DShot Telemetry is working properly!
+#$ DESCRIPTION: WARNING: Too much filtering may cause wobbling.
+#$ DESCRIPTION: Intended for worn, beaten up, or larger (10" and above), builds.
+#$ DESCRIPTION: If motors remain hot despite strong filtering, it may not be a filtering problem.
+#$ DESCRIPTION: If motors grind or make noise at idle, lower the D filter slider.
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# enable dshot rpm telemetry
+set dshot_bidir = ON
+
+# -- Gyro filters --
+# Single static gyro lowpass at 125hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 250
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 125
+
+# -- Gyro Sliders (on by default) --
+# only lpf2 is active
+set simplified_gyro_filter_multiplier = 25
+
+# -- Gyro Static Notches (default)--
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 350
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 350
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 60
+set dterm_lpf1_dyn_max_hz = 120
+set dterm_lpf1_static_hz = 120
+
+set dterm_lpf2_static_hz = 120
+
+# -- Dterm sliders (on by default) --
+set simplified_dterm_filter_multiplier = 80
+
+# -- Yaw lowpass (default) --
+set yaw_lowpass_hz = 50
+
+# -- Accelerometer lowpass (default) --

--- a/presets/4.4/filters/ctzsnooze_race.txt
+++ b/presets/4.4/filters/ctzsnooze_race.txt
@@ -1,0 +1,36 @@
+#$ TITLE: ctzsnooze's race filter settings
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: race, filter, filters, ctzsnooze, RPM
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: ctzsnooze's standard race filter setup.
+#$ DESCRIPTION: tolerates fairly worn setups
+#$ DESCRIPTION: Requires RPM filtering and DShot telemetry!
+
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+# -- Gyro filters --
+# Single static gyro lowpass at 500hz
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 500
+
+# -- Gyro Sliders (on by default at default but only lowpass2 is active) --
+# only lpf2 is active
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 100
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_q = 450
+set rpm_filter_min_hz = 80
+set rpm_filter_fade_range_hz = 60
+
+# -- Dterm filtering (default) --
+
+# -- Yaw lowpass (default) --

--- a/presets/4.4/filters/defaults.txt
+++ b/presets/4.4/filters/defaults.txt
@@ -1,0 +1,68 @@
+#$ TITLE: Default 4.4 Filter settings
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: defaults, filter, filters, reset
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets Filter settings to 4.4 defaults
+
+set gyro_hardware_lpf = NORMAL
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_type = PT1
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_dyn_expo = 5
+set gyro_lpf1_static_hz = 250
+
+set gyro_lpf2_type = PT1
+set gyro_lpf2_static_hz = 500
+
+# -- Gyro sliders --
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 100
+
+# -- Gyro Static Notches --
+set gyro_notch1_hz = 0
+set gyro_notch1_cutoff = 0
+set gyro_notch2_hz = 0
+set gyro_notch2_cutoff = 0
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 3
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 150
+set dyn_notch_max_hz = 600
+set gyro_filter_debug_axis = ROLL
+
+# -- RPM filtering --
+set dshot_bidir = OFF
+set rpm_filter_harmonics = 3
+set rpm_filter_q = 500
+set rpm_filter_min_hz = 100
+set rpm_filter_fade_range_hz = 50
+set rpm_filter_lpf_hz = 150
+
+# -- Dterm filtering --
+set dterm_lpf1_type = PT1
+set dterm_lpf1_dyn_min_hz = 75
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_dyn_expo = 5
+set dterm_lpf1_static_hz = 75
+
+set dterm_lpf2_type = PT1
+set dterm_lpf2_static_hz = 150
+
+set dterm_notch_hz = 0
+set dterm_notch_cutoff = 0
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 100
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+# -- Accelerometer lowpass --
+set acc_lpf_hz = 10
+

--- a/presets/4.4/filters/karate_array.txt
+++ b/presets/4.4/filters/karate_array.txt
@@ -1,0 +1,44 @@
+#$ TITLE: the Karate array 
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: filter, filters, karate, race, freesytle, suagrK, CTZsoonze, KarateBrot, 5"
+#$ AUTHOR: sugarK
+#$ DESCRIPTION: The Karate filter array as developed by @CTZsnooze and @sugarK for 4.3 and 4.4 using @karateBrot's rpm cross fade code.
+#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
+#$ DESCRIPTION: This filtering array will work with most 5" race and freesytle builds that have a solid airframe and motors in good condition. 
+#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK. 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/51
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/filters/defaults.txt
+
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set simplified_gyro_filter = OFF
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 200
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 2
+set rpm_filter_fade_range_hz = 100
+set rpm_filter_min_hz = 150
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 7
+
+
+
+# OPTION BEGIN (UNCHECKED): Dshot300
+set motor_pwm_protocol = Dshot300
+# OPTION END
+
+# OPTION BEGIN (UNCHECKED): Dshot600
+set motor_pwm_protocol = DSHOT600
+# OPTION END


### PR DESCRIPTION
** Breaking ALL the rules **
// Primarily for dependency chain reasons

Did a simple copy over, then Find & Replace All 4.3 to 4.4 for each file
Made minor spelling corrections in Karate Preset

BMI270 presets NOT ported over - would need clarification on OSR4 mode, default behaviors, and what most closely works with the wider range of presets to emulate MPU6000-like performance with the BMI270 hardware.

Dependency chain operation works with this simple port-over and FIRMWARE_VERSION iteration++, appears to work fine.
