### PR TITLE
Supafly 7 Inch 2025.12

### DIFF
--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 2025.12
 #$ CATEGORY: TUNE
 #$ STATUS: OFFICIAL
-#$ KEYWORDS: Supafly, SupaflyFPV, 4S, 6S, Freestyle, 7 inch, 6"
+#$ KEYWORDS: Supafly, SupaflyFPV, 4S, 6S, Freestyle, 7 inch, 7"
 #$ AUTHOR: SupaflyFPV
 
 #$ PARSER: MARKED
@@ -76,7 +76,7 @@ set iterm_relax_cutoff = 8
 
 #$ OPTION_GROUP BEGIN: (EXCLUSIVE) Filters
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
-	    set simplified_gyro_filter_multiplier = 160
+        set simplified_gyro_filter_multiplier = 160
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 600
         set rpm_filter_min_hz = 60
@@ -84,26 +84,26 @@ set iterm_relax_cutoff = 8
         set dyn_notch_q = 400
         set dyn_notch_min_hz = 40
         set dyn_notch_max_hz = 300
-	    set rpm_filter_weights = 90,30,90
-	    set dterm_lpf1_dyn_min_hz = 0
-	    set dterm_lpf1_dyn_max_hz = 0
-	    set dterm_lpf1_dyn_expo = 0
+        set rpm_filter_weights = 90,30,90
+        set dterm_lpf1_dyn_min_hz = 0
+        set dterm_lpf1_dyn_max_hz = 0
+        set dterm_lpf1_dyn_expo = 0
         set dterm_lpf1_static_hz = 120
         set dterm_lpf2_static_hz = 0
         set simplified_dterm_filter_multiplier = 160
     #$ OPTION END 
     #$ OPTION BEGIN (CHECKED): Average Build (Robust)
-	    set simplified_gyro_filter_multiplier = 100
+        set simplified_gyro_filter_multiplier = 100
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 500
         set dyn_notch_count = 2
         set dyn_notch_q = 300
         set dyn_notch_min_hz = 40
         set dyn_notch_max_hz = 300
-	    set rpm_filter_weights = 90,60,90
-	    set dterm_lpf1_dyn_min_hz = 0
-	    set dterm_lpf1_dyn_max_hz = 0
-	    set dterm_lpf1_dyn_expo = 0
+        set rpm_filter_weights = 90,60,90
+        set dterm_lpf1_dyn_min_hz = 0
+        set dterm_lpf1_dyn_max_hz = 0
+        set dterm_lpf1_dyn_expo = 0
         set dterm_lpf1_static_hz = 116
         set dterm_lpf2_static_hz = 0
         set simplified_dterm_filter_multiplier = 155


### PR DESCRIPTION
Supafly 7 Inch 2025.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new community 7" freestyle tuning preset (SupaflyFPV Freestyle 7" EasyTune) with configurable pitch-balance options, selectable filter profiles for different build types, multiple RC link modes, and three freestyle rate presets to match varied flying styles and hardware setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->