### PR TITLE
Remove AWS S3 deployment from build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 basepath="${PWD}"
-artifacts="${basepath}/public"
+artifacts="${basepath}/public/firmware-presets"
 
 echo "Artifacts: ${artifacts}"
 echo "Branch:    ${GITHUB_REF}"
@@ -32,9 +32,4 @@ if [ "${1}" == "deploy" ]; then
   if [ -d ./misc ]; then
     cp -r ./misc/* $artifacts/misc
   fi
-
-  echo "Deploying to AWS S3: ${AWS_REGION}/${AWS_BUCKET}"
-  aws configure set preview.cloudfront true
-  aws s3 sync ${artifacts} s3://${AWS_BUCKET}/firmware-presets --delete --region "${AWS_REGION}" --cache-control max-age=345600
-  aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --path "/firmware-presets/*"
 fi


### PR DESCRIPTION
Removed AWS S3 deployment commands from build script.

Now deploying to cloudflare.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact output location for firmware presets.
  * Modified deployment pipeline configuration to adjust release processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->