### PR TITLE
Update Unify_Pro32_Nano_SA2_1 Power Levels.txt

### DIFF
--- a/presets/4.3/vtx/Unify_Pro32_Nano_SA2_1.txt
+++ b/presets/4.3/vtx/Unify_Pro32_Nano_SA2_1.txt
@@ -22,5 +22,5 @@ vtxtable band 3 BOSCAM_E E FACTORY 5705 5685 5665 5645 5885 5905 5925 5945
 vtxtable band 4 FATSHARK F FACTORY 5740 5760 5780 5800 5820 5840 5860 5880
 vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
 vtxtable powerlevels 4
-vtxtable powervalues 14 20 26 36
+vtxtable powervalues 14 20 26 28
 vtxtable powerlabels 25 100 400 MAX


### PR DESCRIPTION
The present value of 36 (1.6w) is for the Pro32 HV and not the Pro32 Nano. Corrected to 28 (500mw+) per TBS spec sheet.

