### PR TITLE
Mutually exclusive option groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ All field tags must be:
 | FORCE_OPTIONS_REVIEW | Opens a dialog advising the user to review the options if they have not done so before applying the Preset.|
 | INCLUDE | Inserts data from one or more separate Presets ahead of the CLI commands of this Preset.  Useful to enforce defaults ahead of your commands. See details below.|
 | OPTION | Commands within `OPTION` tags present the user with a checkbox to apply, or not apply, the enclosed commands.  The default check-box behaviour can be specified.  Each `OPTION` must have a unique name. For more info, [click here](https://github.com/betaflight/firmware-presets#OPTION). |
-| OPTION_GROUP | Text to appear before a group of Options. The group can be made mutually exclusive by adding the (Exclusive) directive |
+| OPTION_GROUP | Text to appear before a group of Options. The group can be made mutually exclusive by prepending the (Exclusive) directive to the name of the group |
 | DISCLAIMER | Field containing text for a disclaimer. |
 | INCLUDE_DISCLAIMER | path to file containing text for a disclaimer, starting from `presets/`` |
 | WARNING | Field containing text for a warning. Intended to be a final dialog before accepting the Preset |
@@ -287,7 +287,7 @@ Complete `OPTION` example syntax looks like this:
 
 You can also make a set of options mutually exclusive, i.e. only one option can be checked within the group at once.
 ```
-#$ OPTION_GROUP BEGIN (Exclusive): A Mutually Exclusive set of options
+#$ OPTION_GROUP BEGIN: (Exclusive) A Mutually Exclusive set of options
     #$ OPTION BEGIN (UNCHECKED): Option the first
         CLI payload strings
     #$ OPTION END

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ All field tags must be:
 | FORCE_OPTIONS_REVIEW | Opens a dialog advising the user to review the options if they have not done so before applying the Preset.|
 | INCLUDE | Inserts data from one or more separate Presets ahead of the CLI commands of this Preset.  Useful to enforce defaults ahead of your commands. See details below.|
 | OPTION | Commands within `OPTION` tags present the user with a checkbox to apply, or not apply, the enclosed commands.  The default check-box behaviour can be specified.  Each `OPTION` must have a unique name. For more info, [click here](https://github.com/betaflight/firmware-presets#OPTION). |
-| OPTION_GROUP | Text to appear before a group of Options. |
+| OPTION_GROUP | Text to appear before a group of Options. The group can be made mutually exclusive by adding the (Exclusive) directive |
 | DISCLAIMER | Field containing text for a disclaimer. |
 | INCLUDE_DISCLAIMER | path to file containing text for a disclaimer, starting from `presets/`` |
 | WARNING | Field containing text for a warning. Intended to be a final dialog before accepting the Preset |
@@ -280,6 +280,18 @@ Complete `OPTION` example syntax looks like this:
         CLI payload strings
     #$ OPTION END
     #$ OPTION BEGIN (UNCHECKED): <Option2 name>
+        CLI payload strings
+    #$ OPTION END
+#$ OPTION_GROUP END
+```
+
+You can also make a set of options mutually exclusive, i.e. only one option can be checked within the group at once.
+```
+#$ OPTION_GROUP BEGIN (Exclusive): A Mutually Exclusive set of options
+    #$ OPTION BEGIN (UNCHECKED): Option the first
+        CLI payload strings
+    #$ OPTION END
+    #$ OPTION BEGIN (UNCHECKED): Other option that might conflict with the first
         CLI payload strings
     #$ OPTION END
 #$ OPTION_GROUP END

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Complete `OPTION` example syntax looks like this:
 
 You can also make a set of options mutually exclusive, i.e. only one option can be checked within the group at once.
 ```
-#$ OPTION_GROUP BEGIN: (Exclusive) A Mutually Exclusive set of options
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) A Mutually Exclusive set of options
     #$ OPTION BEGIN (UNCHECKED): Option the first
         CLI payload strings
     #$ OPTION END

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ All field tags must be:
 | FORCE_OPTIONS_REVIEW | Opens a dialog advising the user to review the options if they have not done so before applying the Preset.|
 | INCLUDE | Inserts data from one or more separate Presets ahead of the CLI commands of this Preset.  Useful to enforce defaults ahead of your commands. See details below.|
 | OPTION | Commands within `OPTION` tags present the user with a checkbox to apply, or not apply, the enclosed commands.  The default check-box behaviour can be specified.  Each `OPTION` must have a unique name. For more info, [click here](https://github.com/betaflight/firmware-presets#OPTION). |
-| OPTION_GROUP | Text to appear before a group of Options. The group can be made mutually exclusive by prepending the (Exclusive) directive to the name of the group |
+| OPTION_GROUP | Text to appear before a group of Options. The group can be made mutually exclusive by prepending the (EXCLUSIVE) directive to the name of the group |
 | DISCLAIMER | Field containing text for a disclaimer. |
 | INCLUDE_DISCLAIMER | path to file containing text for a disclaimer, starting from `presets/`` |
 | WARNING | Field containing text for a warning. Intended to be a final dialog before accepting the Preset |

--- a/indexer/PresetsFile.js
+++ b/indexer/PresetsFile.js
@@ -218,16 +218,27 @@ class PresetsFile
     _getOptionGroup(line)
     {
         const directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_GROUP_DIRECTIVE.length).trim();
+        const isExclusiveGroup = this._isExclusiveGroup(directiveRemoved.toLowerCase());
 
-        if (0 == directiveRemoved.length || directiveRemoved[0] != ":") {
-                this._addError(`line ${this._currentLine}, OPTION_GROUP BEGIN directive should be followed by ":". Example: #$ OPTION_GROUP BEGIN: My Group Name`);
+        const exclusiveOptionGroupRegex = new RegExp(this._escapeRegex(this._settings.OptionsDirectives.EXCLUSIVE_OPTION_GROUP), 'gi');
+
+        const optionGroupName = directiveRemoved.replace(exclusiveOptionGroupRegex, "");
+
+        if (0 == optionGroupName.length || optionGroupName[0] != ":") {
+            this._addError(`line ${this._currentLine}, OPTION_GROUP BEGIN directive should be followed by ":". Example: #$ OPTION_GROUP BEGIN: My Group Name or if its exclusive: #$ OPTION_GROUP BEGIN (Exclusive): My Exclusive Group`);
         }
 
         let optionGroup = {
-            name: directiveRemoved.slice(1).trim(),
+            name: optionGroupName.slice(1).trim(),
+            exclusive: isExclusiveGroup,
         }
 
         return optionGroup;
+    }
+
+    _isExclusiveGroup(lowercaseLine)
+    {
+        return lowercaseLine.includes(this._settings.OptionsDirectives.EXCLUSIVE_OPTION_GROUP)
     }
 
     _getOption(line)

--- a/indexer/PresetsFile.js
+++ b/indexer/PresetsFile.js
@@ -225,7 +225,7 @@ class PresetsFile
         const optionGroupName = directiveRemoved.replace(exclusiveOptionGroupRegex, "");
 
         if (0 == optionGroupName.length || optionGroupName[0] != ":") {
-            this._addError(`line ${this._currentLine}, OPTION_GROUP BEGIN directive should be followed by ":". Example: #$ OPTION_GROUP BEGIN: My Group Name or if its exclusive: #$ OPTION_GROUP BEGIN (Exclusive): My Exclusive Group`);
+            this._addError(`line ${this._currentLine}, OPTION_GROUP BEGIN directive should be followed by ":". Example: #$ OPTION_GROUP BEGIN: My Group Name or if its exclusive: #$ OPTION_GROUP BEGIN: (Exclusive) My Exclusive Group`);
         }
 
         let optionGroup = {

--- a/indexer/PresetsFile.js
+++ b/indexer/PresetsFile.js
@@ -225,7 +225,7 @@ class PresetsFile
         const optionGroupName = directiveRemoved.replace(exclusiveOptionGroupRegex, "");
 
         if (0 == optionGroupName.length || optionGroupName[0] != ":") {
-            this._addError(`line ${this._currentLine}, OPTION_GROUP BEGIN directive should be followed by ":". Example: #$ OPTION_GROUP BEGIN: My Group Name or if its exclusive: #$ OPTION_GROUP BEGIN: (Exclusive) My Exclusive Group`);
+            this._addError(`line ${this._currentLine}, OPTION_GROUP BEGIN directive should be followed by ":". Example: #$ OPTION_GROUP BEGIN: My Group Name or if its exclusive: #$ OPTION_GROUP BEGIN: (EXCLUSIVE) My Exclusive Group`);
         }
 
         let optionGroup = {

--- a/indexer/Settings.js
+++ b/indexer/Settings.js
@@ -51,6 +51,7 @@ const OptionsDirectives = {
     OPTION_UNCHECKED: "(unchecked)",
     BEGIN_OPTION_GROUP_DIRECTIVE: "option_group begin",
     END_OPTION_GROUP_DIRECTIVE: "option_group end",
+    EXCLUSIVE_OPTION_GROUP: "(exclusive)",
 }
 
 const settings = {

--- a/presets/4.3/rc_link/elrs_150hz.txt
+++ b/presets/4.3/rc_link/elrs_150hz.txt
@@ -73,7 +73,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -87,7 +87,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_150hz.txt
+++ b/presets/4.3/rc_link/elrs_150hz.txt
@@ -73,7 +73,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -87,7 +87,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_150hz.txt
+++ b/presets/4.3/rc_link/elrs_150hz.txt
@@ -73,7 +73,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -87,7 +87,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_250hz.txt
+++ b/presets/4.3/rc_link/elrs_250hz.txt
@@ -75,7 +75,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -89,7 +89,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage telemtry readings (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): Voltage telemtry readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_250hz.txt
+++ b/presets/4.3/rc_link/elrs_250hz.txt
@@ -75,7 +75,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -89,7 +89,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Voltage telemtry readings (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) Voltage telemtry readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_250hz.txt
+++ b/presets/4.3/rc_link/elrs_250hz.txt
@@ -75,7 +75,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -89,7 +89,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Voltage telemtry readings (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Voltage telemtry readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_500hz.txt
+++ b/presets/4.3/rc_link/elrs_500hz.txt
@@ -76,7 +76,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -90,7 +90,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_500hz.txt
+++ b/presets/4.3/rc_link/elrs_500hz.txt
@@ -76,7 +76,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -90,7 +90,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_500hz.txt
+++ b/presets/4.3/rc_link/elrs_500hz.txt
@@ -76,7 +76,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -90,7 +90,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_50hz.txt
+++ b/presets/4.3/rc_link/elrs_50hz.txt
@@ -70,7 +70,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -84,7 +84,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_50hz.txt
+++ b/presets/4.3/rc_link/elrs_50hz.txt
@@ -70,7 +70,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -84,7 +84,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/elrs_50hz.txt
+++ b/presets/4.3/rc_link/elrs_50hz.txt
@@ -70,7 +70,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ELRS Rx connection method (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ELRS Rx connection method (choose one):
 
 #$ OPTION BEGIN (UNCHECKED): Serial, separate Rx
 #$ OPTION END
@@ -84,7 +84,7 @@ set rx_spi_protocol = EXPRESSLRS
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/frsky_sbus_fport.txt
+++ b/presets/4.3/rc_link/frsky_sbus_fport.txt
@@ -16,7 +16,7 @@
 
 feature RX_SERIAL
 
-#$ OPTION_GROUP BEGIN (Exclusive): Sbus or FPort (choose only one)
+#$ OPTION_GROUP BEGIN: (Exclusive) Sbus or FPort (choose only one)
 
 #$ OPTION BEGIN (UNCHECKED): Sbus
 set serialrx_provider = SBUS
@@ -44,7 +44,7 @@ set rc_smoothing = ON
 # set frsky_gps_format = ?
 # set smartport_use_extra_sensors = usually off unless you have extra sensors
 
-#$ OPTION_GROUP BEGIN (Exclusive): Fine-tuning...
+#$ OPTION_GROUP BEGIN: (Exclusive) Fine-tuning...
 
 # sharper handling for racing (25 of auto RC smoothing = 47hz RC smoothing)
 #$ OPTION BEGIN (UNCHECKED): Race
@@ -92,7 +92,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/frsky_sbus_fport.txt
+++ b/presets/4.3/rc_link/frsky_sbus_fport.txt
@@ -16,7 +16,7 @@
 
 feature RX_SERIAL
 
-#$ OPTION_GROUP BEGIN: Sbus or FPort (choose only one)
+#$ OPTION_GROUP BEGIN (Exclusive): Sbus or FPort (choose only one)
 
 #$ OPTION BEGIN (UNCHECKED): Sbus
 set serialrx_provider = SBUS
@@ -44,7 +44,7 @@ set rc_smoothing = ON
 # set frsky_gps_format = ?
 # set smartport_use_extra_sensors = usually off unless you have extra sensors
 
-#$ OPTION_GROUP BEGIN: Fine-tuning...
+#$ OPTION_GROUP BEGIN (Exclusive): Fine-tuning...
 
 # sharper handling for racing (25 of auto RC smoothing = 47hz RC smoothing)
 #$ OPTION BEGIN (UNCHECKED): Race
@@ -92,7 +92,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN (Exclusive): Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/rc_link/frsky_sbus_fport.txt
+++ b/presets/4.3/rc_link/frsky_sbus_fport.txt
@@ -16,7 +16,7 @@
 
 feature RX_SERIAL
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Sbus or FPort (choose only one)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Sbus or FPort (choose only one)
 
 #$ OPTION BEGIN (UNCHECKED): Sbus
 set serialrx_provider = SBUS
@@ -44,7 +44,7 @@ set rc_smoothing = ON
 # set frsky_gps_format = ?
 # set smartport_use_extra_sensors = usually off unless you have extra sensors
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Fine-tuning...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Fine-tuning...
 
 # sharper handling for racing (25 of auto RC smoothing = 47hz RC smoothing)
 #$ OPTION BEGIN (UNCHECKED): Race
@@ -92,7 +92,7 @@ set rc_smoothing_throttle_cutoff = 20
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Voltage readings (choose one):
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Voltage readings (choose one):
 
 # per cell or whole pack voltage readings:
 #$ OPTION BEGIN (UNCHECKED): Single Cell values

--- a/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
@@ -107,7 +107,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DSHOT600
 #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
@@ -107,7 +107,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DSHOT600
 #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_AOS_35_tune_filters.txt
@@ -107,7 +107,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DSHOT600
 #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_Digipick_braced.txt
+++ b/presets/4.3/tune/mouseFPV_Digipick_braced.txt
@@ -132,7 +132,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -233,7 +233,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -284,7 +284,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.3/tune/mouseFPV_Digipick_braced.txt
+++ b/presets/4.3/tune/mouseFPV_Digipick_braced.txt
@@ -132,7 +132,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -233,7 +233,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -284,7 +284,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.3/tune/mouseFPV_Digipick_braced.txt
+++ b/presets/4.3/tune/mouseFPV_Digipick_braced.txt
@@ -132,7 +132,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -233,7 +233,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -284,7 +284,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --

--- a/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --

--- a/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --

--- a/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.3/tune/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
@@ -109,7 +109,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --

--- a/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
@@ -109,7 +109,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --

--- a/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.3/tune/mouseFPV_toothpick3_3s.txt
@@ -109,7 +109,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
 #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
 # -- Filter Settings --

--- a/presets/4.4/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.4/tune/ctzsnooze_5in_4S_race.txt
@@ -85,7 +85,7 @@ set dyn_idle_p_gain = 40
 
 # -- Filters --
 
-#$ OPTION_GROUP BEGIN: Choose ONE Filter option...
+#$ OPTION_GROUP BEGIN (Exclusive): Choose ONE Filter option...
     #$ OPTION BEGIN (UNCHECKED): RPM enabled, normal build
     #$ INCLUDE: presets/4.3/filters/ctzsnooze_race.txt
     #$ OPTION END
@@ -101,7 +101,7 @@ set dyn_idle_p_gain = 40
 
 # -- Fast Rx Link Options --
 
-#$ OPTION_GROUP BEGIN: Choose your RC link speed!
+#$ OPTION_GROUP BEGIN (Exclusive): Choose your RC link speed!
     #$ OPTION BEGIN (UNCHECKED): 150Hz or less
         #$ INCLUDE: presets/4.3/rc_link/generic/150hz_race.txt
     #$ OPTION END

--- a/presets/4.4/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.4/tune/ctzsnooze_5in_4S_race.txt
@@ -85,7 +85,7 @@ set dyn_idle_p_gain = 40
 
 # -- Filters --
 
-#$ OPTION_GROUP BEGIN (Exclusive): Choose ONE Filter option...
+#$ OPTION_GROUP BEGIN: (Exclusive) Choose ONE Filter option...
     #$ OPTION BEGIN (UNCHECKED): RPM enabled, normal build
     #$ INCLUDE: presets/4.3/filters/ctzsnooze_race.txt
     #$ OPTION END
@@ -101,7 +101,7 @@ set dyn_idle_p_gain = 40
 
 # -- Fast Rx Link Options --
 
-#$ OPTION_GROUP BEGIN (Exclusive): Choose your RC link speed!
+#$ OPTION_GROUP BEGIN: (Exclusive) Choose your RC link speed!
     #$ OPTION BEGIN (UNCHECKED): 150Hz or less
         #$ INCLUDE: presets/4.3/rc_link/generic/150hz_race.txt
     #$ OPTION END

--- a/presets/4.4/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.4/tune/ctzsnooze_5in_4S_race.txt
@@ -85,7 +85,7 @@ set dyn_idle_p_gain = 40
 
 # -- Filters --
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Choose ONE Filter option...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Choose ONE Filter option...
     #$ OPTION BEGIN (UNCHECKED): RPM enabled, normal build
     #$ INCLUDE: presets/4.3/filters/ctzsnooze_race.txt
     #$ OPTION END
@@ -101,7 +101,7 @@ set dyn_idle_p_gain = 40
 
 # -- Fast Rx Link Options --
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Choose your RC link speed!
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Choose your RC link speed!
     #$ OPTION BEGIN (UNCHECKED): 150Hz or less
         #$ INCLUDE: presets/4.3/rc_link/generic/150hz_race.txt
     #$ OPTION END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -129,7 +129,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -230,7 +230,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -281,7 +281,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -129,7 +129,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -230,7 +230,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -281,7 +281,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -129,7 +129,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -230,7 +230,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -281,7 +281,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.3/filters/defaults.txt

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -106,7 +106,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-    #$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+    #$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -106,7 +106,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-    #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+    #$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.4/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -106,7 +106,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-    #$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+    #$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.4/tune/uav_tech/UAV_tech_10in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_10in.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_10in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_10in.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_10in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_10in.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
@@ -58,7 +58,7 @@ set anti_gravity_gain = 80
 set pidsum_limit = 1000
 set pidsum_limit_yaw = 1000
 
-#$ OPTION_GROUP BEGIN: Choose ONE Filter option (+ RPM filter if desired)
+#$ OPTION_GROUP BEGIN (Exclusive): Choose ONE Filter option (+ RPM filter if desired)
     #$ OPTION BEGIN (UNCHECKED): low Build Quality
 	# -- ADDER: For HIGH gyro vibration builds --
     	set simplified_gyro_filter = ON
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
  	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
@@ -58,7 +58,7 @@ set anti_gravity_gain = 80
 set pidsum_limit = 1000
 set pidsum_limit_yaw = 1000
 
-#$ OPTION_GROUP BEGIN (Exclusive): Choose ONE Filter option (+ RPM filter if desired)
+#$ OPTION_GROUP BEGIN: (Exclusive) Choose ONE Filter option (+ RPM filter if desired)
     #$ OPTION BEGIN (UNCHECKED): low Build Quality
 	# -- ADDER: For HIGH gyro vibration builds --
     	set simplified_gyro_filter = ON
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
  	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
@@ -58,7 +58,7 @@ set anti_gravity_gain = 80
 set pidsum_limit = 1000
 set pidsum_limit_yaw = 1000
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Choose ONE Filter option (+ RPM filter if desired)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Choose ONE Filter option (+ RPM filter if desired)
     #$ OPTION BEGIN (UNCHECKED): low Build Quality
 	# -- ADDER: For HIGH gyro vibration builds --
     	set simplified_gyro_filter = ON
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
  	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
@@ -117,7 +117,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
@@ -117,7 +117,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
@@ -117,7 +117,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_6-7in.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_8-9in.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
@@ -115,7 +115,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
@@ -115,7 +115,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
@@ -115,7 +115,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinelog.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinelog.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinelog.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinelog.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinelog.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinelog.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Micro.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Micro.txt
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Micro.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Micro.txt
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Micro.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Micro.txt
@@ -107,7 +107,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.4/tune/uav_tech/UAV_tech_Whoop.txt
@@ -111,7 +111,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.5/tune/ctzsnooze_5in_4S_race.txt
@@ -85,7 +85,7 @@ set dyn_idle_p_gain = 40
 
 # -- Filters --
 
-#$ OPTION_GROUP BEGIN: Choose ONE Filter option...
+#$ OPTION_GROUP BEGIN (Exclusive): Choose ONE Filter option...
     #$ OPTION BEGIN (UNCHECKED): RPM enabled, normal build
     #$ INCLUDE: presets/4.3/filters/ctzsnooze_race.txt
     #$ OPTION END

--- a/presets/4.5/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.5/tune/ctzsnooze_5in_4S_race.txt
@@ -85,7 +85,7 @@ set dyn_idle_p_gain = 40
 
 # -- Filters --
 
-#$ OPTION_GROUP BEGIN (Exclusive): Choose ONE Filter option...
+#$ OPTION_GROUP BEGIN: (Exclusive) Choose ONE Filter option...
     #$ OPTION BEGIN (UNCHECKED): RPM enabled, normal build
     #$ INCLUDE: presets/4.3/filters/ctzsnooze_race.txt
     #$ OPTION END

--- a/presets/4.5/tune/ctzsnooze_5in_4S_race.txt
+++ b/presets/4.5/tune/ctzsnooze_5in_4S_race.txt
@@ -85,7 +85,7 @@ set dyn_idle_p_gain = 40
 
 # -- Filters --
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Choose ONE Filter option...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Choose ONE Filter option...
     #$ OPTION BEGIN (UNCHECKED): RPM enabled, normal build
     #$ INCLUDE: presets/4.3/filters/ctzsnooze_race.txt
     #$ OPTION END

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.5/filters/defaults.txt
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.5/filters/defaults.txt
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_AOS_35_tune_filters.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 # This is where the author includes options that require input from the User
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.5/filters/defaults.txt
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -129,7 +129,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -230,7 +230,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -281,7 +281,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -129,7 +129,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -230,7 +230,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -281,7 +281,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_Digipick_braced.txt
@@ -129,7 +129,7 @@ set yaw_lowpass_hz = 100
 
 
 # ------ OPTIONS GO BELOW THIS LINE ------
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- End Defaults --
@@ -230,7 +230,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) PID Options (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) PID Options (Choose One or None)
 
     #$ OPTION BEGIN (UNCHECKED): Standard Lipo 4s
         # -- PID Sliders  --
@@ -281,7 +281,7 @@ set yaw_lowpass_hz = 100
 #$ OPTION_GROUP END
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Auto Profiles (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Auto Profiles (Choose One or None)
     #$ OPTION BEGIN (UNCHECKED): Auto Switch 3s Profile
         set auto_profile_cell_count = 3
     #$ OPTION END

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_FFVCycle_Incisor_PT5_tune_filters.txt
@@ -116,7 +116,7 @@ set yaw_lowpass_hz = 100
 # ------ OPTIONS GO BELOW THIS LINE ------
 
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
         #$ INCLUDE: presets/4.5/filters/defaults.txt

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
         #$ INCLUDE: presets/4.5/filters/defaults.txt

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_FPVCycle_Sonicare_tune_filters.txt
@@ -102,7 +102,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600 (F7 & Up)
         #$ INCLUDE: presets/4.5/filters/defaults.txt

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.5/filters/defaults.txt

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.5/filters/defaults.txt

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_ImpuseRC_Apex_tune.txt
@@ -104,7 +104,7 @@ set yaw_lowpass_hz = 100
 
 # ------ OPTIONS GO BELOW THIS LINE ------
 
-#$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
 
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         #$ INCLUDE: presets/4.5/filters/defaults.txt

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -106,7 +106,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-    #$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
+    #$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -106,7 +106,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-    #$ OPTION_GROUP BEGIN: Filters (Choose One or None)
+    #$ OPTION_GROUP BEGIN (Exclusive): Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.5/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
+++ b/presets/4.5/tune/mouse_fpv/mouseFPV_toothpick3_3s.txt
@@ -106,7 +106,7 @@ set yaw_lowpass_hz = 100
 
 
 # This is where the author includes options that require input from the User
-    #$ OPTION_GROUP BEGIN: (Exclusive) Filters (Choose One or None)
+    #$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters (Choose One or None)
     #$ OPTION BEGIN (CHECKED): RPM Filters DShot600
         # -- Filter Settings --
 

--- a/presets/4.5/tune/uav_tech/UAV_tech_10in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_10in.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_10in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_10in.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_10in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_10in.txt
@@ -109,7 +109,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
  	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
  	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_575-650.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
  	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
@@ -118,7 +118,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
@@ -118,7 +118,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Freestyle_650-750.txt
@@ -118,7 +118,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_5in_Race_500-575.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
   	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_6-7in.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_6-7in.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_6-7in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_6-7in.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_8-9in.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_8-9in.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_8-9in.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
@@ -116,7 +116,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
@@ -116,7 +116,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinelifter_8-9in.txt
@@ -116,7 +116,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinelog.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinelog.txt
@@ -110,7 +110,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinelog.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinelog.txt
@@ -110,7 +110,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinelog.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinelog.txt
@@ -110,7 +110,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -110,7 +110,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -110,7 +110,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Cinewhoop.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Cinewhoop.txt
@@ -110,7 +110,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Micro.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Micro.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Micro.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Micro.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Micro.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Micro.txt
@@ -108,7 +108,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Whoop.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Whoop.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: ESC PWM Options ...
+#$ OPTION_GROUP BEGIN (Exclusive): ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0

--- a/presets/4.5/tune/uav_tech/UAV_tech_Whoop.txt
+++ b/presets/4.5/tune/uav_tech/UAV_tech_Whoop.txt
@@ -112,7 +112,7 @@ set pidsum_limit_yaw = 1000
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (Exclusive) ESC PWM Options ...
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
     #$ OPTION BEGIN (UNCHECKED): 16 & 24k ESC PWM Settings
     	# -- ADDER: For 16 & 24k ESC PWM Settings --
     	set thrust_linear = 0


### PR DESCRIPTION
Add support for mutually exclusive option groups. This uses the directive `(Exclusive)` that can optionally be added on `OPTION GROUP`, .e.g. `#$ OPTION GROUP BEGIN (Exclusive): My Group of Options that should only have one checked at once:`

This allows preset authors to write presets that enforce only one of several options to be selected at once, which is helpful when applying multiple would produce unintended results.

See [this PR](https://github.com/betaflight/betaflight-configurator/pull/3940) for Configurator updates to support the new directive.

Let me know if I should break the changes to the presets into its own PR.