### PR TITLE
4.5 tune defaults changes

### DIFF
--- a/presets/4.5/tune/defaults.txt
+++ b/presets/4.5/tune/defaults.txt
@@ -4,12 +4,11 @@
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: defaults, reset, tune, pid, basic, default
 #$ AUTHOR: Betaflight
-#$ DESCRIPTION: Resets all Basic 4.4 Tune category parameters to defaults
+#$ DESCRIPTION: Resets all Basic 4.5 Tune category parameters to defaults
 #$ DESCRIPTION: WARNING: Overwrites all settings mentioned below to defaults.  The User cannot retain their previous values.
 #$ DESCRIPTION: WARNING: Tune authors must explicitly set these values to something other than default, if needed for the tune.
 #$ DESCRIPTION: DOES NOT reset rates, filters, rc_smoothing, and many other parameters.
 #$ PRIORITY: 0
-
 
 # THE FOLLOWING PARAMETERS ARE CONTROLLED
 # ALL WILL BE RESET TO DEFAULTS WHEN THIS DEFAULT IS RUN
@@ -17,27 +16,80 @@
 # IF THE AUTHOR WANTS A NON-DEFAULT VALUE, THEIR TUNE MUST SET IT
 # BOTH CHECKED AND UNCHECKED OPTIONS CAN BE USED FOR THESE PARAMETERS
 
-# -- PID values (default) --
+set yaw_spin_recovery = AUTO
+
+set dshot_idle_value = 550
+
+set mixer_type = LEGACY
+
+set gyro_cal_on_first_arm = OFF
+
+set pid_at_min_throttle = ON
+set anti_gravity_gain = 80
+set anti_gravity_cutoff_hz = 5
+set anti_gravity_p_gain = 100
+set acc_limit_yaw = 0
+set acc_limit = 0
+
+set iterm_rotation = OFF
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 15
+set iterm_windup = 85
+set iterm_limit = 400
+set pidsum_limit = 500
+set pidsum_limit_yaw = 400
+
+set throttle_boost = 5
+set throttle_boost_cutoff = 15
+
 set p_pitch = 47
 set i_pitch = 84
 set d_pitch = 46
-set d_min_pitch = 34
 set f_pitch = 125
-
 set p_roll = 45
 set i_roll = 80
 set d_roll = 40
-set d_min_roll = 30
 set f_roll = 120
-
 set p_yaw = 45
 set i_yaw = 80
 set d_yaw = 0
-set d_min_yaw = 0
 set f_yaw = 120
+set angle_p_gain = 50
+set angle_feedforward = 50
+set angle_feedforward_smoothing_ms = 80
+set angle_limit = 60
+set angle_earth_ref = 100
+set horizon_level_strength = 75
+set horizon_limit_sticks = 75
+set horizon_limit_degrees = 135
+set horizon_ignore_sticks = OFF
+set horizon_delay_ms = 500
+set abs_control_gain = 0
+set abs_control_limit = 90
+set abs_control_error_limit = 20
+set abs_control_cutoff = 11
+set use_integrated_yaw = OFF
+set integrated_yaw_relax = 200
+set d_min_roll = 30
+set d_min_pitch = 34
+set d_min_yaw = 0
+set d_max_gain = 37
+set d_max_advance = 20
 
-# -- PID Sliders (default) --
-set simplified_pids_mode = RPY
+set thrust_linear = 0
+set transient_throttle_limit = 0
+set feedforward_transition = 0
+
+set feedforward_max_rate_limit = 90
+
+set dyn_idle_min_rpm = 0
+set dyn_idle_p_gain = 50
+set dyn_idle_i_gain = 50
+set dyn_idle_d_gain = 50
+set dyn_idle_max_increase = 150
+set dyn_idle_start_increase = 50
+
 set simplified_master_multiplier = 100
 set simplified_i_gain = 100
 set simplified_d_gain = 100
@@ -47,186 +99,9 @@ set simplified_feedforward_gain = 100
 set simplified_pitch_d_gain = 100
 set simplified_pitch_pi_gain = 100
 
-# -- iTerm relax (default) --
-set iterm_relax = RP
-set iterm_relax_type = SETPOINT
-set iterm_relax_cutoff = 15
-
-# -- iTerm windup (default) --
-set iterm_windup = 85
-
-# -- iTerm rotation (off, default) --
-set iterm_rotation = OFF
-
-# -- Dmax (default) --
-set d_max_gain = 37
-set d_max_advance = 20
-
-# -- TPA (default) --
+set tpa_mode = D
 set tpa_rate = 65
 set tpa_breakpoint = 1350
-set tpa_mode = D
-
-# -- Feedforward (default) --
-set feedforward_transition = 0
-set feedforward_max_rate_limit = 90
-
-# -- Feedforward averaging (do not change)--
-# needs to be set according to RC link type and speed, not changed in the tune
-
-# -- PIDsum limits (default) --
-set pidsum_limit = 500
-set pidsum_limit_yaw = 400
-set iterm_limit = 400
-
-# -- Antigravity (default) --
-set anti_gravity_gain = 80
-set anti_gravity_cutoff_hz = 5
-set anti_gravity_p_gain = 100
-
-# -- Absolute control (off, default) --
-# this tends to cause iTerm oscillation and is best left off
-set abs_control_gain = 0
-set abs_control_limit = 90
-set abs_control_error_limit = 20
-set abs_control_cutoff = 11
-
-# -- Accecleration limits (off, default) --
-# these may be configured to prevent I windup on yaw on low authority quads
-set acc_limit_yaw = 0
-set acc_limit = 0
-
-# -- Angle and Horizon mode tuning (default) 
-set angle_p_gain = 50
-set angle_feedforward = 50
-set angle_feedforward_smoothing_ms = 80
-set angle_limit = 60
-set angle_earth_ref = 100
-set horizon_level_strength = 50
-set horizon_limit_sticks = 75
-set horizon_limit_degrees = 135
-set horizon_ignore_sticks = OFF
-set horizon_delay_ms = 500
-
-# -- PIDs active below min throttle (default) --
-# always best on
-set pid_at_min_throttle = ON
-
-# -- Set mixer type to default (legacy) --
-# Will overwrite a user's prefered mixer method
-set mixer_type = LEGACY
-
-# -- Set yaw spin recovery to default, which is auto --
-# this is the optimal setting for all except radical LOS builds. .
-set yaw_spin_recovery = AUTO
-
-# -- Set integrated yaw to off so yaw tuning is simpler (default) --
-# integrated yaw integrates yaw pidsum when calculating yaw pids
-# tuning is far different with integrated yaw on and should only
-# be set to on if you have tuned for it
-set use_integrated_yaw = OFF
-
-# -- Gyro cal on first arm (off, default) --
-# only calibrates on power up
-# faster take-off after first arm when off
-set gyro_cal_on_first_arm = OFF
-
-# -- Transient throttle limit (off, default) --
-# do not enable if using dynamic idle, replaced with dynamic idle
-# best kept off
-set transient_throttle_limit = 0
-
-# -- Thrust linear (off, default) --
-# increases motor output differentials at low throttle, useful if low thrust at low rpm, commonly used for Whoops
-# reset here to ensure a prior whoop flash won't carry thrust linear into other tunes
-set thrust_linear = 0
-
-# -- Throttle boost (default, 5)
-# adds more throttle when throttle is moved rapidly, to compensate for motor lag
-# aggressive builds may need no throttle boost
-# Different throttle boost values may be provided to the User with Options
-set throttle_boost = 5
-set throttle_boost_cutoff = 15
-
-# -- VBat warning threshold (3.5V, default)--
-#  Often set lower in whoop builds
-set vbat_warning_cell_voltage = 350
-
-# -- DShot Idle (default)--
-# Commonly set lower when dynamic idle is active.
-set dshot_idle_value = 550
-
-# -- Dyn Idle (off, default) --
-# Commonly enabled to improve turns and minimise desyncs
-# Since every preset resets this to off, users with desync prone builds will have to re-apply their personal values after this reset
-set dyn_idle_min_rpm = 0
-set dyn_idle_p_gain = 50
-set dyn_idle_i_gain = 50
-set dyn_idle_d_gain = 50
-set dyn_idle_max_increase = 150
-set motor_pwm_rate = 480
-
-
-#   HONOUR THE FOLLOWING "PERSONAL PREFERENCE" SETTINGS
-#   THEY WILL BE RETAINED, UNCHANGED, AFTER APPLYING THIS DEFAULT FILE
-#   THE AUTHOR MAY PROVIDE AN *UNCHECKED* OPTION TO SET THESE OR OTHER PARAMETERS
-
-# -- Stick behaviour, endpoints -- 
-# -- Deadbands --
-# -- Airmode (should be on) --
-# -- Level Race Mode --
-# -- Runaway takeoff prevention --
-# -- Crash Recovery settings --
-# -- Turtle mode settings --
-# -- Acro trainer settings --
-# -- Launch control settings --
-# -- Motor output limit --
-# -- Motor protocol --
-# -- DShot telemetry status (controlled by a filter set) --
-# -- Throttle limit --
-# -- Throttle curve --
-# -- VBat sag compensation --
-# -- Small Angle --
-
-
-# ------ OPTIONS GO BELOW THIS LINE ------
-
-# This is where the author includes options that require input from the User
-
-# Checked Options are allowed only for values from the list above, e.g. different options for a throttle curve or throttle boost, or a 'spicier' tune.
-
-# Other values may ONLY be included as un-checked options. Examples follow...
-
-# -- Rates --
-# One ore more un-checked 'OPTION' elements that 'Include' external Rates preset files.
-
-# -- Filters --
-# One ore more un-checked or checked 'FILTERS elements that 'Include' external Filter preset files.
-# It may be good to initialise to a non-RPM filter set, then provide your preferred RPM aware filter set as a checked uption.
-
-# -- Throttle limit (default) --
-# For least full throttle noise, use SCALE and values around 95-96-97
-# Different throttle limit values may be provided to the User with Options
-# set throttle_limit_type = OFF
-# set throttle_limit_percent = 100
-
-# -- Throttle curve (default, off) --
-# Whoops etc do best with a concave-down throttle boost at low stick angle
-# Different throttle limit values may be provided to the User with Options
-# set thr_mid = 50
-# set thr_expo = 0
-
-# -- VBat sag compensation (off, default) --
-# Most pilots find that full sag compensation is better than off
-# set vbat_sag_compensation = 0
-# set vbat_sag_lpf_period = 2
-
-# -- Constrain arming within a limited range (default 25 degrees) --
-# useful to be set to 180 to arm if stuck at an angle, increases risk of accidentally arming while being carried
-# set small_angle = 25
-
-# -- Set min stick values to default --
-# in case changed to silly number and can't get stick commands to work
-# both are better set to 1020 for digital radios with sticks adjusted to a 1000-2000 range
-# set min_throttle = 1070
-# set min_check = 1050
+set tpa_rate_lower = 20
+set tpa_breakpoint_lower = 1050
+set tpa_breakpoint_lower_fade = ON


### PR DESCRIPTION
Continuation of this PR:
https://github.com/betaflight/firmware-presets/pull/429

few params are renamed/added in comparisson with 4.4 tune defaults.

I also made this list in the same order it appears in CLI for easier maintenance in the future.

Plus i have removed these two parameters as they probably don't belong to tuning:
```
vbat_warning_cell_voltage
motor_pwm_rate
```

these three parameters might be renamed:
```
set tpa_rate_lower = 20
set tpa_breakpoint_lower = 1050
set tpa_breakpoint_lower_fade = ON
```
if this PR is merged:
https://github.com/betaflight/betaflight/pull/13206
but thats an easy fix