### PR TITLE
Fix: Add keywords to preset lacking them

### DIFF
--- a/presets/4.5/other/bensonk-switches.txt
+++ b/presets/4.5/other/bensonk-switches.txt
@@ -2,6 +2,7 @@
 #$ FIRMWARE_VERSION: 4.5
 #$ CATEGORY: OTHER
 #$ STATUS: COMMUNITY
+#$ KEYWORDS: switch, mode, modes
 #$ AUTHOR: bensonk
 
 #$ DESCRIPTION: Standard controller channel settings used by bensonk


### PR DESCRIPTION
@bensonk seemingly, this preset broke the search functionality across the entire preset system by not including any keywords due to an issue in the Configurator. This should be fixed in Configurator 11.0.0, in [Configurator #4517](https://github.com/betaflight/betaflight-configurator/pull/4517) but for 10.10.0 I added some existing keywords based on what seemed appropriate to fix the issues.

This will be merged rather quickly, please make any suggestions in a future PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added new metadata keywords to the preset file for improved description and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->