### PR TITLE
Add SpeedyBee Ultra VTX tables

### DIFF
--- a/presets/4.3/vtx/speedybee_ultra.txt
+++ b/presets/4.3/vtx/speedybee_ultra.txt
@@ -1,0 +1,54 @@
+#$ TITLE: SpeedyBee Ultra VTX Tables
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: vtx, vtx table, speedybee, tx1600, ultra
+#$ AUTHOR: dmak
+#$ DESCRIPTION: VTX tables for the SpeedyBee Ultra.
+#$ DESCRIPTION: Select the regulatory domain in the options (EU or US). Use "Manufacturer" to disable all restrictions.
+#$ DISCLAIMER: Select only one regulatory option. All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/456
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+# Configure common vtxtable settings
+# vtxtable
+vtxtable channels 8
+vtxtable powerlevels 4
+vtxtable powervalues 25 100 200 500
+vtxtable powerlabels 25 200 800 MAX
+
+#$ OPTION_GROUP BEGIN: Regulatory Domain
+
+#$ OPTION BEGIN (CHECKED): Manufacturer
+vtxtable bands 6
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 LOWRACE  L CUSTOM  5362 5399 5436 5473 5510 5547 5584 5621
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): EU
+vtxtable bands 4
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745    0
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860    0
+vtxtable band 4 RACEBAND R CUSTOM     0    0    0 5769 5806 5843    0    0
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): US
+vtxtable bands 5
+vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665    0 5885 5905    0    0
+vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
+#$ OPTION END
+
+#$ OPTION_GROUP END


### PR DESCRIPTION
[Product link](https://www.speedybee.com/speedybee-tx-ultra/)

VTX tables from manufacturer are attached:
* [SpeedyBee-TX ULTRA.EU.json](https://github.com/betaflight/firmware-presets/files/15061997/SpeedyBee-TX.ULTRA.EU.json)
* [SpeedyBee-TX ULTRA.USA.json](https://github.com/betaflight/firmware-presets/files/15061998/SpeedyBee-TX.ULTRA.USA.json)

![5553677213_w640_h640_video-peredatchik-vtx 1](https://github.com/betaflight/firmware-presets/assets/366965/f2729d55-0b1e-4702-bc9b-d825ad97a4ca)
