### PR TITLE
Added VTX Table for BetaFPV Air FC

### DIFF
--- a/presets/4.5/vtx/BetaFPV_AirFC.txt
+++ b/presets/4.5/vtx/BetaFPV_AirFC.txt
@@ -1,0 +1,29 @@
+#$ TITLE: BetaFPV Air Brushless FC 4in1 VTX Table
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, vtxtable, betafpv, 4in1, air
+#$ AUTHOR: YarosFPV (Yaroslav Syubayev)
+#$ DESCRIPTION: VTX tables for BetaFPV Air Brushless FC 4in1 VTX
+#$ DESCRIPTION: This Flight Controller is used on the Air65 and Air75 whoops by BetaFPV.
+#$ DESCRIPTION: <a href="https://betafpv.com/products/air-brushless-flight-controller">BetaFPV Air Brushless FC</a>
+#$ DISCLAIMER: All previous VTX Table settings will be reset.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+#$ INCLUDE: presets/4.3/vtx/defaults_vtx_tables.txt
+
+# vtxtable
+vtxtable bands 6
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY 5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B FACTORY 5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E FACTORY 5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F FACTORY 5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 LOWRACE  L FACTORY 5333 5373 5413 5453 5493 5533 5573 5613
+vtxtable powerlevels 5
+vtxtable powervalues 1 2 3 4 0
+vtxtable powerlabels 25 100 200 400 PIT


### PR DESCRIPTION
I added the VTX Table for the [BetaFPV Air Brushless Flight Controller's](https://betafpv.com/products/air-brushless-flight-controller) integrated VTX.
I got this VTX table from the factory CLI dump of my Air75 that came with this FC.