### PR TITLE
update rates to match all drones

### DIFF
--- a/presets/2025.12/osd/FaderFPV_DJI.txt
+++ b/presets/2025.12/osd/FaderFPV_DJI.txt
@@ -6,7 +6,7 @@
 #$ KEYWORDS: fader fpv, secretfader, nicholas young, fictive flame
 #$ AUTHOR: Nicholas Young (Fader FPV)
 #$ PARSER: MARKED
-#$ DESCRIPTION: This is the standard OSD for the Fictive Air series of FPV drones, developed by professional FPV pilot, drone builder, and tuner, [Nicholas Young](https://secretfader.com). While the GPS and magnetometer are required for certain features, all navigation elements are optional and designed to be toggled.
+#$ DESCRIPTION: This is the standard OSD for the [Fictive Air series](https://secretfader.com/aircraft) of cinematic FPV drones, developed by professional FPV pilot, drone builder, and tuner, [Nicholas Young](https://secretfader.com). While the GPS and magnetometer are required for certain features, all navigation elements are optional and designed to be toggled.
 
 #$ INCLUDE: presets/2025.12/osd/defaults.txt
 

--- a/presets/2025.12/rates/FaderFPV.txt
+++ b/presets/2025.12/rates/FaderFPV.txt
@@ -5,7 +5,7 @@
 #$ KEYWORDS: fader fpv, secretfader, nicholas young, fictive flame
 #$ AUTHOR: Nicholas Young (Fader FPV)
 #$ PARSER: MARKED
-#$ DESCRIPTION: This are the rates for the Fictive Air series of FPV drones, developed by professional FPV pilot, drone builder, and tuner, [Nicholas Young](https://secretfader.com). Default rates are a max of 720, with additional max rates of 540, with a similar response curve, available as an option.
+#$ DESCRIPTION: This are the rates for the [Fictive Air series](https://secretfader.com/aircraft) of cinematic FPV drones, developed by professional FPV pilot, drone builder, and tuner, [Nicholas Young](https://secretfader.com). Default rates are a max of 720, with additional max rates of 540, with a similar response curve, available as an option.
 #$ WARNING: Before applying this preset, REMEMBER to select your rateprofile to overwrite.
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/526
 


### PR DESCRIPTION
Updating rates to match all of my drones from tiny whoops to larger builds, and removing the throttle limit params which were unintentionally included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * FaderFPV preset tuned: maximum rate set to 720 with an alternate 540 option for a gentler top-end.
  * RC rates increased and expo values raised for snappier yet controlled response.
  * SRates adjusted for a more consistent feel across axes.
  * Cinematic/slower mode consolidated into a single streamlined option; redundant variants removed.

* **Documentation**
  * Preset description updated to reference the Fictive Air series with an inline link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->