### PR TITLE
Fixed image display on YarosFPV OSD preset

### DIFF
--- a/presets/4.4/osd/YarosFPV_DJI_O3_OSD.txt
+++ b/presets/4.4/osd/YarosFPV_DJI_O3_OSD.txt
@@ -6,6 +6,7 @@
 #$ KEYWORDS: DJI, HD, HDOSD, OSD, YAROSFPV
 #$ AUTHOR: YarosFPV (Yaroslav Syubayev)
 
+#$ PARSER: MARKED
 #$ DESCRIPTION: Yaros FPV HD OSD Settings
 #$ DESCRIPTION: Intended to be used with the DJI O3 FPV system.
 #$ DESCRIPTION: -----------


### PR DESCRIPTION
I forgot to add `#$ PARSER: MARKED` originally so the image example of my OSD wouldn't show in Betaflight.
Now it does 🙃 

<img width="450" alt="Screenshot 2024-09-30 at 21 40 27" src="https://github.com/user-attachments/assets/ac3ef1cd-57b0-4766-a06a-87a9955c11e6">
