### PR TITLE
disable colored warnings for HDZERO Preset in 4.5

### DIFF
--- a/presets/4.5/vtx/HDZero.txt
+++ b/presets/4.5/vtx/HDZero.txt
@@ -1,0 +1,120 @@
+#$ TITLE: HDZero VTXs
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, HDzero, divimath, SA 2.1, digital, whoop, whoop lite, race v1, race v2, freestyle, tx5m.1, MSP VTX
+#$ AUTHOR: sugarK
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <img src="https://static.wixstatic.com/media/967e02_82348b3d176249aea0926d07a2de0257~mv2_d_5559_3125_s_4_2.png" width="300px" height="90" style="object-fit: cover; margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION: 
+#$ DESCRIPTION: # VTX tables and Canvas mode setup
+#$ DESCRIPTION: ## for all HDzero digital systems plus the new MSP VTX setup
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: 
+#$ DESCRIPTION: Information about MSP VTX can be found [here](https://github.com/betaflight/betaflight/pull/11705)
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
+#$ DESCRIPTION: <br><br>
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/297
+
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+
+# vtxtable
+vtxtable bands 6
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY    0    0    0    0    0    0    0    0
+vtxtable band 2 BOSCAM_B B FACTORY    0    0    0    0    0    0    0    0
+vtxtable band 3 BOSCAM_E E FACTORY    0    0    0    0    0    0    0    0
+vtxtable band 4 FATSHARK F FACTORY    0 5760    0 5800    0    0    0    0
+vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 IMD6     I CUSTOM     0    0    0    0    0    0    0    0
+
+
+#$ OPTION_GROUP BEGIN: Select VTX model
+
+    #$ OPTION BEGIN (UNCHECKED): All VTXs (except unlocked Freestyle and TX5M.1)
+        vtxtable powerlevels 3
+        vtxtable powervalues 14 23 0
+        vtxtable powerlabels 25 200 0
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Unlocked Freestyle
+        vtxtable powerlevels 5
+        vtxtable powervalues 14 23 27 30 0
+        vtxtable powerlabels 25 200 500 MAX 0
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): TX5M.1
+        vtxtable powerlevels 4
+        vtxtable powervalues 14 23 27 0
+        vtxtable powerlabels 25 200 500 0
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: VTX options
+
+    #$ OPTION BEGIN (CHECKED): Set HD OSD
+        set vcd_video_system = HD
+    #$ OPTION END
+
+    #$ OPTION BEGIN (CHECKED): Map to displayport 
+        set osd_displayport_device = MSP
+    #$ OPTION END
+
+    #$ OPTION BEGIN (CHECKED): Disable colored warnings (not compatible with HDZERO)
+        set displayport_msp_fonts = 0,0,0,0
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+
+#$ OPTION_GROUP BEGIN: Select port for VTX
+
+    #$ OPTION BEGIN (UNCHECKED): UART 1 
+        serial 0 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 2 
+         serial 1 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 3 
+        serial 2 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 4
+        serial 3 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 5 
+        serial 4 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 6 
+        serial 5 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 7
+        serial 6 131073 115200 57600 0 115200
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): UART 8
+        serial 7 131073 115200 57600 0 115200
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+


### PR DESCRIPTION

Created a BF 4.5 Version of the HDZERO VTX preset to add in the disable colored warnings as they are currently not compatible with HDZERO.
Tested from my fork as a source.