### PR TITLE
MultiGP PRO Spec tune - OTHER

### DIFF
--- a/presets/4.5/other/multigp_pro_spec.txt
+++ b/presets/4.5/other/multigp_pro_spec.txt
@@ -1,0 +1,215 @@
+#$ TITLE: MultiGP PRO Spec 7"
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: OTHER
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: 6S, race, 7 inch, 7", Shames, MGP, Sharjah, multigp
+#$ AUTHOR: Armando Gallegos (Mondo)
+
+#$ FORCE_OPTIONS_REVIEW: TRUE
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://github.com/betaflight/firmware-presets/assets/2925027/a75803ff-d1f8-4a47-9a5f-1b5d57d28f56" width="90px" style="display: block; float: left; margin-right: 10px; margin-top: 20px"/>
+#$ DESCRIPTION: <h1>MultiGP PRO Spec</h1>
+#$ DESCRIPTION: Tune + RPM limit + extras.
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: This tune is what was used by MultiGP in Sharjah stock race. Made for ~2807 motors 1300kv, 6S, HQ props 7x4x3, and heavy RPM limit.
+#$ DESCRIPTION:
+#$ DESCRIPTION: More information about [MultiGP PRO Spec](https://www.multigp.com/prospec/)
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This preset requires Betaflight 4.5 flashed with RACE_PRO option, or Betaflight special release KAACK 4.5.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Miscellaneous option
+#$ DESCRIPTION: is checked by default, and includes several usefull settings:
+#$ DESCRIPTION: - Accelerometer and barometer OFF
+#$ DESCRIPTION: - Motor KV = 1300 (change in CLI if needed)
+#$ DESCRIPTION: - RPM limit ON
+#$ DESCRIPTION: - Small angle 180 (arming at any angle)
+#$ DESCRIPTION: - Props out (yaw_motors_reversed = ON)
+#$ DESCRIPTION: - Features: LED strip and OSD
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Things to note:
+#$ DESCRIPTION: - **YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!** Failure to do so might result in fire 🔥
+#$ DESCRIPTION: - This preset is setting up DShot600: if your setup has errors in the motor tab using bidirectional DShot, change to **8k/4k and DShot300**
+#$ DESCRIPTION: - To test arm the quad with props on, it should **sound clean with no grinding**. If it passes that then hover test and check motor temps.
+#$ DESCRIPTION: - **Safety first! If anything is off, don't fly it!!!**
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Second note... Radio links:
+#$ DESCRIPTION: 1. Make sure your radio firmware is up to date using either EdgeTX or OpenTX
+#$ DESCRIPTION: 2. Make sure your **ADC Filter is OFF** in the hardware page
+#$ DESCRIPTION: 3. Go to the radio (RC_LINK) presets and apply the correct setup for your system and link speed
+#$ DESCRIPTION:
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/475
+
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.5/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+# tune/filters
+
+set dshot_bidir = ON
+set motor_pwm_protocol = DSHOT600
+set dyn_notch_count = 2
+set dyn_notch_max_hz = 550
+set simplified_gyro_filter_multiplier = 60
+set rpm_filter_weights = 100,50,100
+
+set anti_gravity_gain = 90
+set iterm_relax_cutoff = 10
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+set yaw_lowpass_hz = 125
+set thrust_linear = 20
+
+set simplified_master_multiplier = 160
+set simplified_i_gain = 65
+set simplified_d_gain = 150
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 115
+set simplified_pitch_d_gain = 110
+set simplified_dterm_filter_multiplier = 120
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (CHECKED): Race miscellaneous
+    set acc_hardware = NONE
+    set baro_hardware = NONE
+    set motor_kv = 1300
+    set rpm_limit = ON
+    set rpm_limit_value = 13000
+    set small_angle = 180
+    set yaw_motors_reversed = ON
+    feature LED_STRIP
+    feature OSD
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Bosch (BMI) gyro - experimantal
+    set gyro_lpf1_dyn_min_hz = 0
+    set gyro_lpf1_dyn_max_hz = 0
+#$ OPTION END
+
+#$ OPTION_GROUP BEGIN: VTX setup
+    #$ OPTION BEGIN (UNCHECKED): HDZero table 25/200/0mw
+        #$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+        vtxtable bands 6
+        vtxtable channels 8
+        vtxtable band 1 BOSCAM_A A FACTORY    0    0    0    0    0    0    0    0
+        vtxtable band 2 BOSCAM_B B FACTORY    0    0    0    0    0    0    0    0
+        vtxtable band 3 BOSCAM_E E FACTORY    0    0    0    0    0    0    0    0
+        vtxtable band 4 FATSHARK F FACTORY    0 5760    0 5800    0    0    0    0
+        vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+        vtxtable band 6 IMD6     I CUSTOM     0    0    0    0    0    0    0    0
+        vtxtable powerlevels 3
+        vtxtable powervalues 14 23 0
+        vtxtable powerlabels 25 200 0
+        set vcd_video_system = HD
+        set osd_displayport_device = MSP
+        set displayport_msp_fonts = 0,0,0,0
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): HDZero powers on AUX 1
+        vtx 0 0 0 0 3 900 1300
+        vtx 1 0 0 0 1 1300 1700
+        vtx 2 0 0 0 2 1700 2100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): HDZero powers on AUX 2
+        vtx 0 1 0 0 3 900 1300
+        vtx 1 1 0 0 1 1300 1700
+        vtx 2 1 0 0 2 1700 2100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): HDZero powers on AUX 3
+        vtx 0 2 0 0 3 900 1300
+        vtx 1 2 0 0 1 1300 1700
+        vtx 2 2 0 0 2 1700 2100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): HDZero powers on AUX 4
+        vtx 0 3 0 0 3 900 1300
+        vtx 1 3 0 0 1 1300 1700
+        vtx 2 3 0 0 2 1700 2100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): HDZero powers on AUX 5
+        vtx 0 4 0 0 3 900 1300
+        vtx 1 4 0 0 1 1300 1700
+        vtx 2 4 0 0 2 1700 2100
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Analog NTSC
+        set osd_displayport_device = MAX7456
+        set vcd_video_system = NTSC
+    #$ OPTION END    
+#$ OPTION_GROUP END
+
+#$ OPTION BEGIN (UNCHECKED): Sharjah drones AUX modes setup
+    aux 0 0 0 1950 2100 0 0
+    aux 1 15 0 900 1225 0 0
+    aux 2 35 1 1950 2100 0 0
+    aux 3 101 2 1950 2100 0 0
+#$ OPTION END
+
+#$ OPTION_GROUP BEGIN: Some popular RC Links
+
+    #$ OPTION BEGIN (UNCHECKED): Tracer/ELRS 250Hz
+        # Tracer/ELRS 250Hz
+        
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS 500Hz
+        # ERLS 500Hz
+        
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+        #$ INCLUDE: presets/4.3/rc_link/generic/500hz_race.txt
+
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): ELRS 1000Hz
+        # ELRS 1000Hz
+       
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+         #$ INCLUDE: presets/4.3/rc_link/generic/1000hz_race.txt
+         
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): Ghost 250Hz
+        # Ghost 250Hz
+      
+        feature RX_SERIAL
+        set serialrx_provider = GHST
+
+         #$ INCLUDE: presets/4.3/rc_link/generic/250hz_race.txt
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 500Hz
+        # Ghost 500Hz
+       
+        feature RX_SERIAL
+        set serialrx_provider = GHST
+
+         #$ INCLUDE: presets/4.3/rc_link/generic/500hz_race.txt
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+


### PR DESCRIPTION
Category: other, because it includes bunch of stuff that's not tune.
Almost full setup for MultiGP PRO Spec drones (7", 6S, ~1100g).
Not included: rates, LED setup, analog VTX tables, ports, motor remapping, board alignment, OSD elements.
![image](https://github.com/betaflight/firmware-presets/assets/2925027/a75803ff-d1f8-4a47-9a5f-1b5d57d28f56)

