### PR TITLE
Add TUNE to OTHER category

### DIFF
--- a/presets/4.4/other/100-euro-fpv-tune.txt
+++ b/presets/4.4/other/100-euro-fpv-tune.txt
@@ -149,7 +149,7 @@ set thrust_linear = 25
 #$ OPTION END
 
 #$ OPTION BEGIN (CHECKED): Min/max check 1000/2000
-    set min_check = 1000
+    set min_check = 1010
     set max_check = 2000
 #$ OPTION END
 

--- a/presets/4.4/other/100-euro-fpv-tune.txt
+++ b/presets/4.4/other/100-euro-fpv-tune.txt
@@ -148,7 +148,7 @@ set thrust_linear = 25
     set dshot_bidir = ON
 #$ OPTION END
 
-#$ OPTION BEGIN (CHECKED): Min/max check 1000/2000
+#$ OPTION BEGIN (CHECKED): Min/max check 1010/2000
     set min_check = 1010
     set max_check = 2000
 #$ OPTION END

--- a/presets/4.4/other/100-euro-fpv-tune.txt
+++ b/presets/4.4/other/100-euro-fpv-tune.txt
@@ -1,0 +1,209 @@
+#$ TITLE: 100-EURO-FPV
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 6S, race, 100 euro fpv, 5 inch, 5", antonig, 2023, multigp, 100euro
+#$ AUTHOR: antonig
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: This is a 6S 5" racing tune created by antonig specifically for the 100Euro racing frame [www.100-euro-fpv.com] - a 6s 5" AUW=480gr quad with a stiff frame.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: !CAUTION! This worked on various lower and mid-tier setups with various gear - the tune was installed at multiple race days on mutliple quads and all reported
+#$ DESCRIPTION: lower latency, better feel and faster lap times. USE AT YOUR OWN RISK - this tune is aggressive and will cause BURNING HOT motors on hot summer days.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This tune is based on various previous tunes and conversations with top pilots and BetaFlight devs. Thanks to: 
+#$ DESCRIPTION: antonig_fpv, Atakan FPV, Burkan fpv, ctsnooze, KababFPV, KILLIAN_FPV, MARV_FPV, MCK FPV, SlyzeFPV, ToPe, UAVtech
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>**YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!**
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Setup:
+#$ DESCRIPTION: - The 100 Euro frame
+#$ DESCRIPTION:     - 4.5mm custom carbon-fiber arms 0°,+45°,-45°
+#$ DESCRIPTION:     - 7075 CNCed mid-wiggle-plate and 7075 custom aluminum standoffs
+#$ DESCRIPTION:     - All M3 Gr5 Titanium bolts, except for stack bolts - Aluminum 6063
+#$ DESCRIPTION: - Five33 2207 2070KV / XNOVA 2207 2050kv
+#$ DESCRIPTION: - F722 with MPU6000
+#$ DESCRIPTION: - Foxeer Reaper F4 60A / Diatone Mamba Reactor 66 ESCs
+#$ DESCRIPTION: - Gemfan MCK 51466 V2 / Gemfan MCK 51433 V3
+#$ DESCRIPTION: - HDZero V2/V3 vTx and Nano 90cam
+#$ DESCRIPTION: - ELRS nano RXs
+#$ DESCRIPTION: - Genuine Panasonic 35V 470mf capacitor, 12AWG battery leads, genuine Amass XT60H
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: DISCALIMER:
+#$ DESCRIPTION: The information provided in these presets is for educational and entertainment purposes only.
+#$ DESCRIPTION: Betaflight makes no representations as to the safety or legality of the use of any information provided herein.
+#$ DESCRIPTION: End users assume all responsibility and liability for ensuring they comply with all relevant laws and regulations.
+#$ DESCRIPTION: Using these VTX tables may be in breach of your local RF laws.
+#$ DESCRIPTION: You as the end user must research and comply with your local regulations.
+#$ DESCRIPTION: In using these presets, the user assumes any and all liability associated with breaching local regulations.
+#$ DESCRIPTION: 
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/310
+
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+# -- Save CPU cycles --
+set acc_hardware = NONE
+set baro_hardware = NONE
+set blackbox_device = NONE
+feature -TELEMETRY
+
+# -- Gyro LPF Filters --
+set simplified_gyro_filter = OFF
+set simplified_dterm_filter = OFF
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 0
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 2
+set dyn_notch_q = 550
+set dyn_notch_min_hz = 125
+set dyn_notch_max_hz = 650
+
+# -- Dterm filtering --
+set simplified_dterm_filter = OFF
+set dterm_lpf1_dyn_min_hz = 90
+set dterm_lpf1_dyn_max_hz = 180
+set dterm_lpf1_static_hz = 90
+set dterm_lpf2_static_hz = 180
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 2
+set rpm_filter_min_hz = 125
+set rpm_filter_fade_range_hz = 50
+
+# -- Yaw lowpass --
+set yaw_lowpass_hz = 0
+
+# -- PIDsum limits --
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+# -- PID values --
+set simplified_pids_mode = OFF
+set p_pitch = 47
+set i_pitch = 90
+set d_pitch = 30
+set f_pitch = 162
+set p_roll = 47
+set i_roll = 88
+set d_roll = 30
+set f_roll = 156
+set p_yaw = 45
+set i_yaw = 88
+set f_yaw = 156
+set d_min_roll = 19
+set d_min_pitch = 19
+set d_max_gain = 25
+set d_max_advance = 0
+set simplified_pids_mode = OFF
+
+# -- iTerm  --
+set iterm_relax = RPY
+set iterm_relax_cutoff = 40
+
+# -- TPA --
+set tpa_mode = D
+set tpa_rate = 65
+set tpa_breakpoint = 1350
+
+# -- Throttle boost
+set throttle_boost = 5
+set thrust_linear = 25
+
+#$ OPTION BEGIN (CHECKED): ELRS=UART1, HDZ=UART3
+    serial 0 64 115200 57600 0 115200
+    serial 2 131073 115200 57600 0 115200
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): !!! MUST BE SELECTED !!! Motol Protocol and Direction
+    set motor_pwm_protocol = DSHOT600
+    set yaw_motors_reversed = ON
+    set dshot_bidir = ON
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Min/max check 1000/2000
+    set min_check = 1000
+    set max_check = 2000
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): RC smoothing > OFF
+    set rc_smoothing = OFF
+    set osd_warn_bitmask = 623
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): Dynamic Idle
+    set dyn_idle_min_rpm = 35
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): ELRS D500 FF preset
+    set feedforward_averaging = 2_POINT
+    set feedforward_smooth_factor = 65
+    set feedforward_jitter_factor = 3
+    set feedforward_boost = 18
+    set feedforward_max_rate_limit = 100
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): HDZero v2/v3 vtxtable - Default to R8 @ 25mw
+    vtxtable bands 6
+    vtxtable channels 8
+    vtxtable band 1 BOSCAM_A A FACTORY    0    0    0    0    0    0    0    0
+    vtxtable band 2 BOSCAM_B B FACTORY    0    0    0    0    0    0    0    0
+    vtxtable band 3 BOSCAM_E E FACTORY    0    0    0    0    0    0    0    0
+    vtxtable band 4 FATSHARK F FACTORY    0 5760    0 5800    0    0    0    0
+    vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+    vtxtable band 6 IMD6     I FACTORY    0    0    0    0    0    0    0    0
+    vtxtable powerlevels 3
+    vtxtable powervalues 14 23 0
+    vtxtable powerlabels 25 200 0
+    set vtx_band = 5
+    set vtx_channel = 8
+    set vtx_power = 1
+    set vtx_freq = 5917
+    set vcd_video_system = HD
+#$ OPTION END
+
+#$ OPTION BEGIN (CHECKED): OSD elements
+    set osd_tim1 = 2577
+    set osd_vbat_pos = 2112
+    set osd_link_quality_pos = 2496
+    set osd_tim_1_pos = 3497
+    set osd_vtx_channel_pos = 2528
+    set osd_warnings_pos = 14708
+    set osd_flip_arrow_pos = 2233
+    set osd_stat_bitmask = 139298
+    set osd_displayport_device = MSP
+    set osd_canvas_width = 50
+    set osd_canvas_height = 18
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): antonig rates
+    set rates_type = BETAFLIGHT
+    set roll_rc_rate = 102
+    set pitch_rc_rate = 100
+    set yaw_rc_rate = 95
+    set roll_expo = 2
+    set pitch_expo = 12
+    set yaw_expo = 0
+    set roll_srate = 69
+    set pitch_srate = 58
+    set yaw_srate = 60
+    set throttle_limit_type = SCALE
+    set throttle_limit_percent = 95
+#$ OPTION END

--- a/presets/4.4/other/100-euro-fpv-tune.txt
+++ b/presets/4.4/other/100-euro-fpv-tune.txt
@@ -58,7 +58,7 @@
 #$ DESCRIPTION: In using these presets, the user assumes any and all liability associated with breaching local regulations.
 #$ DESCRIPTION: 
 
-#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/310
+#$ DISCUSSION: 
 
 #$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
 #$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt

--- a/presets/4.4/other/100-euro-fpv-tune.txt
+++ b/presets/4.4/other/100-euro-fpv-tune.txt
@@ -7,9 +7,12 @@
 
 #$ PARSER: MARKED
 
+#$ DESCRIPTION: The following parameters will be modified: FILTERS, PIDS incl. limits, FF, ACC/BARO/BB/telemetry, thrust/throttle/limit, UARTs, motor protocol/dshot, checks, dyn idle, rc smoothing, vtx table, osd, rates 
 #$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: 
 #$ DESCRIPTION: This is a 6S 5" racing tune created by antonig specifically for the 100Euro racing frame [www.100-euro-fpv.com] - a 6s 5" AUW=480gr quad with a stiff frame.
-#$ DESCRIPTION:
+#$ DESCRIPTION: 
 #$ DESCRIPTION: <br>
 #$ DESCRIPTION:
 #$ DESCRIPTION: !CAUTION! This worked on various lower and mid-tier setups with various gear - the tune was installed at multiple race days on mutliple quads and all reported
@@ -36,6 +39,13 @@
 #$ DESCRIPTION: - HDZero V2/V3 vTx and Nano 90cam
 #$ DESCRIPTION: - ELRS nano RXs
 #$ DESCRIPTION: - Genuine Panasonic 35V 470mf capacitor, 12AWG battery leads, genuine Amass XT60H
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## BlHeli32 settings:
+#$ DESCRIPTION: - Motor Timing = 27 or 28
+#$ DESCRIPTION: - Demag compensation = OFF
+#$ DESCRIPTION: - PWM min = 48, PWM max = 48
 #$ DESCRIPTION:
 #$ DESCRIPTION: <br>
 #$ DESCRIPTION:

--- a/presets/4.4/other/100-euro-fpv-tune.txt
+++ b/presets/4.4/other/100-euro-fpv-tune.txt
@@ -58,7 +58,7 @@
 #$ DESCRIPTION: In using these presets, the user assumes any and all liability associated with breaching local regulations.
 #$ DESCRIPTION: 
 
-#$ DISCUSSION: 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/413
 
 #$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
 #$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt


### PR DESCRIPTION
Hi,

I created this tune as part of my frame bundle [[100-euro-fpv.com](url)] and now sharing it as a preset for BFC.

It contains multiple category changes - a full setup from a blank 4.4 flash, hence why it falls under the OTHER category.

Thanks for looking into this
Tony