### PR TITLE
Update outdate f4/f7 comments, move presets to COMMUNITY

### DIFF
--- a/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE:  AOS 3.5 V1 4s Tune | mouseFPV
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: AOS, 4s, freestyle, sub 250
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -19,8 +19,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ### **Filters:**
-#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). enables gyro LPF 2.
+#$ DESCRIPTION: * **RPM Filters DSHOT600:** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F7 or better, sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DSHOT300:** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F4 or better, sets Dshot300, enables gyro LPF 2 Due to DSHOT300 often run on half loop rate.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### **Additional Options:**
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3.5"
@@ -109,7 +109,7 @@ set yaw_lowpass_hz = 100
 
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
 
-#$ OPTION BEGIN (CHECKED): RPM Filters (F7 & Up)?
+#$ OPTION BEGIN (CHECKED): RPM Filters DSHOT600
 #$ INCLUDE: presets/4.3/filters/defaults.txt
 
 # ------- End Defaults --------
@@ -148,7 +148,7 @@ simplified_tuning apply
 set yaw_lowpass_hz = 100
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): RPM Filters (F4)?
+#$ OPTION BEGIN (UNCHECKED): RPM Filters DSHOT300
 #$ INCLUDE: presets/4.3/filters/defaults.txt
 
 # ------- End Defaults --------

--- a/presets/4.3/tune/mouseFPV_Digipick_braced.txt
+++ b/presets/4.3/tune/mouseFPV_Digipick_braced.txt
@@ -1,7 +1,7 @@
 #$ TITLE: Braced Toothpick/Digipick 3s/4s | mouseFPV
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: FPVCycle TP3, Digipick, Toothpick, 3s, 3 Inch, 4s, AOS T3, T3
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -27,8 +27,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ###  Filters:
-#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually). 
+#$ DESCRIPTION: * **RPM Filters DShot600**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DShot300**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot300, enables gyro LPF 2 Due to DSHOT300 often run on half loop rate.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### Additional Options:
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3"
@@ -134,7 +134,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
 
-    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
         # -- Begin Mouse Tune --
 
@@ -174,7 +174,7 @@ set yaw_lowpass_hz = 100
 
     #$ OPTION END
 
-    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300
         # -- End Defaults --
         # -- Begin Mouse Tune --
 

--- a/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE:  FPVCycle Incisor/Prototype 5 6s Tune | mouseFPV 
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: FPVCycle, 5 inch, 5in, 6S, freestyle, GoPro, mouse fpv
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -18,8 +18,8 @@
 #$ DESCRIPTION: 
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ### **Filters:**
-#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually). 
+#$ DESCRIPTION: * **RPM Filters DShot600**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DShot300**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot300.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### **Additional Options:**
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"
@@ -118,7 +118,7 @@ set yaw_lowpass_hz = 100
 
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
 
-#$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+#$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -167,7 +167,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION END
 
 
-#$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+#$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300
 # -- Filter Settings --
 
 #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE:  FPVCycle Sonicare 6s Tune | mouseFPV 
 #$ FIRMWARE_VERSION: 4.3
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: FPVCycle
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -17,8 +17,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ### **Filters:**
-#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). Enables gyro LPF 2.
+#$ DESCRIPTION: * **RPM Filters DShot300:** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, Sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DShot600:** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, Sets Dshot300, enables gyro LPF 2 Due to DSHOT300 often run on half loop rate.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### **Additional Options:**
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
 
-    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 
         # -- End Defaults --
@@ -142,7 +142,7 @@ set yaw_lowpass_hz = 100
     #$ OPTION END
 
 
-    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 
         # -- End Defaults --

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE:  AOS 3.5 V1 4s Tune | mouseFPV
 #$ FIRMWARE_VERSION: 4.4
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: AOS, 4s, freestyle, sub 250
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -19,8 +19,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ### **Filters:**
-#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). enables gyro LPF 2.
+#$ DESCRIPTION: * **RPM Filters DSHOT600:** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F7 or better, sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DSHOT300:** Enables RPM filtering. ESCs must support bi-directional. sets motor poles to 12, For F4 or better, sets Dshot300, enables gyro LPF 2 Due to DSHOT300 often run on half loop rate.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### **Additional Options:**
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3.5"
@@ -105,7 +105,7 @@ set yaw_lowpass_hz = 100
 # This is where the author includes options that require input from the User
 
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
-    #$ OPTION BEGIN (CHECKED): RPM Filters (F7 & Up)?
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 
         # ------- End Defaults --------
@@ -144,7 +144,7 @@ set yaw_lowpass_hz = 100
         set yaw_lowpass_hz = 100
     #$ OPTION END
 
-    #$ OPTION BEGIN (UNCHECKED): RPM Filters (F4)?
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 
         # ------- End Defaults --------

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -1,7 +1,7 @@
 #$ TITLE: Braced Toothpick/Digipick 3s/4s | mouseFPV
 #$ FIRMWARE_VERSION: 4.4
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: FPVCycle TP3, Digipick, Toothpick, 3s, 3 Inch, 4s, AOS T3, T3
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -27,8 +27,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ###  Filters:
-#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot600**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DShot300**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot300, enables gyro LPF 2 Due to DSHOT300 often run on half loop rate.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### Additional Options:
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 3"
@@ -131,7 +131,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
 
-    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
         # -- Begin Mouse Tune --
 
@@ -171,7 +171,7 @@ set yaw_lowpass_hz = 100
 
     #$ OPTION END
 
-    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300
         # -- End Defaults --
         # -- Begin Mouse Tune --
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE:  FPVCycle Incisor/Prototype 5 6s Tune | mouseFPV
 #$ FIRMWARE_VERSION: 4.4
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: FPVCycle, 5 inch, 5in, 6S, freestyle, GoPro, mouse fpv
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -18,8 +18,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ### **Filters:**
-#$ DESCRIPTION: * **RPM Filters DShot600 (F7 & Up)**: Enables RPM filtering. ESCs must support bi-directional. For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters DShot300 (F4)**: Enables RPM filtering. ESCs must support bi-directional. For F4, sets Dshot300, 4k pidloop recommended (set manually).
+#$ DESCRIPTION: * **RPM Filters DShot600**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DShot300**: Enables RPM filtering. ESCs must support bi-directional. Sets Dshot300.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### **Additional Options:**
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"
@@ -117,7 +117,7 @@ set yaw_lowpass_hz = 100
 
 
 #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
-    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
+    #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 
         #$ INCLUDE: presets/4.3/filters/defaults.txt
@@ -165,7 +165,7 @@ set yaw_lowpass_hz = 100
     #$ OPTION END
 
 
-    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300 (F4)
+    #$ OPTION BEGIN (UNCHECKED): RPM Filters DShot300
         # -- Filter Settings --
 
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE:  FPVCycle Sonicare 6s Tune | mouseFPV
 #$ FIRMWARE_VERSION: 4.4
 #$ CATEGORY: TUNE
-#$ STATUS: EXPERIMENTAL
+#$ STATUS: COMMUNITY
 #$ KEYWORDS: FPVCycle
 #$ AUTHOR: mouseFPV
 #$ PARSER: MARKED
@@ -17,8 +17,8 @@
 #$ DESCRIPTION:
 #$ DESCRIPTION: ## Options:
 #$ DESCRIPTION: ### **Filters:**
-#$ DESCRIPTION: * **RPM Filters (F7 & Up):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F7 or better, sets Dshot600, 8k pidloop recommended (set manually).
-#$ DESCRIPTION: * **RPM Filters (F4):** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, For F4 or better, sets Dshot300, 4k pidloop recommended (set manually). Enables gyro LPF 2.
+#$ DESCRIPTION: * **RPM Filters DShot300:** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, Sets Dshot600.
+#$ DESCRIPTION: * **RPM Filters DShot600:** Enables RPM filtering. ESCs must support bi-directional. Sets motor poles to 14, Sets Dshot300, enables gyro LPF 2 Due to DSHOT300 often run on half loop rate.
 #$ DESCRIPTION:
 #$ DESCRIPTION: ### **Additional Options:**
 #$ DESCRIPTION: * **Dynamic Idle:** Enables Dynamic Idle for Freestyle 5"


### PR DESCRIPTION
Update outdated f4/f7 comments, move presets to COMMUNITY. This changes several files, but all changes are consistent to all the files, and none touch any actual commands, just labels, comments, and wording. Changes for both 4.3 and 4.4 presets.
