### PR TITLE
File Update - Tune

### DIFF
--- a/presets/2025.12/tune/defaults.txt
+++ b/presets/2025.12/tune/defaults.txt
@@ -1,10 +1,10 @@
-#$ TITLE: Betaflight 2025.12.0 TUNE defaults
-#$ FIRMWARE_VERSION: 2025.12.0
+#$ TITLE: Betaflight 2025.12 TUNE defaults
+#$ FIRMWARE_VERSION: 2025.12
 #$ CATEGORY: TUNE
 #$ STATUS: OFFICIAL
 #$ KEYWORDS: defaults, reset, tune, pid, basic, default
 #$ AUTHOR: Betaflight
-#$ DESCRIPTION: Resets all Basic 2025.12.0 Tune category parameters to defaults
+#$ DESCRIPTION: Resets all Basic 2025.12 Tune category parameters to defaults
 #$ DESCRIPTION: WARNING: Overwrites all settings mentioned below to defaults.  The User cannot retain their previous values.
 #$ DESCRIPTION: WARNING: Tune authors must explicitly set these values to something other than default if needed for the tune.
 #$ DESCRIPTION: DOES NOT reset rates, filters, rc_smoothing, and many other parameters.


### PR DESCRIPTION
- Updated tune defaults
- others can update their tunes and refer to this file
- Supafly 2025.12 tune update coming soon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Betaflight 2025.12 tune defaults preset to explicitly reset a broad set of tuning parameters (yaw, mixer, gyro/arm behavior, PID/IG/D, angle/horizon, throttle/boost, TPA and other tuning blocks).
  * Includes clear warnings that applying the preset will overwrite user tuning and notes that some categories (e.g., rates, filters, RC smoothing) are intentionally not reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->