### PR TITLE
fix up LED presets to work with changes to LED race mode

### DIFF
--- a/presets/4.5/leds/LED VTX  race mode.txt
+++ b/presets/4.5/leds/LED VTX  race mode.txt
@@ -8,7 +8,7 @@
 #$ DESCRIPTION: Sets LED settings to change colours when VTX channel is changed.
 #$ DESCRIPTION: This preset is required with HDzero VTX firmware 1.30 and above. See BF pr here https://github.com/betaflight/betaflight/pull/13096#discussion_r1411284423
 #$ DESCRIPTION:
-#$ WARNING: This preset will not work with HDzero firmware 1.20 or older
+
 
 #--- Set up Race mode ---
 

--- a/presets/4.5/leds/LED VTX  race mode.txt
+++ b/presets/4.5/leds/LED VTX  race mode.txt
@@ -6,7 +6,7 @@
 #$ AUTHOR: sugarK
 
 #$ DESCRIPTION: Sets LED settings to change colours when VTX channel is changed.
-#$ DESCRIPTION: This preset is required with HDzero VTX firmware 1.30 and above. See BF pr here https://github.com/betaflight/betaflight/pull/13096#discussion_r1411284423
+#$ DESCRIPTION: This preset is required with HDzero VTX firmware 1.30 and above. See BF PR here https://github.com/betaflight/betaflight/pull/13096
 #$ DESCRIPTION:
 
 

--- a/presets/4.5/leds/LED VTX  race mode.txt
+++ b/presets/4.5/leds/LED VTX  race mode.txt
@@ -1,0 +1,74 @@
+#$ TITLE: RACE mode LED settings
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: LEDS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: leds, race, vtx, colour change, sugarK, spec, spec racing, tinytrainer
+#$ AUTHOR: sugarK
+
+#$ DESCRIPTION: Sets LED settings to change colours when VTX channel is changed.
+#$ DESCRIPTION: This preset is required with HDzero VTX firmware 1.30 and above. See BF pr here https://github.com/betaflight/betaflight/pull/13096#discussion_r1411284423
+#$ DESCRIPTION:
+#$ WARNING: This preset will not work with HDzero firmware 1.20 or older
+
+#--- Set up Race mode ---
+
+set ledstrip_profile = RACE
+set ledstrip_race_color = BLACK
+
+
+# --- Set LED ---
+
+#$ OPTION_GROUP BEGIN: Set up number of LEDS
+    
+    #$ OPTION BEGIN (UNCHECKED): Set 2 LEDs
+        led 0 2,3::COV:1
+        led 1 3,3::COV:1
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): Set 4 LEDs
+        led 0 2,3::COV:1
+        led 1 3,3::COV:1
+        led 2 4,3::COV:1
+        led 3 5,3::COV:1
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Set 8 LEDs
+        led 0 2,3::COV:1
+        led 1 3,3::COV:1
+        led 2 4,3::COV:1
+        led 3 5,3::COV:1
+        led 4 6,3::COV:1
+        led 5 7,3::COV:1
+        led 6 8,3::COV:1
+        led 7 7,5::COV:1
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): Set 8 LEDs
+        led 0 2,3::COV:1
+        led 1 3,3::COV:1
+        led 2 4,3::COV:1
+        led 3 5,3::COV:1
+        led 4 6,3::COV:1
+        led 5 7,3::COV:1
+        led 6 8,3::COV:1
+        led 7 7,5::COV:1
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Set 16 LEDs
+        led 0 2,3::COV:1
+        led 1 3,3::COV:1
+        led 2 4,3::COV:1
+        led 4 6,3::COV:1
+        led 5 7,3::COV:1
+        led 6 8,3::COV:1
+        led 7 7,5::COV:1
+        led 8 8,6::COV:1
+        led 9 9,7::COV:1
+        led 10 10,8::COV:1
+        led 11 11,9::COV:1
+        led 12 12,10::COV:1
+        led 13 13,11::COV:1
+        led 14 14,12::COV:1
+        led 15 15,13::COV:1
+    #$ OPTION END
+#$ OPTION_GROUP END

--- a/presets/4.5/leds/quaddiction_tinytrainer.txt
+++ b/presets/4.5/leds/quaddiction_tinytrainer.txt
@@ -1,12 +1,20 @@
 #$ TITLE: Quaddiction TinyTrainer LED settings
-#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
 #$ CATEGORY: LEDS
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: leds, 533, five33, quaddiction, sugarK, spec, spec racing, tinytrainer, tiny
 #$ AUTHOR: sugarK
 
 #$ DESCRIPTION: Sets LED settings to suit used VTX channels used by the Quaddiction TinyTrainer spec team
-#$ WARNING: This preset will not work with HDzero firmware 1.30 or newer
+#$ DESCRIPTION: this preset is required with HDzero VTX firmware 1.30 and above. See BF pr here https://github.com/betaflight/betaflight/pull/13096#discussion_r1411284423
+#$ DESCRIPTION:
+
+
+#--- Set up Race mode ---
+
+set ledstrip_profile = RACE
+set ledstrip_race_color = BLACK
+
 
 # --- LED Designations ---
 

--- a/presets/4.5/leds/quaddiction_tinytrainer.txt
+++ b/presets/4.5/leds/quaddiction_tinytrainer.txt
@@ -6,7 +6,7 @@
 #$ AUTHOR: sugarK
 
 #$ DESCRIPTION: Sets LED settings to suit used VTX channels used by the Quaddiction TinyTrainer spec team
-#$ DESCRIPTION: this preset is required with HDzero VTX firmware 1.30 and above. See BF pr here https://github.com/betaflight/betaflight/pull/13096#discussion_r1411284423
+#$ DESCRIPTION: This preset is required with HDzero VTX firmware 1.30 and above. See BF PR here https://github.com/betaflight/betaflight/pull/13096
 #$ DESCRIPTION:
 
 


### PR DESCRIPTION
These presets allow you to set your LED colours via your VTX channel and change when you change channel. Behaviour was changed with this pr  https://github.com/betaflight/betaflight/pull/13096#discussion_r1411284423

