### PR TITLE
Supafly 6 Inch 2025.12

### DIFF
--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
@@ -63,7 +63,7 @@ set iterm_relax_cutoff = 10
         set simplified_pitch_pi_gain = 125
         set simplified_pitch_d_gain = 130
     #$ OPTION END 
-    #$ OPTION BEGIN (UNCHECKED):No Action Camera
+    #$ OPTION BEGIN (UNCHECKED): No Action Camera
         set simplified_master_multiplier = 115
         set simplified_i_gain = 85
         set simplified_d_gain = 110
@@ -75,7 +75,7 @@ set iterm_relax_cutoff = 10
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (EXCLUSIVE)Filters
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
 	    set simplified_gyro_filter_multiplier = 160
         set rpm_filter_harmonics = 3
@@ -158,7 +158,7 @@ set iterm_relax_cutoff = 10
     #$ OPTION END
 #$ OPTION_GROUP END
 
-#$ OPTION_GROUP BEGIN: (EXCLUSIVE)Freestyle Rates
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) Freestyle Rates
     #$ OPTION BEGIN (UNCHECKED): Smooth Medium
     #$ INCLUDE: presets/4.3/rates/defaults.txt
         set roll_rc_rate = 2


### PR DESCRIPTION
Supafly 6 Inch 2025.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Betaflight tuning preset for SupaflyFPV Freestyle 6 Inch, featuring configurable options for pitch balance settings, filter profiles, RC link configurations for various receivers, and freestyle rate presets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->