### PR TITLE
Karate changes

### DIFF
--- a/presets/4.5/tune/karate/karate_brushless_whoop.txt
+++ b/presets/4.5/tune/karate/karate_brushless_whoop.txt
@@ -64,9 +64,16 @@ set dterm_lpf1_dyn_expo = 7
 # -- RPM filtering --
 set dshot_bidir = ON
 set rpm_filter_fade_range_hz = 100
+#$ OPTION BEGIN (CHECKED): 3 blade prop
+    set rpm_filter_weights = 100,50,100
+#$ OPTION END
+#$ OPTION BEGIN (UNCHECKED): 2 blade prop
+    set rpm_filter_weights = 100,100,50
+#$ OPTION END
+set rpm_filter_fade_range_hz = 100
 
 # -- Misc --
-set thrust_linear = 20
+set thrust_linear = 30
 
 
 # -- PIDsum limits --
@@ -75,19 +82,6 @@ set pidsum_limit_yaw = 1000
 
 
 # -- PID values --
-set p_pitch = 41
-set i_pitch = 70
-set d_pitch = 37
-set f_pitch = 110
-set p_roll = 41
-set i_roll = 70
-set d_roll = 37
-set f_roll = 111
-set p_yaw = 41
-set i_yaw = 70
-set f_yaw = 111
-set d_min_roll = 37
-set d_min_pitch = 37
 set simplified_master_multiplier = 155
 set simplified_i_gain = 95
 set simplified_d_gain = 80
@@ -96,6 +90,7 @@ set simplified_dmax_gain = 0
 set simplified_feedforward_gain = 60
 set simplified_pitch_d_gain = 90
 set simplified_pitch_pi_gain = 95
+simplified_tuning apply
 
 #$ OPTION BEGIN (UNCHECKED): Dshot600
     set dshot_bidir = ON

--- a/presets/4.5/tune/karate/karate_brushless_whoop.txt
+++ b/presets/4.5/tune/karate/karate_brushless_whoop.txt
@@ -73,8 +73,10 @@ set rpm_filter_fade_range_hz = 100
 set rpm_filter_fade_range_hz = 100
 
 # -- Misc --
-set thrust_linear = 30
+set thrust_linear = 20
 
+# -- iTerm  --
+set iterm_relax_cutoff = 30
 
 # -- PIDsum limits --
 set iterm_limit = 500

--- a/presets/4.5/tune/karate/karate_race.txt
+++ b/presets/4.5/tune/karate/karate_race.txt
@@ -79,7 +79,7 @@ set thrust_linear = 0
 set throttle_boost = 2
 
 # -- iTerm  --
-set iterm_relax_cutoff = 20
+set iterm_relax_cutoff = 45
 
 # -- PIDsum limits --
 set iterm_limit = 500
@@ -120,7 +120,7 @@ set tpa_breakpoint = 1250
     set dyn_idle_p_gain = 35
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Spicy tune
+#$ OPTION BEGIN (UNCHECKED): Old Spice
 
     #spicy tune use with care
     # -- Gyro Dynamic Notches --
@@ -134,6 +134,38 @@ set tpa_breakpoint = 1250
 
     # -- RPM filtering --
     set rpm_filter_harmonics = 2
+    set rpm_filter_min_hz = 150
+
+    # -- PID values --
+    set simplified_pids_mode = RP
+    set simplified_i_gain = 115
+    set simplified_d_gain = 85
+    set simplified_pi_gain = 85
+    set simplified_dmax_gain = 140
+    set simplified_feedforward_gain = 105
+    set simplified_pitch_d_gain = 95
+    set simplified_pitch_pi_gain = 105
+    simplified_tuning apply
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): New Spice ( mid 2024)
+    #spicy tune use with care
+    
+    # -- Gyro Lowpass Filters --
+       set gyro_lpf1_dyn_min_hz = 0
+       
+    # -- Gyro Dynamic Notches --
+    set dyn_notch_count = 1
+    set dyn_notch_q = 600
+    set dyn_notch_min_hz = 200
+    set dyn_notch_max_hz = 650
+
+    # -- Dterm filtering --
+    set dterm_lpf1_dyn_expo = 10
+
+    # -- RPM Filtering --
+    set rpm_filter_harmonics = 3
+    set rpm_filter_weights = 100,50,100
     set rpm_filter_min_hz = 150
 
     # -- PID values --

--- a/presets/4.5/tune/karate/karate_race_lite.txt
+++ b/presets/4.5/tune/karate/karate_race_lite.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 4.5
 #$ CATEGORY: TUNE
 #$ STATUS:  OFFICIAL
-#$ KEYWORDS: karate, race, 5 inch, 5", sugarK, limon, ctzsnooze, KarateBrot, ultralite, viper, viper lite, sliders
+#$ KEYWORDS: karate, race, 5 inch, 5", sugarK, limon, ctzsnooze, KarateBrot, ultralite, viper, viper lite, bezerkrc, neuron, nano, 2024 sliders
 #$ AUTHOR: sugarK
 
 #$ PARSER: MARKED
@@ -13,11 +13,11 @@
 #$ DESCRIPTION: <br>
 #$ DESCRIPTION:
 #$ DESCRIPTION: This racing tune was developed from the Karate Race tune to suit my new Viper lite ultralite 5" racer project. [Viper Lite](https://rotorbuilds.com/build/29775)
-#$ DESCRIPTION:
+#$ DESCRIPTION: The continued development comes from my new racing setup the Bezerk RC [Neuron nano](https://rotorbuilds.com/build/32174#c51556) 
 #$ DESCRIPTION: <br>
 #$ DESCRIPTION:
 #$ DESCRIPTION: This tune should be used with 48khz PWM settings or firmware and it 'SHOULD' work with other ultralite 5" frames eg the ET-5.
-#$ DESCRIPTION: The 4.4 version is slider based to make it easier to adjust for personal taste but use at your own risk.
+#$ DESCRIPTION: From Betaflight 4.4 the tune  is slider based to make it easier to adjust for personal taste but use at your own risk.
 #$ DESCRIPTION:
 #$ DESCRIPTION: <br>
 #$ DESCRIPTION:
@@ -41,7 +41,7 @@
 #$ INCLUDE: presets/4.5/tune/defaults.txt
 #$ INCLUDE: presets/4.5/filters/defaults.txt
 
-# -- Gyro lowpass filters --
+# -- Gyro Lowpass Filters --
 set gyro_lpf1_static_hz = 0
 set gyro_lpf1_dyn_min_hz = 500
 set gyro_lpf1_dyn_max_hz = 1000
@@ -54,10 +54,10 @@ set dyn_notch_q = 450
 set dyn_notch_min_hz = 125
 set dyn_notch_max_hz = 650
 
-# -- Dterm filtering --
+# -- Dterm Filtering --
 set dterm_lpf1_dyn_expo = 7
 
-# -- RPM filtering --
+# -- RPM Filtering --
 set dshot_bidir = ON
 set rpm_filter_fade_range_hz = 100
 
@@ -66,14 +66,14 @@ set yaw_spin_recovery = AUTO
 set thrust_linear = 20
 
 # -- iTerm  --
-set iterm_relax_cutoff = 20
+set iterm_relax_cutoff = 45
 
-# -- PIDsum limits --
+# -- PIDsum Limits --
 set iterm_limit = 500
 set pidsum_limit_yaw = 1000
 
 
-# -- PID values --
+# -- PID Values --
 set simplified_pids_mode = RP
 set simplified_i_gain = 115
 set simplified_d_gain = 75
@@ -100,7 +100,7 @@ set tpa_breakpoint = 1250
     set motor_pwm_protocol = Dshot300
 #$ OPTION END
 
-#$ OPTION BEGIN (UNCHECKED): Dynamic idle for 4s 2850-3000kv
+#$ OPTION BEGIN (UNCHECKED): Dynamic Idle for 4s 2850-3000kv
     #dynamic idle for 4s 2850-3000kv
     set dyn_idle_min_rpm = 50
     set dyn_idle_p_gain = 35
@@ -168,26 +168,26 @@ set tpa_breakpoint = 1250
 
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: Spicy Tune
+#$ OPTION_GROUP BEGIN: Old Spice
     #$ OPTION BEGIN (UNCHECKED): Spicy Filters
         
-        # -- Gyro lowpass filters --
+        # -- Gyro Lowpass Filters --
         set gyro_lpf2_static_hz = 650
         
         # -- Gyro Dynamic Notches --
         set dyn_notch_count = 1
         set dyn_notch_q = 500
         
-        # -- RPM filtering --
+        # -- RPM Filtering --
         set rpm_filter_harmonics = 2
         
-        # -- Dterm filtering --
+        # -- Dterm Filtering --
         set dterm_lpf1_dyn_expo = 10
         
-     #$ OPTION END
+    #$ OPTION END
     #$ OPTION BEGIN (UNCHECKED): Spicy PIDs (not for 6s)
         
-        # -- PID values --
+        # -- PID Values --
         set simplified_pids_mode = RP
         set simplified_master_multiplier = 110
         set simplified_i_gain = 115
@@ -202,9 +202,67 @@ set tpa_breakpoint = 1250
 
 #$ OPTION_GROUP END
 
+#$ OPTION_GROUP BEGIN: New Spice (mid 2024)
+    #$ OPTION BEGIN (UNCHECKED): New Spicy Filters and Iterm
+        
+        # -- Gyro Lowpass Filters --
+       set gyro_lpf1_dyn_min_hz = 0
+        
+        # -- Gyro Dynamic Notches --
+        set dyn_notch_count = 1
+        set dyn_notch_q = 450
+        set dyn_notch_min_hz = 125
+        set dyn_notch_max_hz = 650
+        
+        # -- RPM Filtering --
+        set rpm_filter_harmonics = 3
+        set rpm_filter_weights = 100,50,100
+        set rpm_filter_fade_range_hz = 100
+        
+    #$ OPTION END
+    #$ OPTION BEGIN (UNCHECKED): 4s Tune
+    
+        # --set profile 1 to 4s
+        profile 0
+        set profile_name = 4s
+        
+        # -- 4s PID and Filter Values --
+        set simplified_pids_mode = RP
+        set simplified_master_multiplier = 110
+        set simplified_i_gain = 115
+        set simplified_d_gain = 80
+        set simplified_pi_gain = 85
+        set simplified_dmax_gain = 125
+        set simplified_pitch_d_gain = 90
+        set simplified_dterm_filter_multiplier = 110
+        simplified_tuning apply
+        set yaw_lowpass_hz = 50
+        
+    #$ OPTION END
+    #$ OPTION BEGIN (UNCHECKED): 6s Tune
+    
+        # --set profile 2 to 4s
+        profile 1
+        set profile_name = 6s
+        
+        # -- 6s PID and Filter Values --
+        set simplified_pids_mode = RP
+        set simplified_i_gain = 115
+        set simplified_d_gain = 85
+        set simplified_pi_gain = 85
+        set simplified_dmax_gain = 125
+        set simplified_pitch_d_gain = 90
+        set simplified_pitch_pi_gain = 110
+        set simplified_dterm_filter_multiplier = 90
+        simplified_tuning apply
+        set yaw_lowpass_hz = 50
+        
+    #$ OPTION END
+#$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: Optional rates
-    #$ OPTION BEGIN (UNCHECKED): sugarK's rates
+
+#$ OPTION_GROUP BEGIN: Optional Rates
+    #$ OPTION BEGIN (UNCHECKED): sugarK's Rates
         #$ INCLUDE: presets/4.3/rates/SugarK.txt
     #$ OPTION END
 

--- a/presets/4.5/tune/karate/tiny_karate.txt
+++ b/presets/4.5/tune/karate/tiny_karate.txt
@@ -38,12 +38,7 @@
 #$ INCLUDE: presets/4.5/filters/defaults.txt
 
 # -- Gyro lowpass filters --
-set gyro_lpf2_static_hz = 600
-set gyro_lpf1_dyn_min_hz = 500
-set gyro_lpf1_dyn_max_hz = 1000
-set acc_lpf_hz = 10
-set simplified_gyro_filter = OFF
-set simplified_gyro_filter_multiplier = 200
+set gyro_lpf1_static_hz = 0
 
 # -- Gyro Dynamic Notches --
 set dyn_notch_count = 1
@@ -56,6 +51,7 @@ set dterm_lpf1_dyn_expo = 10
 
 # -- RPM filtering --
 set dshot_bidir = ON
+set rpm_filter_weights = 100,50,100
 set rpm_filter_fade_range_hz = 100
 set motor_poles = 12
 
@@ -65,7 +61,7 @@ set thrust_linear = 0
 set throttle_boost = 7
 
 # -- iTerm  --
-set iterm_relax_cutoff = 20
+set iterm_relax_cutoff = 45
 
 # -- PIDsum limits --
 set iterm_limit = 500


### PR DESCRIPTION
new for 2024 some updates to the Karate racing tunes to reflect the new ideas with filtering 

**KARATE race** lite.. what im using so actively developing it still 
-new spicy tunes for 4 and 6s removing the lpf1, pids and Dterm lpf changes for 4 and 6s 
-no more Turing off the 3rd harmonic of the rpm filtering, using the weight instead as you need harmonic 3 with a 3 blade prop and turning off number 3 has little impact on latency 

**KARATE 6s race**
-same filter ideas as the 'lite' tune above.. old spicey tune is still there this is the new spice!

**KARATE TT** 
-same filter ideas as the 'lite' tune above..

**KARATE whoop** options for the rpm filter weighting depending on your type of props 
