### PR TITLE
Introducing barracuda tune to betaflight

### DIFF
--- a/presets/4.4/tune/barracuda_race_tune.txt
+++ b/presets/4.4/tune/barracuda_race_tune.txt
@@ -1,0 +1,101 @@
+#$ TITLE: Barracuda Racer Tune
+#$ FIRMWARE_VERSION: 4.4
+#$ CATEGORY: TUNE
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: 6S, race, racing, beginner, 5 inch, 5", viki, 2024
+#$ AUTHOR: Viki Baarathi
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: This tune is ideal for beginners who are taking up drone racing. It's light on the motors yet allows for good performance.
+
+#$ DESCRIPTION: ### Requirements:
+#$ DESCRIPTION: - 5 inch race quads with 6S packs.
+#$ DESCRIPTION: - Works with Analog or HDZero
+#$ DESCRIPTION: - DSHOT600 with bidirectional DSHOT enabled. This is very important.
+#$ DESCRIPTION: - Stack nuts must be present and tight. The ones below the FC. Some call them the golden nuts or nuts of glory. 
+#$ DESCRIPTION: - Motor screws should be tight and arms should be solid and not gummy. 
+#$ DESCRIPTION: - Special thanks to testers Meor, Imad, Muqrie, AdilzFPV
+#$ DESCRIPTION: ### Recommendation:
+#$ DESCRIPTION: - ExpressLRS 250Hz or ExpressLRS 500Hz
+#$ DESCRIPTION: - Apply Barracuda filters
+#$ DESCRIPTION: ### BLHeli32 setting
+#$ DESCRIPTION: - Set low and high frequency to 48
+#$ DESCRIPTION: - Rampup power 25%
+#$ DESCRIPTION: - Motor timing 16 deg
+
+#$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+
+#$ OPTION_GROUP BEGIN: Recommended RC Links
+
+    #$ OPTION BEGIN (CHECKED): ELRS 250Hz
+    #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 35
+        set feedforward_jitter_factor = 4
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
+    #$ INCLUDE: presets/4.3/rc_link/defaults.txt
+
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        set feedforward_averaging = 2_POINT
+        set feedforward_smooth_factor = 65
+        set feedforward_jitter_factor = 3
+        set feedforward_boost = 18
+
+        set rc_smoothing_auto_factor = 25
+        set rc_smoothing_auto_factor_throttle = 25
+
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION BEGIN (CHECKED): Recommended Barracuda Filters
+    #$ INCLUDE: presets/4.3/filters/defaults.txt
+    set simplified_gyro_filter_multiplier = 140
+    set gyro_lpf1_static_hz = 350
+    set gyro_lpf2_static_hz = 0
+    set gyro_lpf1_dyn_min_hz = 350
+    set gyro_lpf1_dyn_max_hz = 700
+
+
+#$ OPTION END
+
+
+set profile_name = Brcuda
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+set p_pitch = 28
+set i_pitch = 55
+set d_pitch = 20
+set f_pitch = 59
+set p_roll = 26
+set i_roll = 52
+set d_roll = 17
+set f_roll = 57
+set p_yaw = 26
+set i_yaw = 52
+set f_yaw = 57
+set d_min_roll = 17
+set d_min_pitch = 20
+set simplified_master_multiplier = 60
+set simplified_i_gain = 110
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 80
+set dyn_notch_count = 1
+set dyn_notch_q = 500
+set dshot_bidir = ON
+set motor_pwm_protocol = DSHOT600

--- a/presets/4.4/tune/barracuda_race_tune.txt
+++ b/presets/4.4/tune/barracuda_race_tune.txt
@@ -61,7 +61,7 @@ simplified_tuning apply
     #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz Race setup
         feature RX_SERIAL
         set serialrx_provider = CRSF
-        #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
+        #$ INCLUDE: presets/4.3/rc_link/generic/500hz_race.txt
 
     #$ OPTION END
 

--- a/presets/4.4/tune/barracuda_race_tune.txt
+++ b/presets/4.4/tune/barracuda_race_tune.txt
@@ -1,7 +1,7 @@
 #$ TITLE: Barracuda Racer Tune
 #$ FIRMWARE_VERSION: 4.4
 #$ CATEGORY: TUNE
-#$ STATUS: COMMUNITY
+#$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: 6S, race, racing, beginner, 5 inch, 5", viki, 2024
 #$ AUTHOR: Viki Baarathi
 
@@ -17,85 +17,52 @@
 #$ DESCRIPTION: - Motor screws should be tight and arms should be solid and not gummy. 
 #$ DESCRIPTION: - Special thanks to testers Meor, Imad, Muqrie, AdilzFPV
 #$ DESCRIPTION: ### Recommendation:
-#$ DESCRIPTION: - ExpressLRS 250Hz or ExpressLRS 500Hz
 #$ DESCRIPTION: - Apply Barracuda filters
+#$ DESCRIPTION: - Apply RClink of ExpressLRS 250Hz or ExpressLRS 500Hz for racing
 #$ DESCRIPTION: ### BLHeli32 setting
 #$ DESCRIPTION: - Set low and high frequency to 48
 #$ DESCRIPTION: - Rampup power 25%
 #$ DESCRIPTION: - Motor timing 16 deg
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/442
 #$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
-#$ INCLUDE: presets/4.4/tune/defaults.txt
-
-#$ OPTION_GROUP BEGIN: Recommended RC Links
-
-    #$ OPTION BEGIN (CHECKED): ELRS 250Hz
-    #$ INCLUDE: presets/4.3/rc_link/defaults.txt
-
-        feature RX_SERIAL
-        set serialrx_provider = CRSF
-
-        set feedforward_averaging = 2_POINT
-        set feedforward_smooth_factor = 35
-        set feedforward_jitter_factor = 4
-        set feedforward_boost = 18
-
-        set rc_smoothing_auto_factor = 25
-        set rc_smoothing_auto_factor_throttle = 25
-
-    #$ OPTION END
-
-    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
-    #$ INCLUDE: presets/4.3/rc_link/defaults.txt
-
-        feature RX_SERIAL
-        set serialrx_provider = CRSF
-
-        set feedforward_averaging = 2_POINT
-        set feedforward_smooth_factor = 65
-        set feedforward_jitter_factor = 3
-        set feedforward_boost = 18
-
-        set rc_smoothing_auto_factor = 25
-        set rc_smoothing_auto_factor_throttle = 25
-
-    #$ OPTION END
-
-#$ OPTION_GROUP END
 
 #$ OPTION BEGIN (CHECKED): Recommended Barracuda Filters
     #$ INCLUDE: presets/4.3/filters/defaults.txt
     set simplified_gyro_filter_multiplier = 140
-    set gyro_lpf1_static_hz = 350
     set gyro_lpf2_static_hz = 0
-    set gyro_lpf1_dyn_min_hz = 350
-    set gyro_lpf1_dyn_max_hz = 700
-
 
 #$ OPTION END
 
-
-set profile_name = Brcuda
+#$ INCLUDE: presets/4.4/tune/defaults.txt
 set pidsum_limit = 1000
 set pidsum_limit_yaw = 1000
-set p_pitch = 28
-set i_pitch = 55
-set d_pitch = 20
-set f_pitch = 59
-set p_roll = 26
-set i_roll = 52
-set d_roll = 17
-set f_roll = 57
-set p_yaw = 26
-set i_yaw = 52
-set f_yaw = 57
-set d_min_roll = 17
-set d_min_pitch = 20
+set simplified_pids_mode = RPY
 set simplified_master_multiplier = 60
 set simplified_i_gain = 110
 set simplified_dmax_gain = 0
 set simplified_feedforward_gain = 80
+
 set dyn_notch_count = 1
 set dyn_notch_q = 500
 set dshot_bidir = ON
 set motor_pwm_protocol = DSHOT600
+
+simplified_tuning apply
+
+#$ OPTION_GROUP BEGIN: Recommended Race RC Links
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS 250Hz Race Setup
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+        #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz Race setup
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+        #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
+
+    #$ OPTION END
+
+#$ OPTION_GROUP END

--- a/presets/4.4/tune/barracuda_race_tune.txt
+++ b/presets/4.4/tune/barracuda_race_tune.txt
@@ -23,7 +23,7 @@
 #$ DESCRIPTION: - Set low and high frequency to 48
 #$ DESCRIPTION: - Rampup power 25%
 #$ DESCRIPTION: - Motor timing 16 deg
-
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/442
 #$ INCLUDE_WARNING: misc/warnings/en/dshot.txt
 #$ INCLUDE: presets/4.4/tune/defaults.txt
 


### PR DESCRIPTION
Submitting Tune preset called the Barracuda tune. Made for 5 inch FPV racing quads. It's ideal for beginners as it keeps the motor cool with the right amount of filters but also enough pull some sharp moves. 

Preset has been tested by numerous pilots for 5 months with success. No issues on any builds. 
Sample tune in action: https://www.youtube.com/watch?v=w5hmAOC5o2M&t=47s

Preset provides warning that DSHOT 600 and bidirectional DSHOT will be enabled. 

Preset has recommendation to some RClink settings which will give this preset the perfect setting. 


