### PR TITLE
Karate tunes 4.3->4.4 port

### DIFF
--- a/presets/4.3/filters/karate_array.txt
+++ b/presets/4.3/filters/karate_array.txt
@@ -1,13 +1,14 @@
-#$ TITLE: the Karate array 
+#$ TITLE: the Karate array
 #$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
 #$ CATEGORY: FILTERS
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: filter, filters, karate, race, freesytle, suagrK, CTZsoonze, KarateBrot, 5"
 #$ AUTHOR: sugarK
 #$ DESCRIPTION: the Karate fitler array as developed by @CTZsoonze and @sugarK for 4.3 using @karateBrot's rpm cross fade code.
 #$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
-#$ DESCRIPTION: This filtering array will work with most 5" race and freesytle builds that have a solid airframe and motors in good condition. 
-#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK. 
+#$ DESCRIPTION: This filtering array will work with most 5" race and freesytle builds that have a solid airframe and motors in good condition.
+#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/51
 #$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -36,9 +37,9 @@ set dterm_lpf1_dyn_expo = 7
 
 
 # OPTION BEGIN (UNCHECKED): Dshot300
-set motor_pwm_protocol = Dshot300
+    set motor_pwm_protocol = Dshot300
 # OPTION END
 
 # OPTION BEGIN (UNCHECKED): Dshot600
-set motor_pwm_protocol = DSHOT600
+    set motor_pwm_protocol = DSHOT600
 # OPTION END

--- a/presets/4.4/tune/karate/karate_freestyle_5_inch.txt
+++ b/presets/4.4/tune/karate/karate_freestyle_5_inch.txt
@@ -1,0 +1,65 @@
+#$ TITLE: Freestyle 5" Karate Style
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: karate, 6S,5 inch, 5", sugarK, limon, ctzsnooze, karateBrot, freestyle
+#$ AUTHOR: sugarK
+
+#$ DESCRIPTION: This is the sugarK freestyle tune, its been test over the last few months, on 5" quads by members of the UAVtech discord.. This is a starting point tune and has siders active so you can fine tune it easily. In saying that its still a pretty spicy tune and use at your own risk.
+#$ DESCRIPTION:
+#$ DESCRIPTION: THIS PRESET IS NOT SUITABLE FOR RACING QUADS AND MAY RESULT IN FLY AWAYS OR BURNT MOTORS
+#$ DESCRIPTION:
+#$ DESCRIPTION: Things to note.. YOU HAVE TO USE RPM FILTERING WITH THIS TUNE, failure to do so might result in fire and regarding Dshot600,  if your setup has errors in the motor tab using bidirectional Dshot then change to 8k/4k and dshot300.
+#$ DESCRIPTION: Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc. To test arm the quad with props on, it should sound clean with no grinding, if it passes that then hover test and check motor temps.
+#$ DESCRIPTION:  If any thing is off don't fly it!!
+#$ DESCRIPTION:
+#$ DESCRIPTION: SECOND NOTE.... Radio links.. 1. Make sure your radio system is totally up to date using either Edgetx or Opentx and your ADC in the hardware page is OFF 2. Go to the radio presets and apply the correct setup for your system and link speed.
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/95
+
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE_WARNING: misc/warnings/en/freestyle.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+
+# -- Gyro lowpass filters --
+set simplified_gyro_filter_multiplier = 200
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 120
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 10
+
+# -- RPM filtering --
+set rpm_filter_fade_range_hz = 100
+
+# -- PID values --
+set simplified_pids_mode = RP
+set simplified_d_gain = 145
+set simplified_pi_gain = 115
+set simplified_dmax_gain = 70
+set simplified_feedforward_gain = 115
+set simplified_pitch_d_gain = 95
+set simplified_pitch_pi_gain = 110
+simplified_tuning apply
+
+#$ OPTION BEGIN (CHECKED): Dshot600
+    set dshot_bidir = ON
+    set motor_pwm_protocol = DSHOT600
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dshot300
+    set dshot_bidir = ON
+    set motor_pwm_protocol = Dshot300
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic idle
+    set dshot_idle_value = 450
+    set dyn_idle_min_rpm = 35
+    set dyn_idle_p_gain = 35
+#$ OPTION END

--- a/presets/4.4/tune/karate/karate_race.txt
+++ b/presets/4.4/tune/karate/karate_race.txt
@@ -1,0 +1,250 @@
+#$ TITLE: Karate Race 6s 5"
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: karate, 6S, race, world champion, 5 inch, 5", sugarK, limon, ctzsnooze, KarateBrot
+#$ AUTHOR: sugarK
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174759844-ffd85f42-1f1c-42bf-9032-d9f96d4d9619.svg" width="90px" style="display: block; float: left; margin-right: 10px; margin-top: 20px"/>
+#$ DESCRIPTION: <h1>Karate Race 6S 5"</h1>
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This 6S racing tune was developed with the help of **@ctzsnooze** around **@KarateBrot**'s [RPM Crossfade code](https://github.com/betaflight/betaflight/pull/10757) allowing for a pretty aggressive filter tune, which is called the [Karate Array](https://github.com/betaflight/firmware-presets/blob/master/presets/4.3/filters/karate_array.txt).
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This tune works well on any quality airframes and has been flown on the Viper racer (where it was developed), BMS Js1, 533 Switchback, HGLRC Wind and of course **@limon**'s OpenRacer.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: It should also work on other quality racing frames but use at your own risk as it is an aggressive tune. This tune so far has won a good number of events, including the **2021 MultiGP International Open**.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Things to note:
+#$ DESCRIPTION: - **YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!** Failure to do so might result in fire 🔥
+#$ DESCRIPTION: - Regarding DShot600: if your setup has errors in the motor tab using bidirectional DShot, change to **8k/4k and DShot300**
+#$ DESCRIPTION: - Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc.
+#$ DESCRIPTION: - To test arm the quad with props on, it should **sound clean with no grinding**. If it passes that then hover test and check motor temps.
+#$ DESCRIPTION: - **If anything is off, don't fly it!!**
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Second note... Radio links:
+#$ DESCRIPTION: 1. Make sure your radio firmware is up to date using either EdgeTX or OpenTX
+#$ DESCRIPTION: 1. Make sure your **ADC Filter is OFF** in the hardware page
+#$ DESCRIPTION: 1. Go to the radio (RC_LINK) presets and apply the correct setup for your system and link speed
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/41
+
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 500
+set gyro_lpf1_dyn_max_hz = 1000
+set simplified_gyro_filter = OFF
+
+#$ OPTION BEGIN (UNCHECKED): Bosch (BMI) gyro - experimantal
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+#$ OPTION END
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 200
+set dyn_notch_max_hz = 650
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 7
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_fade_range_hz = 100
+
+# -- Misc --
+set yaw_spin_recovery = AUTO
+set thrust_linear = 0
+set throttle_boost = 2
+
+# -- iTerm  --
+set iterm_relax_cutoff = 20
+
+# -- PIDsum limits --
+set iterm_limit = 500
+set pidsum_limit_yaw = 1000
+
+
+# -- PID values --
+set p_pitch = 42
+set i_pitch = 85
+set d_pitch = 42
+set f_pitch = 135
+
+set p_roll = 37
+set d_roll = 36
+
+set f_yaw = 80
+
+set d_min_roll = 22
+set d_min_pitch = 22
+set d_max_gain = 35
+set d_max_advance = 0
+set simplified_pids_mode = OFF
+
+# -- Feedforward --
+set feedforward_max_rate_limit = 100
+
+# -- TPA --
+set tpa_rate = 70
+set tpa_breakpoint = 1250
+
+#$ OPTION BEGIN (CHECKED): Dshot600
+    set dshot_bidir = ON
+    set motor_pwm_protocol = DSHOT600
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dshot300
+    set dshot_bidir = ON
+    set motor_pwm_protocol = Dshot300
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic idle for 2000kv 6s
+    #dynamic idle for 6s 2000kv
+    set dyn_idle_min_rpm = 40
+    set dyn_idle_p_gain = 35
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Spicy tune
+
+    #spicy tune use with care
+    # -- Gyro Dynamic Notches --
+    set dyn_notch_count = 1
+    set dyn_notch_q = 600
+    set dyn_notch_min_hz = 250
+    set dyn_notch_max_hz = 650
+
+    # -- Dterm filtering --
+    set dterm_lpf1_dyn_expo = 10
+
+    # -- RPM filtering --
+    set rpm_filter_harmonics = 2
+    set rpm_filter_min_hz = 150
+
+    # -- PID values --
+    set p_pitch = 42
+    set i_pitch = 85
+    set d_pitch = 42
+    set f_pitch = 135
+    set p_roll = 37
+    set i_roll = 80
+    set d_roll = 36
+    set f_roll = 120
+    set p_yaw = 45
+    set i_yaw = 80
+    set d_yaw = 0
+    set f_yaw = 80
+
+    set d_min_roll = 26
+    set d_min_pitch = 26
+    set d_max_gain = 25
+    set d_max_advance = 0
+    set simplified_pids_mode = OFF
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Noisy airframe (can be used with Spicy)
+
+    # -- Gyro lowpass filters --
+    set gyro_lpf1_static_hz = 0
+    set gyro_lpf2_static_hz = 0
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+
+    # -- Dterm filtering --
+    set dterm_lpf1_dyn_expo = 10
+    set dterm_lpf1_type = BIQUAD
+#$ OPTION END
+
+#$ OPTION_GROUP BEGIN: Some popular RC Links
+
+    #$ OPTION BEGIN (UNCHECKED): Tracer/ELRS 250Hz
+        # Tracer/ELRS 250Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
+        # ERLS 500Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 3
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 250Hz
+        # Ghost 250Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = GHST
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 500Hz
+        # Ghost 500Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 3
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Optional rates
+
+    #$ OPTION BEGIN (UNCHECKED): sugarK's rates
+        set thr_mid = 25
+        set thr_expo = 65
+        set roll_expo = 54
+        set pitch_expo = 54
+        set yaw_expo = 54
+        set roll_srate = 40
+        set pitch_srate = 40
+        set yaw_srate = 42
+    #$ OPTION END
+
+#$ OPTION_GROUP END

--- a/presets/4.4/tune/karate/karate_race_lite.txt
+++ b/presets/4.4/tune/karate/karate_race_lite.txt
@@ -1,0 +1,212 @@
+#$ TITLE: Karate 'Viper Lite' Race  5"
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: karate, race, 5 inch, 5", sugarK, limon, ctzsnooze, KarateBrot, ultralite, viper, viper lite
+#$ AUTHOR: sugarK
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/176932353-fdc42c5e-33ae-42d7-b34c-e981b6cffa3f.png" style="max-width: 100%; margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION: <h1>Karate Viper Lite race</h1>
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This racing tune was developed from the Karate Race tune to suit my new Viper lite ultralite 5" racer project. [Viper Lite](https://rotorbuilds.com/build/29775)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This tune should be used with 48khz PWM settings or firmware and it 'SHOULD' work with other ultralite 5" frames eg the ET-5 but use at your own risk.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Things to note:
+#$ DESCRIPTION: - **YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!** Failure to do so might result in fire 🔥
+#$ DESCRIPTION: - Regarding DShot600: if your setup has errors in the motor tab using bidirectional DShot, change to **8k/4k and DShot300**
+#$ DESCRIPTION: - Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc.
+#$ DESCRIPTION: - To test arm the quad with props on, it should **sound clean with no grinding**. If it passes that then hover test and check motor temps.
+#$ DESCRIPTION: - **If anything is off, don't fly it!!**
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Second note... Radio links:
+#$ DESCRIPTION: 1. Make sure your radio firmware is up to date using either EdgeTX or OpenTX
+#$ DESCRIPTION: 1. Make sure your **ADC Filter is OFF** in the hardware page
+#$ DESCRIPTION: 1. Go to the radio (RC_LINK) presets and apply the correct setup for your system and link speed
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/272
+
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 500
+set gyro_lpf1_dyn_max_hz = 1000
+set gyro_lpf1_dyn_expo = 7
+set simplified_gyro_filter = OFF
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 450
+set dyn_notch_min_hz = 125
+set dyn_notch_max_hz = 650
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 7
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_fade_range_hz = 100
+
+# -- Misc --
+set yaw_spin_recovery = AUTO
+set thrust_linear = 20
+
+# -- iTerm  --
+set iterm_relax_cutoff = 20
+
+# -- PIDsum limits --
+set iterm_limit = 500
+set pidsum_limit_yaw = 1000
+
+
+# -- PID values --
+set p_pitch = 42
+set i_pitch = 85
+set d_pitch = 34
+set f_pitch = 135
+set p_roll = 37
+set d_roll = 30
+set f_yaw = 80
+
+set d_min_roll = 22
+set d_min_pitch = 22
+set d_max_gain = 35
+set d_max_advance = 0
+
+set simplified_pids_mode = OFF
+
+# -- Feedforward --
+set feedforward_max_rate_limit = 100
+
+# -- TPA --
+set tpa_rate = 60
+set tpa_breakpoint = 1250
+
+#$ OPTION BEGIN (CHECKED): Dshot600
+    set dshot_bidir = ON
+    set motor_pwm_protocol = DSHOT600
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dshot300
+    set dshot_bidir = ON
+    set motor_pwm_protocol = Dshot300
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic idle for 4s 2850-3000kv
+    #dynamic idle for 4s 2850-3000kv
+   set dyn_idle_min_rpm = 50
+   set dyn_idle_p_gain = 35
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Vbat Sag Compensation
+    set vbat_sag_compensation = 100
+  #$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Noisy airframe
+
+    # -- Gyro lowpass filters --
+    set gyro_lpf1_static_hz = 0
+    set gyro_lpf2_static_hz = 0
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+
+    # -- Dterm filtering --
+    set dterm_lpf1_dyn_expo = 10
+    set dterm_lpf1_type = BIQUAD
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Bosch (BMI) gyro - EXPERIMANTAL
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+#$ OPTION END
+
+#$ OPTION_GROUP BEGIN: Some popular RC Links
+
+    #$ OPTION BEGIN (UNCHECKED): Tracer/ELRS 250Hz
+        # Tracer/ELRS 250Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
+        # ERLS 500Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 0
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 250Hz
+        # Ghost 250Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+        set serialrx_provider = GHST
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 500Hz
+        # Ghost 500Hz
+        #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+        feature RX_SERIAL
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 0
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Optional rates
+
+    #$ OPTION BEGIN (UNCHECKED): sugarK's rates
+        set thr_mid = 25
+        set thr_expo = 65
+        set roll_expo = 54
+        set pitch_expo = 54
+        set yaw_expo = 54
+        set roll_srate = 40
+        set pitch_srate = 40
+        set yaw_srate = 42
+    #$ OPTION END
+
+#$ OPTION_GROUP END

--- a/presets/4.4/tune/karate/tiny_karate.txt
+++ b/presets/4.4/tune/karate/tiny_karate.txt
@@ -1,0 +1,73 @@
+#$ TITLE: 533 TinyTrainer Karate
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: karate, race, 533, 3 inch, 3", sugarK, shames, tiny, trainer, spec, tinyTrainer
+#$ AUTHOR: sugarK
+#$ DESCRIPTION: This racing tune was developed for the 533 TinyTrainer spec class with @Shames throwing his quad out the window of his office and sending me logs.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Things to note.. YOU HAVE TO USE RPM FILTERING WITH THIS TUNE, failure to do so might result in fire and regarding Dshot600,  if your setup has errors in the motor tab using bidirectional Dshot then change to 8k/4k and dshot300.
+#$ DESCRIPTION: SECOND NOTE.... Radio links.. 1. Make sure your radio system is totally up to date using either Edgetx or Opentx and your ADC in the hardware page is OFF 2. Go to the radio presets and apply the correct setup for your system and link speed.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/81
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 200
+set dyn_notch_max_hz = 700
+
+# -- Dterm filtering --
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_fade_range_hz = 100
+
+# -- Misc --
+set yaw_spin_recovery = AUTO
+set thrust_linear = 0
+set throttle_boost = 7
+
+# -- iTerm  --
+set iterm_relax_cutoff = 20
+
+# -- PIDsum limits --
+set iterm_limit = 500
+set pidsum_limit_yaw = 1000
+
+# -- PID values --
+set simplified_pids_mode = RP
+set simplified_i_gain = 115
+set simplified_d_gain = 125
+set simplified_pi_gain = 90
+set simplified_dmax_gain = 70
+set simplified_feedforward_gain = 105
+set simplified_pitch_d_gain = 95
+simplified_tuning apply
+
+# -- TPA --
+set tpa_rate = 70
+set tpa_breakpoint = 1250
+
+#$ OPTION BEGIN (CHECKED): Dshot600
+    set dshot_bidir = ON
+    set motor_pwm_protocol = DSHOT600
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dshot300
+    set dshot_bidir = ON
+    set motor_pwm_protocol = Dshot300
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): dynamic idle
+    set dshot_idle_value = 700
+    set dyn_idle_min_rpm = 60
+    set dyn_idle_p_gain = 35
+#$ OPTION END


### PR DESCRIPTION
This is just a simple port from 4.3 to 4.4 for the Karate tunes/filters by @sugaarK. Mostly copy-paste.
Filters stay the same so far.
Tunes require new AG settings so leaving them at defaults until further testing. Marking 4.4 tunes as experimental.

Read more about the new 4.4 AG:
https://github.com/betaflight/betaflight/pull/11679

Leaving discussion links the same as for 4.3

