### PR TITLE
Add presets for the AOS T3

### DIFF
--- a/presets/4.4/filters/aos_rc/aos_t3_filters.txt
+++ b/presets/4.4/filters/aos_rc/aos_t3_filters.txt
@@ -1,0 +1,40 @@
+#$ TITLE: AOS T3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: FILTERS
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: filter, filters, aos, chris, rosser, T3, 3
+#$ AUTHOR: Chris Rosser
+#$ DESCRIPTION: Developed for the AOS T3
+#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
+#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK.
+#$ DISCUSSION: https://www.aos-rc.com
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.3/filters/defaults.txt
+
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 1000
+set simplified_gyro_filter = OFF
+
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 150
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 3
+set rpm_filter_fade_range_hz = 50
+set rpm_filter_min_hz = 100
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 80
+set dterm_lpf1_dyn_max_hz = 110
+set dterm_lpf1_type = BIQUAD
+set dterm_lpf2_static_hz = 0
+set simplified_dterm_filter = OFF

--- a/presets/4.4/tune/aos_rc/aos_t3_tune.txt
+++ b/presets/4.4/tune/aos_rc/aos_t3_tune.txt
@@ -1,0 +1,140 @@
+#$ TITLE: AOS T3 tune by Chris Rosser
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.3
+#$ CATEGORY: TUNE
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: aos, chris, rosser, pid, tune, T3, 3
+#$ AUTHOR: Chris Rosser
+#$ DISCUSSION: https://www.aos-rc.com
+#$ DESCRIPTION: Custom Tune for the AOS T3. Based on a 450mAh 3S build with 5000KV Motors.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Master multiplier is set to 1.0 for safety. Increase it carefully to further improve flight performance.
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM filtering is MANDATORY!
+#$ DESCRIPTION:
+#$ DESCRIPTION: Please carefully review the options above and tick any that are relevant.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Choose your RC link speed.
+#$ DESCRIPTION:
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.4/tune/defaults.txt
+
+# -- PID values --
+
+set p_pitch = 33
+set i_pitch = 59
+set f_pitch = 124
+set p_roll = 33
+set i_roll = 60
+set f_roll = 125
+set p_yaw = 33
+set i_yaw = 60
+set f_yaw = 125
+set simplified_pi_gain = 75
+set simplified_feedforward_gain = 105
+set simplified_pitch_pi_gain = 95
+
+# -- iTerm relax (default)--
+# -- iTerm windup (default)--
+# -- iTerm rotation (off, default) --
+
+# -- Dmax --
+set d_max_advance = 0
+
+# -- TPA --
+
+# -- Feedforward --
+set feedforward_max_rate_limit = 95
+
+# -- PIDsum limits (default)--
+# -- Antigravity (default) --
+# -- Absolute control (off, default) --
+# -- Accecleration limits (off, default) --
+# -- Angle and Horizon mode tuning (default) --
+# -- PIDs active below min throttle (default) --
+# -- Set mixer type to default (legacy) --
+# -- Set yaw spin recovery to default, which is auto --
+# -- Set integrated yaw to off, so pitch and yaw are independent (default) --
+# -- Gyro cal on first arm (off, default) --
+# -- Transient throttle limit (off, default) --
+# -- Thrust linear (off, default) --
+# -- Throttle boost (default, 5)
+# -- VBat warning threshold --
+
+# -- DShot Idle --
+set dshot_idle_value = 300
+
+# -- Dynamic idle ON at 5000 rpm --
+set dyn_idle_min_rpm = 50
+set dyn_idle_p_gain = 40
+
+
+# ------ OPIONS GO BELOW THIS LINE ------
+
+# -- Filters --
+
+#$ OPTION_GROUP BEGIN: Filters
+    #$ OPTION BEGIN (CHECKED): AOS Filters (Recommended)
+    #$ INCLUDE: presets/4.4/filters/aos_rc/aos_t3_filters.txt
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+# -- Fast Rx Link Options --
+
+#$ OPTION_GROUP BEGIN: Choose your RC link (or apply another preset separately)
+    #$ OPTION BEGIN (UNCHECKED): ELRS_250HZ (Recommended)
+        #$ INCLUDE: presets/4.3/rc_link/elrs_250hz.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS_500HZ
+        #$ INCLUDE: presets/4.3/rc_link/elrs_500hz.txt
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): DJI Normal
+        #$ INCLUDE: presets/4.3/rc_link/DJI_Normal.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): DJI SBUS FAST
+        #$ INCLUDE: presets/4.3/rc_link/DJI_SBUS_Fast.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Crossfire 50Hz
+        #$ INCLUDE: presets/4.3/rc_link/tbs/crossfire_50hz.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Crossfire 150Hz
+        #$ INCLUDE: presets/4.3/rc_link/tbs/crossfire_150hz.txt
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+# -- Recommended options --
+
+#$ OPTION_GROUP BEGIN: Check all of these (recommended)
+
+    # -- VBat sag compensation --
+    #$ OPTION BEGIN (UNCHECKED): Full battery sag compensation
+        set vbat_sag_compensation = 100
+        set vbat_sag_lpf_period = 2
+    #$ OPTION END
+
+    # -- Stick behaviour --
+    #$ OPTION BEGIN (UNCHECKED): No stick deadband
+        set deadband = 0
+        set yaw_deadband = 0
+    #$ OPTION END
+
+    # -- Startup and arming --
+    #$ OPTION BEGIN (UNCHECKED): Arm at any angle
+        set small_angle = 180
+    #$ OPTION END
+
+    # -- Prop direction --
+    #$ OPTION BEGIN (UNCHECKED): Props out (check motor direction!)
+        set yaw_motors_reversed = ON
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+simplified_tuning apply

--- a/presets/4.5/filters/aos_rc/aos_t3_filters.txt
+++ b/presets/4.5/filters/aos_rc/aos_t3_filters.txt
@@ -1,0 +1,51 @@
+#$ TITLE: AOS T3 Filters
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: FILTERS
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: filter, filters, aos, chris, rosser, T3, 3
+#$ AUTHOR: Chris Rosser
+#$ DESCRIPTION: Developed for the AOS T3
+#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
+#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK.
+#$ DISCUSSION: https://www.aos-rc.com
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 1000
+set simplified_gyro_filter = OFF
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 150
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 3
+set rpm_filter_fade_range_hz = 50
+set rpm_filter_min_hz = 100
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 80
+set dterm_lpf1_dyn_max_hz = 110
+set dterm_lpf1_type = BIQUAD
+set dterm_lpf2_static_hz = 0
+set simplified_dterm_filter = OFF
+
+# ------ OPIONS GO BELOW THIS LINE ------
+
+# -- RPM Filter Weights --
+
+#$ OPTION_GROUP BEGIN: Props
+    #$ OPTION BEGIN (CHECKED): RPM Filter Weights for triblade props
+        set rpm_filter_weights = 100, 0, 80
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filter Weights for other props
+        set rpm_filter_weights = 100, 100, 100
+    #$ OPTION END
+#$ OPTION_GROUP END

--- a/presets/4.5/tune/aos_rc/aos_t3_tune.txt
+++ b/presets/4.5/tune/aos_rc/aos_t3_tune.txt
@@ -1,0 +1,147 @@
+#$ TITLE: AOS T3 tune by Chris Rosser
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: TUNE
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: aos, chris, rosser, pid, tune, T3, 3
+#$ AUTHOR: Chris Rosser
+#$ DISCUSSION: https://www.aos-rc.com
+#$ DESCRIPTION: Custom Tune for the AOS T3. Based on a 450mAh 3S build with 5000KV Motors.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Master multiplier is set to 1.0 for safety. Increase it carefully to further improve flight performance.
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM filtering is MANDATORY!
+#$ DESCRIPTION:
+#$ DESCRIPTION: Please carefully review the options above and tick any that are relevant.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Choose your RC link speed.
+#$ DESCRIPTION:
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.5/tune/defaults.txt
+
+# -- PID values --
+
+set p_pitch = 33
+set i_pitch = 59
+set f_pitch = 124
+set p_roll = 33
+set i_roll = 60
+set f_roll = 125
+set p_yaw = 33
+set i_yaw = 60
+set f_yaw = 125
+set simplified_pi_gain = 75
+set simplified_feedforward_gain = 105
+set simplified_pitch_pi_gain = 95
+
+# -- iTerm relax (default)--
+# -- iTerm windup (default)--
+# -- iTerm rotation (off, default) --
+
+# -- Dmax --
+set d_max_advance = 0
+
+# -- TPA --
+
+# -- Feedforward --
+set feedforward_max_rate_limit = 95
+
+# -- PIDsum limits (default)--
+# -- Antigravity (default) --
+# -- Absolute control (off, default) --
+# -- Accecleration limits (off, default) --
+# -- Angle and Horizon mode tuning (default) --
+# -- PIDs active below min throttle (default) --
+# -- Set mixer type to default (legacy) --
+# -- Set yaw spin recovery to default, which is auto --
+# -- Set integrated yaw to off, so pitch and yaw are independent (default) --
+# -- Gyro cal on first arm (off, default) --
+# -- Transient throttle limit (off, default) --
+# -- Thrust linear (off, default) --
+# -- Throttle boost (default, 5)
+# -- VBat warning threshold --
+
+# -- DShot Idle --
+set dshot_idle_value = 300
+
+# -- Dynamic idle ON at 5000 rpm --
+set dyn_idle_min_rpm = 50
+set dyn_idle_p_gain = 40
+
+
+# ------ OPIONS GO BELOW THIS LINE ------
+
+# -- Filters --
+
+#$ OPTION_GROUP BEGIN: Filters
+    #$ OPTION BEGIN (CHECKED): AOS Filters (Recommended)
+    #$ INCLUDE: presets/4.5/filters/aos_rc/aos_t3_filters.txt
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (CHECKED): RPM Filter Weights for triblade props
+        set rpm_filter_weights = 100, 0, 80
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): RPM Filter Weights for other props
+        set rpm_filter_weights = 100, 100, 100
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+# -- Fast Rx Link Options --
+
+#$ OPTION_GROUP BEGIN: Choose your RC link (or apply another preset separately)
+    #$ OPTION BEGIN (UNCHECKED): ELRS_250HZ (Recommended)
+        #$ INCLUDE: presets/4.3/rc_link/elrs_250hz.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS_500HZ
+        #$ INCLUDE: presets/4.3/rc_link/elrs_500hz.txt
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): DJI Normal
+        #$ INCLUDE: presets/4.3/rc_link/DJI_Normal.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): DJI SBUS FAST
+        #$ INCLUDE: presets/4.3/rc_link/DJI_SBUS_Fast.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Crossfire 50Hz
+        #$ INCLUDE: presets/4.3/rc_link/tbs/crossfire_50hz.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Crossfire 150Hz
+        #$ INCLUDE: presets/4.3/rc_link/tbs/crossfire_150hz.txt
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+# -- Recommended options --
+
+#$ OPTION_GROUP BEGIN: Check all of these (recommended)
+
+    # -- VBat sag compensation --
+    #$ OPTION BEGIN (UNCHECKED): Full battery sag compensation
+        set vbat_sag_compensation = 100
+        set vbat_sag_lpf_period = 2
+    #$ OPTION END
+
+    # -- Stick behaviour --
+    #$ OPTION BEGIN (UNCHECKED): No stick deadband
+        set deadband = 0
+        set yaw_deadband = 0
+    #$ OPTION END
+
+    # -- Startup and arming --
+    #$ OPTION BEGIN (UNCHECKED): Arm at any angle
+        set small_angle = 180
+    #$ OPTION END
+
+    # -- Prop direction --
+    #$ OPTION BEGIN (UNCHECKED): Props out (check motor direction!)
+        set yaw_motors_reversed = ON
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+simplified_tuning apply


### PR DESCRIPTION
Identical to previous AOS presets in form and function. This preset is for the AOS T3 frame. It needs a slightly lower P:D ratio and higher dynamic idle than stock.

Configs for 4.3, 4.4 and 4.5 are included.