### PR TITLE
update rates for 730 max

### DIFF
--- a/presets/2025.12/rates/FaderFPV.txt
+++ b/presets/2025.12/rates/FaderFPV.txt
@@ -1,5 +1,4 @@
 #$ TITLE: Nicholas Young Rates
-#$ FIRMWARE_VERSION: 4.5
 #$ FIRMWARE_VERSION: 2025.12
 #$ CATEGORY: RATES
 #$ STATUS: COMMUNITY
@@ -8,6 +7,7 @@
 #$ PARSER: MARKED
 #$ DESCRIPTION: This are the rates for the Fictive Air series of FPV drones, developed by professional FPV pilot, drone builder, and tuner, [Nicholas Young](https://secretfader.com). Default rates are a max of 730, with additional max rates of 530 and 330, both with similar curves, available as options.
 #$ WARNING: Before applying this preset, REMEMBER to select your rateprofile to overwrite.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/526
 
 #$ INCLUDE: presets/2025.12/rates/defaults.txt
 


### PR DESCRIPTION
- Updating rates for a standard 730 max, with optional 530 and 330 values (formula is max / 5.2 = center)
- Improved formatting, included markdown parser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Presets**
  * Updated Nicholas Young flight-rate preset with refined configurations for Main, Racing, and Freestyle modes
  * Adjusted rate values, responsiveness (srate) and mode-specific rc rates for clearer distinctions between Main, Racing, and Freestyle
  * Unified maximum rate limits and preserved throttle/limit behavior
    
* **Documentation**
  * Metadata and description updated to reference Nicholas Young and the Fictive Air series

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->