### PR TITLE
AOS 65mm Tiny Whoop Tune

### DIFF
--- a/presets/4.5/filters/aos_rc/aos_65mm_filters.txt
+++ b/presets/4.5/filters/aos_rc/aos_65mm_filters.txt
@@ -1,0 +1,37 @@
+#$ TITLE: AOS 65mm Filters
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: FILTERS
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: filter, filters, aos, chris, rosser, 65mm, tiny, whoop
+#$ AUTHOR: Chris Rosser
+#$ DESCRIPTION: Developed for a 65mm Tiny whoop. Based on a 300mAh 1S build with 23000KV Motors.
+#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
+#$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK.
+#$ DISCUSSION: https://www.aos-rc.com
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 1000
+set simplified_gyro_filter = OFF
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 1
+set dyn_notch_q = 500
+set dyn_notch_min_hz = 150
+
+# -- RPM filtering --
+set dshot_bidir = ON
+set rpm_filter_harmonics = 1
+set rpm_filter_fade_range_hz = 50
+set rpm_filter_min_hz = 100
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_min_hz = 75
+set dterm_lpf1_dyn_max_hz = 150
+set dterm_lpf1_type = PT1
+set dterm_lpf2_static_hz = 150
+set simplified_dterm_filter = OFF

--- a/presets/4.5/filters/aos_rc/aos_65mm_filters.txt
+++ b/presets/4.5/filters/aos_rc/aos_65mm_filters.txt
@@ -1,7 +1,7 @@
 #$ TITLE: AOS 65mm Filters
 #$ FIRMWARE_VERSION: 4.5
 #$ CATEGORY: FILTERS
-#$ STATUS: COMMUNITY
+#$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: filter, filters, aos, chris, rosser, 65mm, tiny, whoop
 #$ AUTHOR: Chris Rosser
 #$ DESCRIPTION: Developed for a 65mm Tiny whoop. Based on a 300mAh 1S build with 23000KV Motors.
@@ -34,4 +34,4 @@ set dterm_lpf1_dyn_min_hz = 75
 set dterm_lpf1_dyn_max_hz = 150
 set dterm_lpf1_type = PT1
 set dterm_lpf2_static_hz = 150
-set simplified_dterm_filter = OFF
+set simplified_dterm_filter = ON

--- a/presets/4.5/filters/aos_rc/aos_65mm_filters.txt
+++ b/presets/4.5/filters/aos_rc/aos_65mm_filters.txt
@@ -5,7 +5,7 @@
 #$ KEYWORDS: filter, filters, aos, chris, rosser, 65mm, tiny, whoop
 #$ AUTHOR: Chris Rosser
 #$ DESCRIPTION: Developed for a 65mm Tiny whoop. Based on a 300mAh 1S build with 23000KV Motors.
-#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATEMPT TO USE WITH OUT RPM FILTERING!
+#$ DESCRIPTION: NOTE this needs bidirectional Dshot support and RPM filtering active to use. DO NOT ATTEMPT TO USE WITH OUT RPM FILTERING!
 #$ DESCRIPTION: Follow the usual process of hover testing and safely checking out your tune before using. USE AT YOUR OWN RISK.
 #$ DISCUSSION: https://www.aos-rc.com
 #$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt

--- a/presets/4.5/tune/aos_rc/aos_65mm_tune.txt
+++ b/presets/4.5/tune/aos_rc/aos_65mm_tune.txt
@@ -1,7 +1,7 @@
 #$ TITLE: 65mm Tiny whoop tune by Chris Rosser
 #$ FIRMWARE_VERSION: 4.5
 #$ CATEGORY: TUNE
-#$ STATUS: COMMUNITY
+#$ STATUS: EXPERIMENTAL
 #$ KEYWORDS: aos, chris, rosser, pid, tune, 65mm, tiny, whoop
 #$ AUTHOR: Chris Rosser
 #$ DISCUSSION: https://www.aos-rc.com
@@ -21,19 +21,6 @@
 
 # -- PID values --
 set profile_name = AOS 65mm
-set p_pitch = 95
-set i_pitch = 170
-set d_pitch = 44
-set f_pitch = 194
-set p_roll = 76
-set i_roll = 135
-set d_roll = 39
-set f_roll = 156
-set p_yaw = 76
-set i_yaw = 135
-set f_yaw = 156
-set d_min_roll = 39
-set d_min_pitch = 44
 set angle_p_gain = 100
 set simplified_master_multiplier = 130
 set simplified_pi_gain = 130
@@ -69,10 +56,9 @@ set feedforward_max_rate_limit = 95
 # -- Throttle boost (default, 5)
 # -- VBat warning threshold --
 
-# -- Dynamic idle ON at 5000 rpm --
-set dyn_idle_min_rpm = 50
+# -- Dynamic idle ON at 10000 rpm --
+set dyn_idle_min_rpm = 100
 set dyn_idle_p_gain = 40
-
 
 # ------ OPIONS GO BELOW THIS LINE ------
 
@@ -80,7 +66,7 @@ set dyn_idle_p_gain = 40
 
 #$ OPTION_GROUP BEGIN: Filters
     #$ OPTION BEGIN (CHECKED): AOS 65mm Filters (Recommended)
-    #$ INCLUDE: presets/4.5/filters/aos_rc/aos_65mm_filters.txt
+        #$ INCLUDE: presets/4.5/filters/aos_rc/aos_65mm_filters.txt
     #$ OPTION END
 
 #$ OPTION_GROUP END

--- a/presets/4.5/tune/aos_rc/aos_65mm_tune.txt
+++ b/presets/4.5/tune/aos_rc/aos_65mm_tune.txt
@@ -1,0 +1,129 @@
+#$ TITLE: 65mm Tiny whoop tune by Chris Rosser
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: TUNE
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: aos, chris, rosser, pid, tune, 65mm, tiny, whoop
+#$ AUTHOR: Chris Rosser
+#$ DISCUSSION: https://www.aos-rc.com
+#$ DESCRIPTION: Custom Tune for a 65mm Tiny whoop. Based on a 300mAh 1S build with 23000KV Motors.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Master multiplier is set to 1.3 for safety. Increase it carefully to further improve flight performance.
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM filtering is MANDATORY!
+#$ DESCRIPTION:
+#$ DESCRIPTION: Please carefully review the options above and tick any that are relevant.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Choose your RC link speed.
+#$ DESCRIPTION:
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+#$ INCLUDE: presets/4.5/tune/defaults.txt
+
+# -- PID values --
+set profile_name = AOS 65mm
+set p_pitch = 95
+set i_pitch = 170
+set d_pitch = 44
+set f_pitch = 194
+set p_roll = 76
+set i_roll = 135
+set d_roll = 39
+set f_roll = 156
+set p_yaw = 76
+set i_yaw = 135
+set f_yaw = 156
+set d_min_roll = 39
+set d_min_pitch = 44
+set angle_p_gain = 100
+set simplified_master_multiplier = 130
+set simplified_pi_gain = 130
+set simplified_dmax_gain = 0
+set simplified_pitch_pi_gain = 120
+set tpa_mode = PD
+set tpa_rate = 55
+
+# -- iTerm relax (default)--
+# -- iTerm windup (default)--
+# -- iTerm rotation (off, default) --
+
+# -- Dmax --
+set d_max_advance = 0
+
+# -- TPA --
+
+# -- Feedforward --
+set feedforward_max_rate_limit = 95
+
+# -- PIDsum limits (default)--
+# -- Antigravity (default) --
+# -- Absolute control (off, default) --
+# -- Accecleration limits (off, default) --
+# -- Angle and Horizon mode tuning (default) --
+# -- PIDs active below min throttle (default) --
+# -- Set mixer type to default (legacy) --
+# -- Set yaw spin recovery to default, which is auto --
+# -- Set integrated yaw to off, so pitch and yaw are independent (default) --
+# -- Gyro cal on first arm (off, default) --
+# -- Transient throttle limit (off, default) --
+# -- Thrust linear (off, default) --
+# -- Throttle boost (default, 5)
+# -- VBat warning threshold --
+
+# -- Dynamic idle ON at 5000 rpm --
+set dyn_idle_min_rpm = 50
+set dyn_idle_p_gain = 40
+
+
+# ------ OPIONS GO BELOW THIS LINE ------
+
+# -- Filters --
+
+#$ OPTION_GROUP BEGIN: Filters
+    #$ OPTION BEGIN (CHECKED): AOS 65mm Filters (Recommended)
+    #$ INCLUDE: presets/4.5/filters/aos_rc/aos_65mm_filters.txt
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+# -- Fast Rx Link Options --
+
+#$ OPTION_GROUP BEGIN: Choose your RC link (or apply another preset separately)
+    #$ OPTION BEGIN (UNCHECKED): ELRS_250HZ (Recommended)
+        #$ INCLUDE: presets/4.3/rc_link/elrs_250hz.txt
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): ELRS_500HZ
+        #$ INCLUDE: presets/4.3/rc_link/elrs_500hz.txt
+    #$ OPTION END
+    
+#$ OPTION_GROUP END
+
+# -- Recommended options --
+
+#$ OPTION_GROUP BEGIN: Check all of these (recommended)
+
+    # -- VBat sag compensation --
+    #$ OPTION BEGIN (UNCHECKED): Full battery sag compensation
+        set vbat_sag_compensation = 100
+        set vbat_sag_lpf_period = 2
+    #$ OPTION END
+
+    # -- Stick behaviour --
+    #$ OPTION BEGIN (UNCHECKED): No stick deadband
+        set deadband = 0
+        set yaw_deadband = 0
+    #$ OPTION END
+
+    # -- Startup and arming --
+    #$ OPTION BEGIN (UNCHECKED): Arm at any angle
+        set small_angle = 180
+    #$ OPTION END
+
+    # -- Prop direction --
+    #$ OPTION BEGIN (UNCHECKED): Props out (check motor direction!)
+        set yaw_motors_reversed = ON
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+simplified_tuning apply


### PR DESCRIPTION
A simple filter and PID tune for 65mm Tiny Whoops based on the BetaFPV Air65 with 23000KV motors. I hope it helps!