### PR TITLE
Ported SupaflyFPV tunes 4.3->4.4, removed AG values, marked as experimental

### DIFF
--- a/presets/4.4/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
+++ b/presets/4.4/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
@@ -1,0 +1,108 @@
+#$ TITLE: SupaflyFPV Freestyle 5 Inch
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Supafly, SupaflyFPV, 4S, 6S, Freestyle, 5 inch, 5"
+#$ AUTHOR: SupaflyFPV
+#$ DESCRIPTION: SupaflyFPV Community Freestyle Preset for 5 Inch Builds
+#$ DESCRIPTION:
+#$ DESCRIPTION: Select the option for your build with or without HD camera (eg GoPro) as the baseline.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Half to one click up or down Master Slider to tweak the tune - in OSD or Configurator.
+#$ DESCRIPTION:
+#$ DESCRIPTION: For a Master Slider setting tailored to your Lipo and Motor Kv go here: https://tinyurl.com/SupaflyFPV
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM Filtering for best performance (default) - or de-select for Non RPM Setup (check esc compatibility).
+#$ DESCRIPTION:
+#$ DESCRIPTION: If using F7/H7 Flight Controller run 8k Pidloop and turn off Gyro Low Pass Filter 2 for max performance.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Enjoy!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/124
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Non-RPM Filtering --
+
+set dshot_bidir = OFF
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 300
+set gyro_lpf1_dyn_max_hz = 600
+set dyn_notch_count = 3
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 800
+
+# -- Dterm filtering --
+
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 0
+set dterm_lpf1_dyn_max_hz = 0
+set dterm_lpf1_dyn_expo = 0
+set dterm_lpf1_static_hz = 80
+set dterm_lpf2_static_hz = 140
+
+#$ OPTION BEGIN (CHECKED): RPM filtering
+    set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set simplified_gyro_filter = OFF
+    set rpm_filter_harmonics = 1
+    set gyro_lpf2_static_hz = 1000
+    set gyro_lpf1_dyn_min_hz = 300
+    set gyro_lpf1_dyn_max_hz = 600
+    set gyro_lpf1_dyn_expo = 8
+    set dyn_notch_count = 2
+    set dyn_notch_q = 400
+    set dyn_notch_min_hz = 100
+    set dyn_notch_max_hz = 800
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): 4s Lipo with HD Cam (2400-2700kv motors)
+    # -- Sliders --
+    set simplified_master_multiplier = 120
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 110
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 95
+    set simplified_pitch_pi_gain = 115
+    simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 4s Lipo with No HD Cam (2400-2700kv motors)
+    # -- Sliders --
+    set simplified_master_multiplier = 120
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 110
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 90
+    simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 6s Lipo with HD Cam (1750 - 1950kv motors)
+    # -- Sliders --
+    set simplified_master_multiplier = 100
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 115
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_pi_gain = 110
+    simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): 6s Lipo with No HD Cam (1750 - 1950kv motors)
+    # -- Sliders --
+    set simplified_master_multiplier = 100
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 115
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 95
+    simplified_tuning apply
+#$ OPTION END

--- a/presets/4.4/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
+++ b/presets/4.4/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
@@ -1,0 +1,83 @@
+#$ TITLE: SupaflyFPV Freestyle 6 Inch
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Supafly, SupaflyFPV, Freestyle, 6", 6 Inch
+#$ AUTHOR: SupaflyFPV
+#$ DESCRIPTION: SupaflyFPV Community Freestyle Preset for 6 Inch Builds
+#$ DESCRIPTION:
+#$ DESCRIPTION: Select the option for your build with or without HD camera (eg GoPro) as the baseline.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Half to one click up or down Master Slider to tweak the tune - in OSD or Configurator.
+#$ DESCRIPTION:
+#$ DESCRIPTION: For a Master Slider setting tailored to your Lipo and Motor Kv go here: https://tinyurl.com/SupaflyFPV
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM Filtering for best performance (default) - or de-select for Non RPM Setup (check esc compatibility).
+#$ DESCRIPTION:
+#$ DESCRIPTION: If using F7/H7 Flight Controller run 8k Pidloop and turn off Gyro Low Pass Filter 2 for max performance.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Enjoy!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/124
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Non-RPM Filtering --
+
+set dshot_bidir = OFF
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 120
+set gyro_lpf1_dyn_max_hz = 350
+set dyn_notch_count = 4
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 800
+
+# -- Dterm filtering --
+
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 0
+set dterm_lpf1_dyn_max_hz = 0
+set dterm_lpf1_dyn_expo = 0
+set dterm_lpf1_static_hz = 80
+set dterm_lpf2_static_hz = 140
+
+#$ OPTION BEGIN (CHECKED): RPM filtering
+    set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set simplified_gyro_filter = OFF
+    set gyro_lpf2_static_hz = 1000
+    set gyro_lpf1_dyn_min_hz = 120
+    set gyro_lpf1_dyn_max_hz = 350
+    set dyn_notch_count = 2
+    set dyn_notch_q = 300
+    set dyn_notch_min_hz = 100
+    set dyn_notch_max_hz = 800
+    set rpm_filter_harmonics = 3
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): With HD Cam
+    # -- Sliders --
+    set simplified_master_multiplier = 130
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 115
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 105
+    set simplified_pitch_pi_gain = 110
+    simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Without HD Cam
+    # -- Sliders --
+    set simplified_master_multiplier = 130
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 115
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 95
+    simplified_tuning apply
+#$ OPTION END

--- a/presets/4.4/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
+++ b/presets/4.4/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
@@ -1,0 +1,84 @@
+#$ TITLE: SupaflyFPV Freestyle 7 Inch
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: Supafly, SupaflyFPV, Freestyle, 7", 7 Inch
+#$ AUTHOR: SupaflyFPV
+#$ DESCRIPTION: SupaflyFPV Community Freestyle Preset for 7 Inch Builds
+#$ DESCRIPTION:
+#$ DESCRIPTION: Select the option for your build with or without HD camera (eg GoPro) as the baseline.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Half to one click up or down Master Slider to tweak the tune - in OSD or Configurator.
+#$ DESCRIPTION:
+#$ DESCRIPTION: For a Master Slider setting tailored to your Lipo and Motor Kv go here: https://tinyurl.com/SupaflyFPV
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM Filtering for best performance (default) - or de-select for Non RPM Setup (check esc compatibility).
+#$ DESCRIPTION:
+#$ DESCRIPTION: If using F7/H7 Flight Controller run 8k Pidloop and turn off Gyro Low Pass Filter 2 for max performance.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Enjoy!
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/124
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Non-RPM Filtering --
+
+set dshot_bidir = OFF
+set simplified_gyro_filter = OFF
+set gyro_lpf2_static_hz = 1000
+set gyro_lpf1_dyn_min_hz = 120
+set gyro_lpf1_dyn_max_hz = 350
+set dyn_notch_count = 5
+set dyn_notch_q = 300
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 800
+
+# -- Dterm filtering --
+
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 0
+set dterm_lpf1_dyn_max_hz = 0
+set dterm_lpf1_dyn_expo = 0
+set dterm_lpf1_static_hz = 80
+set dterm_lpf2_static_hz = 140
+
+#$ OPTION BEGIN (CHECKED): RPM filtering
+    set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set simplified_gyro_filter = OFF
+    set gyro_lpf2_static_hz = 1000
+    set gyro_lpf1_dyn_min_hz = 120
+    set gyro_lpf1_dyn_max_hz = 350
+    set dyn_notch_count = 2
+    set dyn_notch_q = 300
+    set dyn_notch_min_hz = 100
+    set dyn_notch_max_hz = 800
+    set rpm_filter_harmonics = 3
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): With HD Cam
+    # -- Sliders --
+    set simplified_master_multiplier = 140
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 115
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 105
+    set simplified_pitch_pi_gain = 110
+    simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Without HD Cam
+    # -- Sliders --
+    set simplified_master_multiplier = 140
+    set simplified_i_gain = 75
+    set simplified_d_gain = 110
+    set simplified_pi_gain = 115
+    set simplified_dmax_gain = 0
+    set simplified_feedforward_gain = 90
+    set simplified_pitch_d_gain = 95
+    set simplified_pitch_pi_gain = 105
+    simplified_tuning apply
+#$ OPTION END


### PR DESCRIPTION
A simple port for @SupaflyFPV presets to 4.4
Mostly copy-paste. Changes:

- include 4.4 tune defaults
- removing AG values, leaving them 4.4 defaults
- changing all to experimental (till 4.4 AG values are defined and tested)
- indentation

Read more about the new 4.4 AG:
https://github.com/betaflight/betaflight/pull/11679