### PR TITLE
Ported mouseFPV tunes 4.3->4.4, removed AG values

### DIFF
--- a/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -1,0 +1,201 @@
+#$ TITLE:  AOS 3.5 V1 4s Tune | mouseFPV
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: AOS, 4s, freestyle, sub 250
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for AOS 3.5
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * May be appropriate for v2 frame and/or different motors/cell counts
+#$ DESCRIPTION: * Tune/Filters are aggressive, and may not be appropriate for non trussed/braced frames
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION: * Uses Multi-Dynamic notich by default. Options for RPM filtering which use Dshot. Using DShot on Unsupported ESC's is Dangerous. See Warning.
+#$ DESCRIPTION: * RPM Filtering is recommended
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). enables gyro LPF 2.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3.5"
+#$ DESCRIPTION: * **95% Motor Limit:** Takes some of the spice out of powerful motors on 4s
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created on:
+#$ DESCRIPTION: * **Frame:** AOS 3.5 V1
+#$ DESCRIPTION: * **Motors:** FPVCycle 16mm (4s 95% Motor Limit)
+#$ DESCRIPTION: * **FC/ESC:** Foxeer Reaper f7 AIO
+#$ DESCRIPTION: * **AUW:** 243g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION:
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/247
+#$ WARNING: If You Choose To Include RPM Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ FORCE_OPTIONS_REVIEW: TRUE
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# ------- End Defaults --------
+# ----- Begin Mouse Tune-------
+
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 130
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 60
+set simplified_dmax_gain = 000
+set simplified_i_gain = 80
+set simplified_pitch_d_gain = 105
+set simplified_pitch_pi_gain = 105
+set simplified_master_multiplier = 145
+simplified_tuning apply
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Thrust linear --
+set thrust_linear = 20
+
+# -- DShot Idle --
+# Commonly set lower when dynamic idle is active.
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set gyro_lpf2_static_hz = 0
+set simplified_gyro_filter = OFF
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 3
+set dyn_notch_q = 425
+set dyn_notch_min_hz = 150
+set dyn_notch_max_hz = 600
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 125
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+# This is where the author includes options that require input from the User
+
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+    #$ OPTION BEGIN (CHECKED): RPM Filters (F7 & Up)?
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # ------- End Defaults --------
+        # ----- Begin Mouse Tune-------
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set gyro_lpf2_static_hz = 0
+        set simplified_gyro_filter = off
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 125
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 125
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters (F4)?
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # ------- End Defaults --------
+        # ----- Begin Mouse Tune-------
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT300
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter_multiplier = 200
+        set simplified_gyro_filter = on
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 125
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 125
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 25
+        set dyn_idle_p_gain = 50
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): 95% Motor Limit
+        set motor_output_limit = 95
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+#$ OPTION_GROUP END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -1,0 +1,296 @@
+#$ TITLE: Braced Toothpick/Digipick 3s/4s | mouseFPV
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle TP3, Digipick, Toothpick, 3s, 3 Inch, 4s, AOS T3, T3
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for Digital FPVCycle Toothpick 3 **with braces**
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * **NOT** APPROPRIATE FOR A TP3 Frame *Without* Carbon Braces/Trusses
+#$ DESCRIPTION: * Defaults to PIDS made for 3s
+#$ DESCRIPTION: * Only flash If you have a Braced TP3, an AOS-T3, or a toothpick frame with braces/trusses/additional arm struts.
+#$ DESCRIPTION: * FOR SIDE MOUNT LIPOS ONLY, Experimental options for front-back lipos
+#$ DESCRIPTION: * Lipo Orientation very important
+#$ DESCRIPTION: * My filters are strongly encouraged. These gains will be high if your filtering is inadequate. Frame is noisy below 150hz.
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Goals:
+#$ DESCRIPTION: * The toothpick class of frames has a small weight window before things get out of control. The target weight is usually about 100g.
+#$ DESCRIPTION: * When you go digital and add weight to the quad, things get a bit unstable. You would usually increase the PID's to make up for this, however a normal toothpick frame cannot handle this.
+#$ DESCRIPTION: * If you brace the arms, or the frame has a design that incorporates a trussed arm system, you can push the gains much higher and get a far better flying craft.
+#$ DESCRIPTION: * This tune is made to specifically push the pids beyond the boundary of what most "standard" arm toothpick class quads would normally handle.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ###  Filters:
+#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually).
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### Additional Options:
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3"
+#$ DESCRIPTION: * **Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **86% Motor Limit:** Sets a motor limit for 5000kv motors on 4s
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### PID Options (Default/None is Standard Lipo 3s):
+#$ DESCRIPTION: * **Standard Lipo 4s:** Applies Pids made for the additional weight and power of 4s. Strongly Recommend a Motor Limit if over 4000kv
+#$ DESCRIPTION: * **Front-Back Lipo 3s:** The FPVCycle TP3 frame has a side mount lipo. Try this if you choose to mount the lipo front to back for 3s pids. Experimental.
+#$ DESCRIPTION: * **Front-Back Lipo 4s:** The FPVCycle TP3 frame has a side mount lipo. Try this if you choose to mount the lipo front to back for 4s pids. Experimental.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### Auto Profiles:
+#$ DESCRIPTION: * **Auto Switch 3s Profile:** Will Activate the chosen PID Profile when plugging in 3s lipo. Choose this with 3s settings.
+#$ DESCRIPTION: * **Auto Switch 4s Profile:** Will Activate the chosen PID Profile when plugging in 4s lipo. Choose this with 4s settings.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created On (3s):
+#$ DESCRIPTION: * **Frame:** FPVCycle TP3 With Braces
+#$ DESCRIPTION: * **Motors:** FPVCycle 13mm 5000kv 3s, no motor limit
+#$ DESCRIPTION: * **FC/ESC:** Flywoo GOKU GNF745 40a
+#$ DESCRIPTION: * **Lipo:** GNB 500mah 3s
+#$ DESCRIPTION: * **AUW:** 121g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created On (4s):
+#$ DESCRIPTION: * **Frame:** FPVCycle TP3 With Braces
+#$ DESCRIPTION: * **Motors:** FPVCycle 13mm 5000kv 4s, 86% motor limit
+#$ DESCRIPTION: * **FC/ESC:** Flywoo GOKU GNF745 40a
+#$ DESCRIPTION: * **Lipo:** Tattu 450mah 4s
+#$ DESCRIPTION: * **AUW:** 131g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION:
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/274
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 125
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 55
+set simplified_dmax_gain = 000
+set simplified_i_gain = 75
+set simplified_pitch_d_gain = 80
+set simplified_pitch_pi_gain = 85
+set simplified_master_multiplier = 170
+simplified_tuning apply
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Thrust linear  --
+set thrust_linear = 20
+
+# -- DShot Idle (default)--
+# Commonly set lower when dynamic idle is active.
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 400
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 550
+
+# -- Dterm filtering --
+set simplified_dterm_filter = on
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+        # -- End Defaults --
+        # -- Begin Mouse Tune --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = on
+        set simplified_gyro_filter_multiplier = 150
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 100
+        set dyn_notch_max_hz = 550
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 100
+        set rpm_filter_fade_range_hz = 60
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+        # -- End Defaults --
+        # -- Begin Mouse Tune --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DShot300
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = on
+        set simplified_gyro_filter_multiplier = 150
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 100
+        set dyn_notch_max_hz = 550
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 100
+        set rpm_filter_fade_range_hz = 60
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 30
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Battery Sag Compensation
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): 86% Motor Limit (4s)
+         # -- Motor Output Limit for 4s --
+        set motor_output_limit = 86
+     #$ OPTION END
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: PID Options (Choose One or None)
+
+    #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 130
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 55
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 75
+        set simplified_pitch_d_gain = 80
+        set simplified_pitch_pi_gain = 80
+        set simplified_master_multiplier = 150
+        simplified_tuning apply
+        
+    #$ OPTION END
+
+
+    #$ OPTION BEGIN (UNCHECKED): Front-Back Lipo 3s (experimental, flips pitch/roll)
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 125
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 55
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 75
+        set simplified_pitch_d_gain = 100
+        set simplified_pitch_pi_gain = 110
+        set simplified_master_multiplier = 150
+        simplified_tuning apply
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Front-Back Lipo 4s (experimental, flips pitch/roll)
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 145
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 55
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 75
+        set simplified_pitch_d_gain = 95
+        set simplified_pitch_pi_gain = 115
+        set simplified_master_multiplier = 125
+        simplified_tuning apply
+
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Auto Profiles (Choose One or None)
+    #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
+        set auto_profile_cell_count = 3
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Auto Switch 4s Profile
+        set auto_profile_cell_count = 4
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -1,0 +1,231 @@
+#$ TITLE:  FPVCycle Incisor/Prototype 5 6s Tune | mouseFPV
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle, 5 inch, 5in, 6S, freestyle, GoPro, mouse fpv
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for FPVCycle Incisor/Prototype 5
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * If tune is too spicy, lower the master by a click or bring in a motor limit
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION: * Uses Multi-Dynamic notich by default. Options for RPM filtering which use Dshot. Using DShot on Unsupported ESC's is Dangerous. See Warning.
+#$ DESCRIPTION: * RPM Filtering is recommended
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually).
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"
+#$ DESCRIPTION: * **Set 93% Motor Limit:** Simulates 1800-1900kv motors down closer to 1700kv
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **Heavy Action Camera:** Increases the Pids/Master Slider
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created On:
+#$ DESCRIPTION: * **Frame:** FPVCycle Incisor/PT5
+#$ DESCRIPTION: * **Motors:** FPVCycle 25mm Emerald 1880kv w/ 93 % Motor Limit 6s
+#$ DESCRIPTION: * **FC:** TMotor F7 (MPU6000)
+#$ DESCRIPTION: * **ESC:** TMotor F55a (non f3)
+#$ DESCRIPTION: * **Action Cam:** GoPro Hero 5 Session
+#$ DESCRIPTION: * **AUW:** 660-670g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION: * Set Feedforward Boost (feedforward_boost) to 10
+#$ DESCRIPTION:
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/254
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 135
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 70
+set simplified_dmax_gain = 000
+set simplified_i_gain = 090
+set simplified_pitch_d_gain = 110
+set simplified_pitch_pi_gain = 115
+set simplified_master_multiplier = 110
+simplified_tuning apply
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 75
+
+# -- Thrust linear  --
+set thrust_linear = 20
+
+
+# -- DShot Idle (default)--
+# Commonly set lower when dynamic idle is active.
+set dshot_idle_value = 400
+
+
+# -- Filters for non bi-directional setups as a base--
+
+
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 140
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 375
+set dyn_notch_min_hz = 125
+set dyn_notch_max_hz = 600
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 93
+set dterm_lpf1_dyn_max_hz = 187
+set dterm_lpf1_dyn_expo = 5
+set dterm_lpf1_static_hz = 93
+set dterm_lpf2_static_hz = 187
+
+# -- Dterm sliders --
+set simplified_dterm_filter_multiplier = 125
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+
+
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+        # -- Filter Settings --
+
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 14
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = ON
+        set simplified_gyro_filter_multiplier = 140
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 125
+        set rpm_filter_fade_range_hz = 60
+
+        # -- Dterm filtering --
+        set dterm_lpf1_dyn_min_hz = 93
+        set dterm_lpf1_dyn_max_hz = 187
+        set dterm_lpf1_dyn_expo = 5
+        set dterm_lpf1_static_hz = 93
+        set dterm_lpf2_static_hz = 187
+
+        # -- Dterm sliders --
+        set simplified_dterm_filter_multiplier = 125
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+        # -- Filter Settings --
+
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT300
+        set dshot_bidir = ON
+        set motor_poles = 14
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = ON
+        set simplified_gyro_filter_multiplier = 140
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 125
+        set rpm_filter_fade_range_hz = 60
+
+
+        # -- Dterm sliders --
+        set simplified_dterm_filter = ON
+        set simplified_dterm_filter_multiplier = 125
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 20
+        set dyn_idle_p_gain = 45
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Set 93% Motor Limit
+        set motor_output_limit = 93
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Heavy Action Cam (Hero8/9/10)
+        set simplified_master_multiplier = 120
+        simplified_tuning apply
+    #$ OPTION END
+#$ OPTION_GROUP END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -1,0 +1,205 @@
+#$ TITLE:  FPVCycle Sonicare 6s Tune | mouseFPV
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for FPVCycle Sonicare
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * This was tuned on a very light quad. If you are over 670g maybe try the Heavy Action Cam Option. YMMV.
+#$ DESCRIPTION: * 20mm and 25mm Stacks (as supported by this frame) may have inadequate capacitance. 1000uf 35v Cap on ESC leads *and* 200-470uf 35v on FC Vbatt rail recommended.
+#$ DESCRIPTION: * Recommended 48k PWM.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). Enables gyro LPF 2.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"
+#$ DESCRIPTION: * **93% Motor Limit:** Simulates 1800-1900kv motors down closer to 1700kv
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **Heavy Action Camera:** Increases the Pids/Master Slider
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Build Specs This Was Created on:
+#$ DESCRIPTION: * **Frame:** FPVCycle Sonicare
+#$ DESCRIPTION: * **Motors:** iFlight Xing2 2306 1755kv (6s)
+#$ DESCRIPTION: * **FC:** DarwinFPV Whoop Mount (MPU6000)
+#$ DESCRIPTION: * **ESC:** DarwinFPV Whoop Mount 45a
+#$ DESCRIPTION: * **Action Cam:** GoPro Hero 5 Session
+#$ DESCRIPTION: * **AUW:** 620-640g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION:
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/275
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 120
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 60
+set simplified_dmax_gain = 000
+set simplified_i_gain = 090
+set simplified_pitch_d_gain = 105
+set simplified_pitch_pi_gain = 115
+set simplified_master_multiplier = 135
+simplified_tuning apply
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Thrust linear  --
+set thrust_linear = 20
+
+# -- DShot Idle --
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 3
+set dyn_notch_q = 375
+set dyn_notch_min_hz = 150
+set dyn_notch_max_hz = 600
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+
+#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 14
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set gyro_lpf2_static_hz = 0
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 150
+        set rpm_filter_fade_range_hz = 75
+
+        # -- Dterm sliders --
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT300
+        set dshot_bidir = ON
+        set motor_poles = 14
+
+        # -- Gyro lowpass filters --
+        # -- No Gyro Lowpass
+        set gyro_lpf1_static_hz = 0
+        set gyro_lpf1_dyn_min_hz = 0
+        set gyro_lpf1_dyn_max_hz = 0
+        set simplified_gyro_filter = ON
+        set simplified_gyro_filter_multiplier = 200
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 150
+        set rpm_filter_fade_range_hz = 75
+
+        # -- Dterm sliders --
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 20
+        set dyn_idle_p_gain = 45
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): 93% Motor Limit (Use this if its too spicy)
+        set motor_output_limit = 93
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Heavy Action Cam (Hero8/9/10)
+            set simplified_master_multiplier = 150
+            simplified_tuning apply
+    #$ OPTION END
+
+#$ OPTION_GROUP END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -1,0 +1,214 @@
+#$ TITLE:  FPVCycle Toothpick 3 3s | mouseFPV
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FPVCycle TP3, Toothpick, 3s, 3 inch
+#$ AUTHOR: mouseFPV
+#$ PARSER: MARKED
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174462482-28bdcfec-1c3a-43db-99d7-50688b92f050.svg" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: # Tune for Toothpick 3
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## About:
+#$ DESCRIPTION: * These gains will be high if your filtering is inadequate. Frame is noisey below 150hz
+#$ DESCRIPTION: * FOR SIDE MOUNT LIPOS ONLY, Experimental option for front-back lipos
+#$ DESCRIPTION: * Lipo Orientation very important
+#$ DESCRIPTION: * Recommended 48k PWM
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Options:
+#$ DESCRIPTION: ### **Filters:**
+#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually).
+#$ DESCRIPTION:
+#$ DESCRIPTION: ### **Additional Options:**
+#$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3"
+#$ DESCRIPTION: * **Enable Battery Sag Compensation:** Self Explanatory (see tooltip). Land at 3.5v/Cell or it's a bad time.
+#$ DESCRIPTION: * **Front-Back Lipo:** The FPVCycle TP3 frame has a side mount lipo. Try this if you choose to mount the lipo front to back. Experimental.
+#$ DESCRIPTION:
+#$ DESCRIPTION: ##  Build Specs This Was Created on:
+#$ DESCRIPTION: * **Frame:** FPVCycle TP3
+#$ DESCRIPTION: * **Motors:** FPVCycle 13mm 5000kv 3s
+#$ DESCRIPTION: * **FC/ESC:** Flywoo GOKU GNF411 40a
+#$ DESCRIPTION: * **AUW:** 103g
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Fly Like mouseFPV | Recommendations Outside of Tune:
+#$ DESCRIPTION: * Apply mouseFPV Freestyle Rates
+#$ DESCRIPTION: * Use 250hz radio link if possible
+#$ DESCRIPTION: * **Set Jitter Reduction (feedforward_jitter_factor) to 14**
+#$ DESCRIPTION:
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/269
+#$ WARNING: If You Choose To Include Filters, Please, See The Following:
+#$ FORCE_OPTIONS_REVIEW: TRUE
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- End Defaults --
+# -- Begin Mouse Tune --
+
+# -- PID Sliders  --
+set simplified_pids_mode = RPY
+set simplified_d_gain = 130
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 70
+set simplified_dmax_gain = 000
+set simplified_i_gain = 80
+set simplified_pitch_d_gain = 75
+set simplified_pitch_pi_gain = 80
+set simplified_master_multiplier = 135
+simplified_tuning apply
+
+
+# -- iTerm relax --
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 10
+
+# -- TPA  --
+set tpa_rate = 70
+
+# -- Thrust linear (off, default) --
+set thrust_linear = 20
+
+# -- DShot Idle (default)--
+# Commonly set lower when dynamic idle is active.
+set dshot_idle_value = 400
+
+# -- Filters for non bi-directional setups as a base--
+
+# -- Gyro lowpass filters --
+# -- No Gyro Lowpass
+set simplified_gyro_filter = on
+set simplified_gyro_filter_multiplier = 150
+simplified_tuning apply
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 4
+set dyn_notch_q = 325
+set dyn_notch_min_hz = 100
+set dyn_notch_max_hz = 600
+
+# -- Dterm filtering --
+
+# -- Dterm sliders --
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 115
+simplified_tuning apply
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 100
+
+
+
+# ------ OPTIONS GO BELOW THIS LINE ------
+
+
+# This is where the author includes options that require input from the User
+    #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+        # -- Filter Settings --
+
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT600
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+        set simplified_gyro_filter = on
+        set simplified_gyro_filter_multiplier = 150
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 450
+        set dyn_notch_min_hz = 100
+        set dyn_notch_max_hz = 550
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 100
+        set rpm_filter_fade_range_hz = 50
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+        # -- Filter Settings --
+
+        #$ INCLUDE: presets/4.3/filters/defaults.txt
+
+        # -- End Defaults --
+        # -- Begin Mouse Filters --
+
+        # enable dshot rpm telemetry
+        set motor_pwm_protocol = DSHOT300
+        set dshot_bidir = ON
+        set motor_poles = 12
+
+        # -- Gyro lowpass filters --
+
+        set simplified_gyro_filter = on
+        set simplified_gyro_filter_multiplier = 150
+        simplified_tuning apply
+
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 450
+        set dyn_notch_min_hz = 100
+        set dyn_notch_max_hz = 550
+
+        # -- RPM filtering --
+        set rpm_filter_q = 500
+        set rpm_filter_min_hz = 100
+        set rpm_filter_fade_range_hz = 50
+        set rpm_filter_harmonics = 3
+
+        # -- Dterm filtering --
+        set simplified_dterm_filter = on
+        set simplified_dterm_filter_multiplier = 115
+        simplified_tuning apply
+
+        # -- Yaw lowpass --
+        set yaw_lowpass_hz = 100
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Additional Options (Choose Many or None)
+    #$ OPTION BEGIN (CHECKED): Dynamic Idle
+        set dyn_idle_min_rpm = 30
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Enable Battery Sag Compensation?
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Front-Back Lipo (experimental, flips pitch/roll gains)
+        # -- PID Sliders  --
+        set simplified_pids_mode = RPY
+        set simplified_d_gain = 130
+        set simplified_pi_gain = 100
+        set simplified_feedforward_gain = 70
+        set simplified_dmax_gain = 000
+        set simplified_i_gain = 95
+        set simplified_pitch_d_gain = 105
+        set simplified_pitch_pi_gain = 115
+        set simplified_master_multiplier = 115
+        simplified_tuning apply
+    #$ OPTION END
+#$ OPTION_GROUP END


### PR DESCRIPTION
A simple port for @rochford77 (mouseFPV) presets to 4.4
Mostly copy-paste. Changes:

- include 4.4 tune defaults
- removing AG values, leaving them 4.4 defaults
- indentation

Read more about the new 4.4 AG:
https://github.com/betaflight/betaflight/pull/11679