### PR TITLE
rates for zoeFPV

### DIFF
--- a/presets/4.5/rates/ZoeFPV_3D_rates.txt
+++ b/presets/4.5/rates/ZoeFPV_3D_rates.txt
@@ -9,7 +9,7 @@
 
 #$ PARSER: MARKED
 
-#$ DESCRIPTION:<img src="https://cdn.discordapp.com/attachments/1175277085321863188/1178779293376057425/ZoeClearBackground.png?ex=657762c4&is=6564edc4&hm=1c6b4d99f7a96c8c27ff8af42383848f5c5109bb9cff46e1d7a3a08204779557&" style="max-width: 50%; margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:<img src="https://private-user-images.githubusercontent.com/83344205/286465879-f2649e30-4df1-498c-ba82-122e3195dec7.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDEyMjgzODksIm5iZiI6MTcwMTIyODA4OSwicGF0aCI6Ii84MzM0NDIwNS8yODY0NjU4NzktZjI2NDllMzAtNGRmMS00OThjLWJhODItMTIyZTMxOTVkZWM3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFJV05KWUFYNENTVkVINTNBJTJGMjAyMzExMjklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjMxMTI5VDAzMjEyOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTAzZjFlMGI3Mjg0NmMxZWU5YWMyMDRhZTQ0OGI3NzcyNWI3YjFlYjVkZThlY2Q0NmQzOTdlZjAxMjljMGFiODImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.GjmLy0jZcVcv2b9X0LjU1MKW8DOfeJlyhzugDMhRH5g" style="max-width: 50%; margin-left: auto; margin-right: auto; display: block;"/>
 #$ DESCRIPTION: -----------
 #$ DESCRIPTION: [YouTube](www.youtube.com/@ZoeFPV)
 #$ DESCRIPTION: [Instagram] (https://www.instagram.com/zoefpv/)

--- a/presets/4.5/rates/ZoeFPV_3D_rates.txt
+++ b/presets/4.5/rates/ZoeFPV_3D_rates.txt
@@ -5,7 +5,7 @@
 #$ CATEGORY: RATES
 #$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: rates, freestyle, juicy, sbang, zoeFPV, zoe, 3d, upside down, sugarK
-#$ AUTHOR: ZoeFPV (co authored sugarK)
+#$ AUTHOR: ZoeFPV
 
 #$ PARSER: MARKED
 
@@ -22,6 +22,7 @@
 #$ DESCRIPTION: Each rate has been tested for it’s ability to do chaotic 3D maneuvers, and for tight tic-tocs.
 #$ DESCRIPTION: 
 #$ DESCRIPTION: <br /><br />
+#$ DESCRIPTION: Co authored by sugarK
 #$ DESCRIPTION:
 #$ WARNING: This rate preset will overwrite all the rate profiles 
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/424

--- a/presets/4.5/rates/ZoeFPV_3D_rates.txt
+++ b/presets/4.5/rates/ZoeFPV_3D_rates.txt
@@ -1,0 +1,94 @@
+#$ TITLE: ZoeFPV 3D Rate Bomb
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: RATES
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: rates, freestyle, juicy, sbang, zoeFPV, zoe, 3d, upside down, sugarK
+#$ AUTHOR: ZoeFPV (co authored sugarK)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:<img src="https://cdn.discordapp.com/attachments/1175277085321863188/1178779293376057425/ZoeClearBackground.png?ex=657762c4&is=6564edc4&hm=1c6b4d99f7a96c8c27ff8af42383848f5c5109bb9cff46e1d7a3a08204779557&" style="max-width: 50%; margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: [YouTube](www.youtube.com/@ZoeFPV)
+#$ DESCRIPTION: [Instagram] (https://www.instagram.com/zoefpv/)
+#$ DESCRIPTION: [Discord with 3D Pilots around to help](https://discord.com/invite/nRn9gU3)
+#$ DESCRIPTION: <br /><br />
+#$ DESCRIPTION:
+#$ DESCRIPTION: ZoeFPV 3D rates
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Zoes legendary rate profile that she’s used for years, along with 2 variations of it depending on your own style and feel, plus KittFPV’s rates for a more linear and locked in experience. 
+#$ DESCRIPTION: Each rate has been tested for it’s ability to do chaotic 3D maneuvers, and for tight tic-tocs.
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <br /><br />
+#$ DESCRIPTION:
+#$ WARNING: This rate preset will overwrite all the rate profiles 
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/424
+
+#$ INCLUDE: presets/4.3/rates/defaults.txt
+
+# -- End Defaults --
+# -- Begin ZoeFPV Rates --
+
+rateprofile 0
+
+# rateprofile 0
+set rateprofile_name = Z' Magic
+set thr_expo = 25
+set roll_rc_rate = 4
+set pitch_rc_rate = 4
+set yaw_rc_rate = 4
+set roll_expo = 33
+set pitch_expo = 33
+set yaw_expo = 33
+set roll_srate = 80
+set pitch_srate = 80
+set yaw_srate = 80
+
+rateprofile 1
+
+# rateprofile 1
+set rateprofile_name = Z' Buttr
+set thr_expo = 33
+set roll_rc_rate = 6
+set pitch_rc_rate = 6
+set yaw_rc_rate = 6
+set roll_expo = 42
+set pitch_expo = 42
+set yaw_expo = 42
+set roll_srate = 74
+set pitch_srate = 74
+set yaw_srate = 74
+
+rateprofile 2
+
+# rateprofile 2
+set rateprofile_name = Z's OG
+set roll_rc_rate = 17
+set pitch_rc_rate = 17
+set yaw_rc_rate = 17
+set roll_expo = 58
+set pitch_expo = 58
+set yaw_expo = 58
+set roll_srate = 74
+set pitch_srate = 74
+set yaw_srate = 74
+
+rateprofile 3
+
+# rateprofile 3
+set rateprofile_name = KittFPV
+set thr_expo = 33
+set roll_rc_rate = 20
+set pitch_rc_rate = 20
+set yaw_rc_rate = 17
+set roll_expo = 42
+set pitch_expo = 42
+set yaw_expo = 31
+set roll_srate = 62
+set pitch_srate = 62
+set yaw_srate = 43
+
+# restore original rateprofile selection
+rateprofile 2


### PR DESCRIPTION
first part of making a ZoeFPV 3d profile. this preset will overwrite all your rate profiles with Zoes different rate profiles 



![ZoeClearBackground](https://github.com/betaflight/firmware-presets/assets/83344205/f2649e30-4df1-498c-ba82-122e3195dec7)


Zoes legendary rate profile that she’s used for years, along with 2 variations of it depending on your own style and feel, plus KittFPV’s rates for a more linear and locked in experience. 
Each rate has been tested for it’s ability to do chaotic 3D maneuvers, and for tight tic-tocs.
