### PR TITLE
533 rates update + Headsup rates

### DIFF
--- a/presets/4.3/rates/533.txt
+++ b/presets/4.3/rates/533.txt
@@ -1,15 +1,24 @@
-#$ TITLE: Headsup racing rates
+#$ TITLE: 533 racing rates
 #$ FIRMWARE_VERSION: 4.3
 #$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
 #$ CATEGORY: RATES
 #$ STATUS: COMMUNITY
 #$ KEYWORDS: racing, Headsup, 533, five33, rates, MultiGP
 #$ AUTHOR: Evan Turner (Headsup)
-#$ DESCRIPTION: Famous 533 racing rates by Headsup - Evan Turner.
-#$ DESCRIPTION: Betaflight type of rates with 533 degrees/sec max on all three axes.
-#$ DESCRIPTION: Evan Turner - MultiGP Champion 2021, 2019 and 2018. MultiGP Internation Open Champion 2021 and 2021 DRL pilot.
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: <b>Evan flies slightly different rates now, check Headsup racing rates preset.</b><br />
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/2925027/265237661-ec5dcc2e-2ed8-46e3-a5c2-25c08c990450.png"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Legacy, famous 533 racing rates by Headsup - Evan Turner.<br />
+#$ DESCRIPTION: Betaflight type of rates with 533 degrees/sec max on all three axes.<br />
+#$ DESCRIPTION: Evan Turner - MultiGP Champion 2021, 2019 and 2018. MultiGP Internation Open Champion 2021 and 2021 DRL pilot.<br />
 #$ DESCRIPTION: Optional checkbox provides almost identical rates, but with the type = ACTUAL.
-#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/92/
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/410
+
 #$ INCLUDE: presets/4.3/rates/defaults.txt
 
 set rates_type = BETAFLIGHT

--- a/presets/4.3/rates/Headsup.txt
+++ b/presets/4.3/rates/Headsup.txt
@@ -1,0 +1,42 @@
+#$ TITLE: Headsup racing rates
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: RATES
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: racing, Headsup, 533, 633, five33, rates, MultiGP
+#$ AUTHOR: Evan Turner (Headsup)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/2925027/265237647-084a9dea-22b1-4093-8f5d-eae62ce45d66.png"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Racing rates by Headsup - Evan Turner.<br />
+#$ DESCRIPTION: Betaflight type of rates with 533 degrees/sec max on pitch and yaw, and 633 degrees/sec on roll.<br />
+#$ DESCRIPTION: Evan Turner - MultiGP Champion 2021, 2019 and 2018. MultiGP Internation Open Champion 2021 and 2021 DRL pilot.<br />
+#$ DESCRIPTION: Optional checkbox provides almost identical rates, but with the type = ACTUAL.
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/410
+
+#$ INCLUDE: presets/4.3/rates/defaults.txt
+
+set rates_type = BETAFLIGHT
+set roll_rc_rate = 95
+set pitch_rc_rate = 80
+set yaw_rc_rate = 80
+set roll_srate = 70
+set pitch_srate = 70
+set yaw_srate = 70
+
+#$ OPTION BEGIN (UNCHECKED): Actual rates analogue
+    set rates_type = ACTUAL
+	set roll_rc_rate = 17
+	set pitch_rc_rate = 14
+	set yaw_rc_rate = 14
+	set roll_expo = 50
+	set pitch_expo = 50
+	set yaw_expo = 50
+	set roll_srate = 63
+	set pitch_srate = 53
+	set yaw_srate = 53
+#$ OPTION END


### PR DESCRIPTION
Rates are almost identical, except Headsup flies 633 deg/sec for roll now.

Headsup rates:
![image](https://github.com/betaflight/firmware-presets/assets/2925027/084a9dea-22b1-4093-8f5d-eae62ce45d66)

Legacy 533 rates:
![image](https://github.com/betaflight/firmware-presets/assets/2925027/ec5dcc2e-2ed8-46e3-a5c2-25c08c990450)
