### PR TITLE
Supafly 5 Inch 2025.12

### DIFF
--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
@@ -161,7 +161,7 @@ set dshot_bidir = ON
 
 #$ OPTION_GROUP BEGIN: (EXCLUSIVE) Freestyle Rates
     #$ OPTION BEGIN (UNCHECKED): Smooth Medium
-    #$ INCLUDE: presets/4.3/rates/defaults.txt
+    #$ INCLUDE: presets/2025.12/rates/defaults.txt
         set roll_rc_rate = 2
         set pitch_rc_rate = 2
         set yaw_rc_rate = 2
@@ -173,7 +173,7 @@ set dshot_bidir = ON
         set yaw_srate = 60
     #$ OPTION END
     #$ OPTION BEGIN (UNCHECKED): Smooth Fast
-    #$ INCLUDE: presets/4.3/rates/defaults.txt
+    #$ INCLUDE: presets/2025.12/rates/defaults.txt
         set roll_rc_rate = 3
         set pitch_rc_rate = 3
         set yaw_rc_rate = 3
@@ -185,7 +185,7 @@ set dshot_bidir = ON
         set yaw_srate = 90
     #$ OPTION END
     #$ OPTION BEGIN (UNCHECKED): Medium Fast
-    #$ INCLUDE: presets/4.3/rates/defaults.txt
+    #$ INCLUDE: presets/2025.12/rates/defaults.txt
         set roll_rc_rate = 25
         set pitch_rc_rate = 25
         set yaw_rc_rate = 25


### PR DESCRIPTION
Supafly 5 Inch 2025.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new tuning preset for SupaflyFPV Freestyle 5 Inch drones with multiple customizable configuration options, including pitch balance, filter settings, RC link variants, and freestyle rate profiles to accommodate different flying styles and aircraft builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->