### PR TITLE
Add QuadMcFly 5in Freestyle Tune

### DIFF
--- a/presets/4.4/tune/quadmcfly/QuadMcFly_5_Inch_Freestyle.txt
+++ b/presets/4.4/tune/quadmcfly/QuadMcFly_5_Inch_Freestyle.txt
@@ -1,0 +1,86 @@
+#$ TITLE: QuadMcFly - 5" Freestyle with GoPro (Mid-Weight)
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 4S, 6S, 5in, 5", freestyle
+#$ AUTHOR: QuadMcFly (Ryan Harrell)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: QuadMcFly 5" Freestyle Tune (Mid Weight)
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION:
+#$ DESCRIPTION: <a href="https://www.youtube.com/c/QuadMcFlyFlies" target="_blank"><img src="https://www.miniquadtestbench.com/assets/images/me-small-dji.png" width="125px" style="float:left; margin-right: 25px; display: block;"/></a><br />
+#$ DESCRIPTION: After quite a while refining a base tune across multiple 5 inch setups I think I've gotten a very robust starting point that is worth sharing. This tune is designed to be somewhat conservative to handle things like dinged props and imperfect motors, but still handle well enough to minimize prop wash and feel sharp and connected.
+#$ DESCRIPTION: <br /><br /><br />
+#$ DESCRIPTION: 
+#$ DESCRIPTION: This should handle anything from around 650g up to close to 800g. Above 750g it might start feeling sluggish, but it should be a good starting point for any mid-weight 5 inch build. Only small adjustments to the P and D sliders should be necessary for most builds. This tune works well for me on both F4 and F7 processors at 8khz and Dshot 600. If you have a noisy ESC or ESCs with poorly designed input filtering you may need to drop to DShot 300, but otherwise it should be fine.
+#$ DESCRIPTION: <br /><br />
+#$ DESCRIPTION: <strong>This tune requires ESCs capable of RPM telemetry (BLheli 32, AM32, or BlueJay/JESC).</strong>
+#$ DESCRIPTION: 
+#$ DESCRIPTION: Suggested ESC settings are:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION:  - Timing: 23 degrees
+#$ DESCRIPTION:  - PWM: 48khz fixed (May also work with 24khz and ByRPM)
+#$ DESCRIPTION:
+#$ DESCRIPTION: Suggested Propellers:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION:  - Gemfan 51455 Hurricane X 
+#$ DESCRIPTION:  - Gemfan 51466 Hurricane
+#$ DESCRIPTION:
+#$ DESCRIPTION: Suggested Motors:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION:  - ~2500kv on 4S
+#$ DESCRIPTION:  - ~1700kv on 6S
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+
+#$ WARNING: This tune enables RPM filtering, Dynamic Idle, and Thrust Linear. I run fairly high Thrust Linear and Throttle Boost, so low throttle may be more agressive than some other tunes.
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/387
+
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- QuadMcFly PID Settings --
+set simplified_master_multiplier = 115
+set simplified_i_gain = 135
+set simplified_d_gain = 115
+set simplified_dmax_gain = 115
+set simplified_pitch_pi_gain = 105
+
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+set dyn_idle_min_rpm = 30
+set thrust_linear = 40
+set tpa_mode = PD
+set iterm_relax_cutoff = 12
+set simplified_gyro_filter_multiplier = 200
+set simplified_dterm_filter_multiplier = 120
+set motor_pwm_protocol = DSHOT600
+set dshot_bidir = ON
+
+#$ OPTION_GROUP BEGIN: Optional Settings (Choose Many or None)
+    
+    #$ OPTION BEGIN (UNCHECKED): 180 Degree Arm Angle
+        set small_angle = 180
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): 100% Battery Sag Compensation
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): QuadMcFly Magic Throttle Boost (15%)
+        set throttle_boost = 15
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): DSHOT 300 instead of 600
+            set motor_pwm_protocol = DSHOT300
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+simplified_tuning apply


### PR DESCRIPTION
Mid-weight freestyle build with options for Dshot 600 and Dshot 300. RPM Filtering required. Update from broken pull request #383 