### PR TITLE
Fixed the link for the BetaFPV AirFC VTX Table

### DIFF
--- a/presets/4.5/vtx/BetaFPV_AirFC.txt
+++ b/presets/4.5/vtx/BetaFPV_AirFC.txt
@@ -7,9 +7,12 @@
 #$ STATUS: COMMUNITY
 #$ KEYWORDS:  vtx, vtx table, vtxtable, betafpv, 4in1, air
 #$ AUTHOR: YarosFPV (Yaroslav Syubayev)
+#$ PARSER: MARKED
 #$ DESCRIPTION: VTX tables for BetaFPV Air Brushless FC 4in1 VTX
 #$ DESCRIPTION: This Flight Controller is used on the Air65 and Air75 whoops by BetaFPV.
-#$ DESCRIPTION: <a href="https://betafpv.com/products/air-brushless-flight-controller">BetaFPV Air Brushless FC</a>
+#$ DESCRIPTION:
+#$ DESCRIPTION: [BetaFPV Air Brushless FC](https://betafpv.com/products/air-brushless-flight-controller)
+#$ DESCRIPTION:
 #$ DISCLAIMER: All previous VTX Table settings will be reset.
 #$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
 


### PR DESCRIPTION
Fixed the link that didn't work in my BetaFPV AirFC VTX Table preset.

 
<img width="450" alt="Screenshot" src="https://github.com/user-attachments/assets/37e9b503-e158-47fc-ac69-3a7fa3531923">
