### PR TITLE
4.5 filter defaults

### DIFF
--- a/presets/4.5/filters/defaults.txt
+++ b/presets/4.5/filters/defaults.txt
@@ -1,0 +1,48 @@
+#$ TITLE: Default 4.5 Filter settings
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: FILTERS
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: defaults, filter, filters, reset
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets Filter settings to 4.5 defaults
+
+set gyro_hardware_lpf = NORMAL
+set gyro_lpf1_type = PT1
+set gyro_lpf1_static_hz = 250
+set gyro_lpf2_type = PT1
+set gyro_lpf2_static_hz = 500
+set gyro_notch1_hz = 0
+set gyro_notch1_cutoff = 0
+set gyro_notch2_hz = 0
+set gyro_notch2_cutoff = 0
+
+defaults group_id 554 nosave # PG_DYN_NOTCH_CONFIG
+
+set gyro_lpf1_dyn_min_hz = 250
+set gyro_lpf1_dyn_max_hz = 500
+set gyro_lpf1_dyn_expo = 5
+set gyro_filter_debug_axis = ROLL
+
+set acc_lpf_hz = 25
+
+set dshot_bidir = OFF
+
+set simplified_gyro_filter = ON
+set simplified_gyro_filter_multiplier = 100
+
+defaults group_id 544 nosave # PG_RPM_FILTER_CONFIG
+
+set dterm_lpf1_dyn_min_hz = 75
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_dyn_expo = 5
+set dterm_lpf1_type = PT1
+set dterm_lpf1_static_hz = 75
+set dterm_lpf2_type = PT1
+set dterm_lpf2_static_hz = 150
+set dterm_notch_hz = 0
+set dterm_notch_cutoff = 0
+
+set yaw_lowpass_hz = 100
+
+set simplified_dterm_filter = ON
+set simplified_dterm_filter_multiplier = 100


### PR DESCRIPTION
This PR is the first PR in the sequence of transferring tune/filter presets for 4.5.

My dream about full transfer defaults to PG groups can't become true yet.
The main reason that `PG_GYRO_CONFIG` includes some stuff that's hardware/user related.
And that `PG_PID_PROFILE` contains d-term filters.

So for 4.5 filters defaults can only use:
`defaults group_id 554 nosave # PG_DYN_NOTCH_CONFIG`
`defaults group_id 544 nosave # PG_RPM_FILTER_CONFIG`
which I did here.

the rest of the parameters should be listed explicitly.

I listed them in the order they appear in CLI, that's easier to maintain.

The next PRs will be:
1. 4.5 tune defaults
2. Remove 4.5 firmware from previous tunes/filters presets
3. Copy filter/tune presets over to 4.5 folder and tag them as 4.5