### PR TITLE
VTX tables for some popular long range transmitters

### DIFF
--- a/presets/4.3/vtx/AKK_FX2_Dominator_2W.txt
+++ b/presets/4.3/vtx/AKK_FX2_Dominator_2W.txt
@@ -1,0 +1,27 @@
+#$ TITLE: AKK FX2-Dominator VTX Table
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, vtxtable, akk, dominator, fx2,
+#$ AUTHOR: Sartor
+#$ DESCRIPTION: VTX tables for AKK FX2-Dominator. (TBS Smart audio)
+#$ DESCRIPTION: Link to product manufacturer: https://www.akktek.com/products/vtx/fx2-dominator.html
+#$ DISCLAIMER: All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+vtxtable bands 5
+vtxtable channels 8
+vtxtable powerlevels 4
+vtxtable powervalues 0 1 2 3
+vtxtable powerlabels 250 500 1W 2W
+
+vtxtable band 1 A        A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 B        B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 E        E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 F        F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 R        R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917

--- a/presets/4.3/vtx/GepRC_RAD_2W5.txt
+++ b/presets/4.3/vtx/GepRC_RAD_2W5.txt
@@ -1,0 +1,27 @@
+#$ TITLE: GEPRC RAD 5.8G 2.5W VTX Table
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, vtxtable, geprc, rad,
+#$ AUTHOR: Sartor
+#$ DESCRIPTION: VTX tables for GEPRC RAD 5.8G 2.5W. (IRC Tramp)
+#$ DESCRIPTION: Link to product manufacturer: https://geprc.com/product/geprc-rad-vtx-5-8g-2-5w/
+#$ DISCLAIMER: All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+vtxtable bands 5
+vtxtable channels 8
+vtxtable powerlevels 5
+vtxtable powervalues 25 200 600 1600 2500
+vtxtable powerlabels 25 200 600 1W6 2W5
+
+vtxtable band 1 A        A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 B        B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 E        E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 F        F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 R        R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917

--- a/presets/4.3/vtx/JHEMCU_2W5.txt
+++ b/presets/4.3/vtx/JHEMCU_2W5.txt
@@ -1,0 +1,27 @@
+#$ TITLE: JHEMCU 5.8G 2.5W VTX Table
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, vtxtable, jhemcu,
+#$ AUTHOR: Sartor
+#$ DESCRIPTION: VTX tables for JHEMCU 5.8G 2.5W. (IRC Tramp)
+#$ DESCRIPTION: Link to product manufacturer: https://www.jhemcu.com/e_productshow/?69-JHEMCU-VTX2W5-58GHZ-25W-image-transmission-69.html
+#$ DISCLAIMER: All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+vtxtable bands 5
+vtxtable channels 8
+vtxtable powerlevels 6
+vtxtable powervalues 25 100 200 400 600 1
+vtxtable powerlabels 25 400 800 1W5 2W5 0MW
+
+vtxtable band 1 A        A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 B        B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 E        E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 F        F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 R        R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917

--- a/presets/4.3/vtx/PandaRC_VT5804_BAT_2W5.txt
+++ b/presets/4.3/vtx/PandaRC_VT5804_BAT_2W5.txt
@@ -1,0 +1,27 @@
+#$ TITLE: PandaRc VT5804 BAT VTX Table
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, vtxtable, panda, pandarc, vt5804, vt5804bat,
+#$ AUTHOR: Sartor
+#$ DESCRIPTION: VTX tables for PandaRc VT5804 BAT. (IRC Tramp)
+#$ DESCRIPTION: Link to product manufacturer: https://www.pandarc.com/mntc
+#$ DISCLAIMER: All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+vtxtable bands 5
+vtxtable channels 8
+vtxtable powerlevels 5
+vtxtable powervalues 25 100 200 400 600
+vtxtable powerlabels 25 400 800 1W5 2W5
+
+vtxtable band 1 A        A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 B        B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 E        E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 F        F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 R        R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917


### PR DESCRIPTION
VTX tables for:
- AKK FX2 Dominator 2W
- GepRC RAD 2.5W
- JHEMCU 2.5W
- PandaRC VT5804 BAT 2.5W

All tables received from manufacturers directly
