### PR TITLE
Add FrSky R9 RC link preset (FPORT, 6.67 ms mode)

### DIFF
--- a/presets/4.4/rc_link/FrSky R9 (6.67ms).txt
+++ b/presets/4.4/rc_link/FrSky R9 (6.67ms).txt
@@ -1,0 +1,131 @@
+#$ TITLE: FrSky R9 (6.67 ms)
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: RC_LINK
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: FrSky, R9, 6.67 ms, ACCESS, FPORT, rc, rx , link
+#$ AUTHOR: Jakub Espandr (FlyCamCzech)
+#$ DESCRIPTION: RC link settings for a 150 Hz (6.67 ms PWM) Frsky R9 FLEX ACCESS.
+
+#$ DESCRIPTION: WARNING: Make ABSOLUTELY SURE that the Hardware ADC Filter is unchecked in OpenTx/EdgeTx!
+#$ DESCRIPTION: WARNING: Check that you have selected 6.67 ms PWM mode in the model settings in the receiver tab (under Modules and Preferences)!
+#$ DESCRIPTION: WARNING: All cinematic settings are very smooth, resulting in a noticeable delay in stick response.
+#$ DESCRIPTION: WARNING: Frsky R9 module does not have a consistent packet rate, so 4-point FF averaging is required!
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: * Modern FrSky receivers use the FPORT protocol, which requires only a single cable that acts as RC command output from the receiver and telemetry input from the FC.
+#$ DESCRIPTION: * Due to the fact that FPORT is an uninverted protocol, when connecting the SPORT wire from RX to TX pin on the FC, you must choose the correct preset.
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: If you do not see any moving channels in the Receiver tab, check your connection (TX pin on FC).
+#$ DESCRIPTION: If you are sure that the connection is correct, you can try to play with serialrx_inverted = ON or OFF.
+
+
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+# Setup correct SerialRx port
+#$ OPTION_GROUP BEGIN: Port settings
+
+    #$ OPTION BEGIN (CHECKED): use SerialRx UART 1 (TX 1)
+        serial 0 64 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): use SerialRx UART 2 (TX 2)
+         serial 1 64 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): use SerialRx UART 3 (TX 3)
+        serial 2 64 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): use SerialRx UART 4 (TX 4)
+        serial 3 64 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): use SerialRx UART 5 (TX 5)
+        serial 4 64 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): use SerialRx UART 6 (TX 6)
+        serial 5 64 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): use SerialRx UART 7 (TX 7)
+        serial 6 64 115200 57600 0 115200
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+#$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+# Basic requirements for FrSky R9 FPORT receiver 
+set serialrx_provider = FPORT
+set serialrx_halfduplex = ON
+set feedforward_averaging = 4_POINT
+
+# Minimal settings for Frsky R9 in case option is not selected by the user
+set feedforward_smooth_factor = 30
+set feedforward_jitter_factor = 10
+
+# Setup of RC link smoothing
+#$ OPTION_GROUP BEGIN: RC smoothing
+
+    # Preset for racing, super small amount of filtering. (Not consistent R9 packet rate may appear in Setpoint traces):
+    #$ OPTION BEGIN (UNCHECKED): Racing
+    set feedforward_jitter_factor = 8
+    set rc_smoothing_auto_factor = 35
+    #$ OPTION END
+
+    # Preset for freestyle flights with small amount of filtering:
+    #$ OPTION BEGIN (UNCHECKED): Freestyle
+    set feedforward_smooth_factor = 25
+    set feedforward_jitter_factor = 9
+    set rc_smoothing_auto_factor = 40
+    set rc_smoothing_setpoint_cutoff = 25
+    set rc_smoothing_feedforward_cutoff = 25
+    #$ OPTION END
+
+    # Stronger smoothing for HD freestyle flight:
+    #$ OPTION BEGIN (UNCHECKED): HD Freestyle
+    set feedforward_smooth_factor = 30
+    set feedforward_jitter_factor = 10
+    set rc_smoothing_auto_factor = 80
+    set rc_smoothing_setpoint_cutoff = 20
+    set rc_smoothing_feedforward_cutoff = 20
+    #$ OPTION END
+
+
+    # Smooth Cinematic traces (producing some delay between TX command and Setpoint):
+    #$ OPTION BEGIN (UNCHECKED): Cinematic
+    set feedforward_smooth_factor = 35
+    set feedforward_jitter_factor = 12
+    set rc_smoothing_auto_factor = 170
+    set rc_smoothing_auto_factor_throttle = 100
+    set rc_smoothing_setpoint_cutoff = 12
+    set rc_smoothing_feedforward_cutoff = 12
+    set rc_smoothing_throttle_cutoff = 20
+    #$ OPTION END
+
+   # Super smooth Setpoint traces for Cinematic crusing and HD video recording:
+    #$ OPTION BEGIN (UNCHECKED): Super Cinematic
+    set feedforward_smooth_factor = 40
+    set feedforward_jitter_factor = 16
+    set rc_smoothing_auto_factor = 250
+    set rc_smoothing_auto_factor_throttle = 100
+    set rc_smoothing_setpoint_cutoff = 6
+    set rc_smoothing_feedforward_cutoff = 6
+    set rc_smoothing_throttle_cutoff = 20
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+# Setup correct inversion
+#$ OPTION_GROUP BEGIN: Port inversion
+
+    #$ OPTION BEGIN (CHECKED): RX: SPort pin connected on FC TX
+        set serialrx_inverted = ON
+    #$ OPTION END
+
+     #$ OPTION BEGIN (UNCHECKED): RX: Inverted SPort pin connected on FC TX
+        set serialrx_inverted = OFF
+    #$ OPTION END
+#$ OPTION_GROUP END


### PR DESCRIPTION
Due to missing FrSky R9 preset, I created RC LINK preset with modified setpoint and feedforward filtering.
I've included port selection, a choice connection the RX to the FC (Serial_RX_inversion), and various filtering options depending on intended flight style.