### PR TITLE
Supafly 3-4 Inch 2025.12

### DIFF
--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_3_4_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_3_4_Inch_EasyTune.txt
@@ -51,7 +51,7 @@ set tpa_low_always = ON
 set dyn_idle_min_rpm = 30
 set dshot_bidir = ON
 
-#$ OPTION_GROUP BEGIN:(EXCLUSIVE) Pitch Balance
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Pitch Balance
     #$ OPTION BEGIN (CHECKED): Flying with Action Camera
         set simplified_master_multiplier = 120
         set simplified_i_gain = 85
@@ -74,7 +74,7 @@ set dshot_bidir = ON
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (EXCLUSIVE)Filters
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
 	    set simplified_gyro_filter_multiplier = 160
         set rpm_filter_harmonics = 3
@@ -159,7 +159,7 @@ set dshot_bidir = ON
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (EXCLUSIVE)Freestyle Rates
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Freestyle Rates
     #$ OPTION BEGIN (UNCHECKED): Smooth Medium
     #$ INCLUDE: presets/4.3/rates/defaults.txt
         set roll_rc_rate = 2


### PR DESCRIPTION
Supafly 3-4 Inch 2025.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SupaflyFPV Freestyle 3/4" EasyTune preset configuration.
  * Offers selectable pitch-balance (Action Camera ON/OFF), filter choices (Clean vs Average), and multiple RC link setups including Crossfire variants.
  * Provides three freestyle rate profiles with per-profile RC rate/expo/srate and a simplified apply command for easy setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->