### PR TITLE
add spicy tune option to Karate 'lite' tune

### DIFF
--- a/presets/4.5/tune/karate/karate_race_lite.txt
+++ b/presets/4.5/tune/karate/karate_race_lite.txt
@@ -168,6 +168,41 @@ set tpa_breakpoint = 1250
 
 #$ OPTION_GROUP END
 
+#$ OPTION_GROUP BEGIN: Spicy Tune
+    #$ OPTION BEGIN (UNCHECKED): Spicy Filters
+        
+        # -- Gyro lowpass filters --
+        set gyro_lpf2_static_hz = 650
+        
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        
+        # -- RPM filtering --
+        set rpm_filter_harmonics = 2
+        
+        # -- Dterm filtering --
+        set dterm_lpf1_dyn_expo = 10
+        
+     #$ OPTION END
+    #$ OPTION BEGIN (UNCHECKED): Spicy PIDs (not for 6s)
+        
+        # -- PID values --
+        set simplified_pids_mode = RP
+        set simplified_master_multiplier = 110
+        set simplified_i_gain = 115
+        set simplified_d_gain = 75
+        set simplified_pi_gain = 85
+        set simplified_dmax_gain = 125
+        set simplified_pitch_d_gain = 90
+        set simplified_pitch_pi_gain = 110
+        simplified_tuning apply
+        
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
 #$ OPTION_GROUP BEGIN: Optional rates
     #$ OPTION BEGIN (UNCHECKED): sugarK's rates
         #$ INCLUDE: presets/4.3/rates/SugarK.txt


### PR DESCRIPTION
spicy tune and filter options for Karate 'lite' race tune. PIDS and filters are good for 4s viper lites the filters are fine for a 6s viper lite the PIDs are a bit too spicy for a 6s build

