### PR TITLE
Add rates preset for Fader FPV

### DIFF
--- a/presets/2025.12/rates/FaderFPV.txt
+++ b/presets/2025.12/rates/FaderFPV.txt
@@ -5,7 +5,7 @@
 #$ STATUS: COMMUNITY
 #$ KEYWORDS: fader fpv, secretfader, nicholas young, fictive flame
 #$ AUTHOR: Fader FPV (Nicholas Young)
-#$ DESCRIPTION: Nicholas Young is a professional FPV pilot, drone builder, and professional tuner. YouTube: [https://youtube.com/@secretfader].
+#$ DESCRIPTION: Nicholas Young is a professional FPV pilot, drone builder, and tuner. [https://youtube.com/@secretfader](https://youtube.com/@secretfader).
 #$ DESCRIPTION:
 #$ DESCRIPTION: Information:
 #$ DESCRIPTION: -----------


### PR DESCRIPTION
Adding a community rates preset for all of my custom cinematic drones. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new FPV rate preset with configurable base RC rates, expos, and slew rates plus two optional Racing and Freestyle profiles for quick manual activation and tuning.
* **Documentation**
  * Preset includes descriptive metadata (title, firmware compatibility, category, status, keywords, author, description) and references default settings for easier discovery and use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->