### PR TITLE
Llama 5in MultiVoltage Mega Tune - Fix Spicy Tune RPM Filter Fade Range to 77

### DIFF
--- a/presets/4.4/other/Tehllama_5in_Race_Multivoltage.txt
+++ b/presets/4.4/other/Tehllama_5in_Race_Multivoltage.txt
@@ -158,7 +158,7 @@
 			set rpm_filter_harmonics = 2
 			set rpm_filter_q = 750
 			set rpm_filter_min_hz = 133
-			set rpm_filter_fade_range_hz = 111
+			set rpm_filter_fade_range_hz = 77
 	#$ OPTION END
 
 	#$ OPTION BEGIN (UNCHECKED): Use Non-RPM Filters on All Profiles (Not Recommended)


### PR DESCRIPTION
Did some more testing, the spicy tune filter fade range at 111Hz  was a little bit too spicy for my liking - if a pilot wants to run a more aggressive tune than this, they would be better off running Karate or MCK.

Matching Revision coming for the Llama-5in-SpecOnly