### PR TITLE
Porting UAV_tech presets 4.3->4.4

### DIFF
--- a/presets/4.4/tune/uav_tech/UAV_tech_5in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in.txt
@@ -1,0 +1,102 @@
+#$ TITLE: UAV Tech - 5in (590-630g AUW)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 4S, 6S, 5in, 5", freestyle
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://www.youtube.com/c/spatzengr-uav_tech"><img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: PIDs Tab Changes:
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158019544-b4f42518-3b2b-4101-afde-671a44647ee5.png"><img src="https://user-images.githubusercontent.com/25570978/158019544-b4f42518-3b2b-4101-afde-671a44647ee5.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Filters Tab Changes:
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/175781771-5adb9234-6f6b-4f42-8fbe-294699959dad.png"><img src="https://user-images.githubusercontent.com/25570978/175781771-5adb9234-6f6b-4f42-8fbe-294699959dad.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a 5in quad with HD camera, approximate weight 630grams.  This tune is good for 4S or 6S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default).  If you are on 48K+ ESC PWM, click that option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [Low Gyro Noise](https://youtu.be/WiWr0gP3AT0) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/175781642-3e42c38b-2ca6-440a-928b-854dd4d32d2c.png"><img src="https://user-images.githubusercontent.com/25570978/175781642-3e42c38b-2ca6-440a-928b-854dd4d32d2c.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158003506-357ef669-d03d-4b54-8509-e167c5f857ef.png"><img src="https://user-images.githubusercontent.com/25570978/158003506-357ef669-d03d-4b54-8509-e167c5f857ef.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158003431-63c95403-6c7a-4b40-bb63-89e3ae994139.png"><img src="https://user-images.githubusercontent.com/25570978/158003431-63c95403-6c7a-4b40-bb63-89e3ae994139.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158003472-4a03ae4c-e593-4ef7-b418-9eee00757665.png"><img src="https://user-images.githubusercontent.com/25570978/158003472-4a03ae4c-e593-4ef7-b418-9eee00757665.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ WARNING: **DO NOT** select the RPM Filter option unless your ESCs support DSHOT and Bi-Directional Communication.  If you are unsure, HIT CANCEL and de-select that option, OTHERWISE it can spin up motors even before you arm your quad!!!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/201
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+
+# -- Filter Settings --
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 60
+set dyn_notch_count = 3
+set dyn_notch_min_hz = 125
+set dyn_notch_max_hz = 650
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 120
+set yaw_lowpass_hz = 0
+
+# -- PID Settings --
+set yaw_lowpass_hz = 0
+set simplified_master_multiplier = 135
+set simplified_pi_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 130
+set simplified_pitch_d_gain = 100
+set simplified_pitch_pi_gain = 100
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): LOW GYRO NOISE BUILDS
+    # -- ADDER: For low gyro noise builds --
+    set simplified_gyro_filter = OFF
+    set gyro_lpf1_static_hz = 0
+    set gyro_lpf2_static_hz = 0
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+    set dyn_notch_count = 4
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 48k+ ESC PWM
+    # -- ADDER: For 48khz+ PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    # -- ADDER: Enabling RPM filtering --
+    set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    # -- ADDER: Enabling Dynamic Idle --
+    set dyn_idle_min_rpm = 35
+#$ OPTION END

--- a/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
@@ -1,0 +1,89 @@
+#$ TITLE: UAV Tech - 6-7in (~700g AUW)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: 4S, 6S, 6in, 7in, 6", 7", freestyle, long range
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://www.youtube.com/c/spatzengr-uav_tech"><img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: PIDs Tab Changes:
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/167264419-2a779a01-02fe-487f-937d-3bdaee7cde11.png"><img src="https://user-images.githubusercontent.com/25570978/167264419-2a779a01-02fe-487f-937d-3bdaee7cde11.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Filters Tab Changes:
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158019484-640d6668-0f19-4c75-81e4-74a3b4b8df22.png"><img src="https://user-images.githubusercontent.com/25570978/158019484-640d6668-0f19-4c75-81e4-74a3b4b8df22.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a 6-7in quad with HD camera, approximate weight 700grams.  This tune is good for 4S or 6S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default).  If you are on 48K+ ESC PWM, click that option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Recommended MINIMUM motor sizes:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: 6″ is 25xx+  |  7″/8″ is 28xx+
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158003506-357ef669-d03d-4b54-8509-e167c5f857ef.png"><img src="https://user-images.githubusercontent.com/25570978/158003506-357ef669-d03d-4b54-8509-e167c5f857ef.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158003431-63c95403-6c7a-4b40-bb63-89e3ae994139.png"><img src="https://user-images.githubusercontent.com/25570978/158003431-63c95403-6c7a-4b40-bb63-89e3ae994139.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE) <--CLICK for topic video
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://user-images.githubusercontent.com/25570978/158003472-4a03ae4c-e593-4ef7-b418-9eee00757665.png"><img src="https://user-images.githubusercontent.com/25570978/158003472-4a03ae4c-e593-4ef7-b418-9eee00757665.png" width="500px" style="margin-left: auto; margin-right: auto; display: block;"/></a>
+#$ DESCRIPTION:
+#$ WARNING: **DO NOT** select the RPM Filter option unless your ESCs support DSHOT and Bi-Directional Communication.  If you are unsure, HIT CANCEL and de-select that option, OTHERWISE it can spin up motors even before you arm your quad!!!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/202
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Filter Settings --
+set simplified_dterm_filter = ON
+set simplified_gyro_filter = ON
+set dyn_notch_count = 5
+set dyn_notch_min_hz = 100
+set simplified_gyro_filter_multiplier = 60
+set simplified_dterm_filter_multiplier = 120
+
+# -- PID Settings --
+set simplified_d_gain = 130
+set simplified_pi_gain = 85
+set simplified_feedforward_gain = 115
+set simplified_dmax_gain = 0
+set simplified_i_gain = 65
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 100
+set simplified_master_multiplier = 150
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 48k ESC PWM
+    # -- ADDER: For 48khz PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    set dyn_idle_min_rpm = 40
+#$ OPTION END

--- a/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
@@ -1,0 +1,70 @@
+#$ TITLE: UAV Tech - 8-9in (~750g AUW)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 4S, 6S, 8in, 9in, 8", 9", freestyle, long range
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a 8-9in quad with HD camera, approximate weight 750grams.  This tune is good for 4S or 6S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default).  If you are on 48K+, click the option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U)
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE)
+#$ DESCRIPTION:
+#$ DESCRIPTION: Minimum motor size for a 9″/10″ is 28xx+ | 31xx is recommended for heavier builds.
+#$ DESCRIPTION:
+#$ WARNING: Prior to selecting the "RPM Filter" or "Dynamic Idle" options, Bi-Directional DSHOT must be setup for your quad.  If you have not setup yet, click "CANCEL" and setup first (PROPS OFF to test).  If you have NOT selected the "RPM Filter" or "Dynamic Idle" options, YOU CAN IGNORE THIS MESSAGE.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/206
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Filter Settings --
+set simplified_dterm_filter = ON
+set simplified_gyro_filter = ON
+set dyn_notch_count = 5
+set dyn_notch_min_hz = 100
+set simplified_gyro_filter_multiplier = 60
+set simplified_dterm_filter_multiplier = 120
+
+# -- PID Settings --
+set simplified_d_gain = 140
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 140
+set simplified_dmax_gain = 0
+set simplified_i_gain = 50
+set simplified_pitch_d_gain = 120
+set simplified_pitch_pi_gain = 110
+set simplified_master_multiplier = 170
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 48k ESC PWM
+    # -- ADDER: For 48khz PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    set dshot_bidir = ON
+    set dyn_idle_min_rpm = 40
+#$ OPTION END

--- a/presets/4.4/tune/uav_tech/UAV_tech_8-9in_Cinelifter.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_8-9in_Cinelifter.txt
@@ -1,0 +1,75 @@
+#$ TITLE: UAV Tech - 8-9in Cinelifter (>2,000g AUW)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 6S, 8S, 8in, 9in, 8", 9", cinelifter
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a 8-9in Cinelifter (4x or 8x) quad with Red or BlackMagic cameras, approximae weight 2000 grams. This tune is good for 6S or 8S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default). If you are on 48K+, click the option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U)
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE)
+#$ DESCRIPTION:
+#$ DESCRIPTION: Minimum motor size for a 8″/9″ Cinelifter is 28xx; 31xx is recommended.
+#$ DESCRIPTION:
+#$ WARNING: Prior to selecting the "RPM Filter" or "Dynamic Idle" options, Bi-Directional DSHOT must be setup for your quad.  If you have not setup yet, click "CANCEL" and setup first (PROPS OFF to test).  If you have NOT selected the "RPM Filter" or "Dynamic Idle" options, YOU CAN IGNORE THIS MESSAGE.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/207
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Filter Settings --
+set simplified_dterm_filter = ON
+set simplified_gyro_filter = ON
+set dyn_notch_count = 5
+set dyn_notch_min_hz = 80
+set simplified_gyro_filter_multiplier = 60
+set simplified_dterm_filter_multiplier = 120
+
+# -- PID Settings --
+set simplified_pids_mode = RP
+set iterm_relax_cutoff = 5
+set simplified_d_gain = 140
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 100
+set simplified_dmax_gain = 150
+set simplified_i_gain = 75
+set simplified_pitch_d_gain = 120
+set simplified_pitch_pi_gain = 100
+set simplified_master_multiplier = 150
+set p_yaw = 150
+set i_yaw = 150
+set f_yaw = 0
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 48k ESC PWM
+    # -- ADDER: For 48khz PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 3
+    set dyn_notch_count = 3
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    set dshot_bidir = ON
+    set dyn_idle_min_rpm = 40
+#$ OPTION END

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -1,0 +1,74 @@
+#$ TITLE: UAV Tech - Cinewhoop
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: cinewhoop
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a Cinewhoop.  This tune is good for 4S or 6S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default). If you are on 48K+, click the option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [96K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U)
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE)
+#$ DESCRIPTION:
+#$ WARNING: Prior to selecting the "RPM Filter" or "Dynamic Idle" options, Bi-Directional DSHOT must be setup for your quad.  If you have not setup yet, click "CANCEL" and setup first (PROPS OFF to test).  If you have NOT selected the "RPM Filter" or "Dynamic Idle" options, YOU CAN IGNORE THIS MESSAGE.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/208
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Filter Settings --
+set simplified_dterm_filter = ON
+set simplified_gyro_filter = ON
+set dyn_notch_count = 4
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 1000
+set simplified_gyro_filter_multiplier = 150
+
+# -- PID Settings --
+set vbat_sag_compensation = 100
+set iterm_relax_cutoff = 10
+set simplified_d_gain = 140
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 100
+set simplified_dmax_gain = 0
+set simplified_i_gain = 100
+set simplified_pitch_d_gain = 100
+set simplified_pitch_pi_gain = 100
+set simplified_master_multiplier = 160
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 48k ESC PWM
+    # -- ADDER: For 48khz PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 96k ESC PWM
+    # -- ADDER: For 96khz PWM --
+    set thrust_linear = 40
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    set dshot_bidir = ON
+    set dyn_idle_min_rpm = 35
+#$ OPTION END

--- a/presets/4.4/tune/uav_tech/UAV_tech_Toothpic.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Toothpic.txt
@@ -1,0 +1,75 @@
+#$ TITLE: UAV Tech - Toothpic (2in to 4in)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 2S, 4S, 6S, toothpic, 2in, 3in, 3.5in, 4in
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a toothpic quad; anything from 2" to 4".  This tune is good for 2S or 6S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default). If you are on 48K+, click the option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [96K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U)
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE)
+#$ DESCRIPTION:
+#$ WARNING: Prior to selecting the "RPM Filter" or "Dynamic Idle" options, Bi-Directional DSHOT must be setup for your quad.  If you have not setup yet, click "CANCEL" and setup first (PROPS OFF to test).  If you have NOT selected the "RPM Filter" or "Dynamic Idle" options, YOU CAN IGNORE THIS MESSAGE.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/209
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Filter Settings --
+set simplified_dterm_filter = ON
+set simplified_gyro_filter = ON
+set dyn_notch_count = 4
+set dyn_notch_min_hz = 125
+set dyn_notch_max_hz = 850
+set simplified_gyro_filter_multiplier = 150
+set simplified_dterm_filter_multiplier = 120
+set yaw_lowpass_hz = 0
+
+# -- PID Settings --
+set simplified_d_gain = 90
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 100
+set simplified_dmax_gain = 0
+set simplified_i_gain = 100
+set simplified_pitch_d_gain = 100
+set simplified_pitch_pi_gain = 100
+set simplified_master_multiplier = 150
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 48k ESC PWM
+    # -- ADDER: For 48khz PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 96k ESC PWM
+    # -- ADDER: For 96khz PWM --
+    set thrust_linear = 40
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    set dshot_bidir = ON
+    set dyn_idle_min_rpm = 35
+#$ OPTION END

--- a/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
@@ -1,0 +1,74 @@
+#$ TITLE: UAV Tech - Whoop (1S & 2S)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: whoop
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, Youtube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="125px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Information:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a Whoop.  This tune is good for 1S or 2S batteries.
+#$ DESCRIPTION: The base preset assume you have your ESC set to 24K PWM (default). If you are on 48K+, click the option above.
+#$ DESCRIPTION: Also if you would like to use with the RPM filtering or Dynamic Idle, click the option above.
+#$ DESCRIPTION: If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [48K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [96K ESC PWM](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [RPM Filter](https://youtu.be/ve_TNB0D87U)
+#$ DESCRIPTION: - [Dynamic Idle](https://youtu.be/2Mr-AP7K8YE)
+#$ DESCRIPTION:
+#$ WARNING: Prior to selecting the "RPM Filter" or "Dynamic Idle" options, Bi-Directional DSHOT must be setup for your quad.  If you have not setup yet, click "CANCEL" and setup first (PROPS OFF to test).  If you have NOT selected the "RPM Filter" or "Dynamic Idle" options, YOU CAN IGNORE THIS MESSAGE.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/210
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Filter Settings --
+set simplified_dterm_filter = ON
+set simplified_gyro_filter = ON
+set dyn_notch_count = 4
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 1000
+set simplified_gyro_filter_multiplier = 150
+
+# -- PID Settings --
+set vbat_sag_compensation = 100
+set iterm_relax_cutoff = 10
+set simplified_d_gain = 140
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 100
+set simplified_dmax_gain = 0
+set simplified_i_gain = 100
+set simplified_pitch_d_gain = 100
+set simplified_pitch_pi_gain = 100
+set simplified_master_multiplier = 160
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 48k ESC PWM
+    # -- ADDER: For 48khz PWM --
+    set thrust_linear = 20
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 96k ESC PWM
+    # -- ADDER: For 96khz PWM --
+    set thrust_linear = 40
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): RPM filtering
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+    set dshot_bidir = ON
+    set dyn_idle_min_rpm = 35
+#$ OPTION END


### PR DESCRIPTION
A simple port for @spatzengr presets to 4.4
Mostly copy-paste. Changes:
- include 4.4 tune defaults
- removing AG values, leaving them 4.4 defaults
- changing all to experimental (till 4.4 values are defined and tested)
- indentation, trailing spaces

Read more about the new 4.4 AG:
https://github.com/betaflight/betaflight/pull/11679