### PR TITLE
Supafly fpv tune tweaks

### DIFF
--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_3_4_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_3_4_Inch_EasyTune.txt
@@ -79,6 +79,7 @@ set dshot_bidir = ON
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
 	    set simplified_gyro_filter_multiplier = 160
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 800
         set dyn_notch_count = 1
@@ -95,6 +96,7 @@ set dshot_bidir = ON
     #$ OPTION BEGIN (CHECKED): Average Build (Robust)
 	    set simplified_gyro_filter_multiplier = 120
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 700
         set dyn_notch_count = 2

--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
@@ -79,6 +79,7 @@ set dshot_bidir = ON
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
 	    set simplified_gyro_filter_multiplier = 160
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 800
         set dyn_notch_count = 1
@@ -95,6 +96,7 @@ set dshot_bidir = ON
     #$ OPTION BEGIN (CHECKED): Average Build (Robust)
 	    set simplified_gyro_filter_multiplier = 120
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 700
         set dyn_notch_count = 2

--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
@@ -80,6 +80,7 @@ set iterm_relax_cutoff = 10
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
 	    set simplified_gyro_filter_multiplier = 160
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 800
         set dyn_notch_count = 1
@@ -95,6 +96,7 @@ set iterm_relax_cutoff = 10
     #$ OPTION BEGIN (CHECKED): Average Build (Robust)
 	    set simplified_gyro_filter_multiplier = 120
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 700
         set dyn_notch_count = 2

--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
@@ -79,6 +79,7 @@ set iterm_relax_cutoff = 8
     #$ OPTION BEGIN (UNCHECKED): Clean Build (High Performance)
         set simplified_gyro_filter_multiplier = 160
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 600
         set rpm_filter_min_hz = 60
@@ -97,6 +98,7 @@ set iterm_relax_cutoff = 8
     #$ OPTION BEGIN (CHECKED): Average Build (Robust)
         set simplified_gyro_filter_multiplier = 100
         set gyro_lpf1_static_hz = 0
+        set simplified_gyro_filter = ON
         set rpm_filter_harmonics = 3
         set rpm_filter_q = 500
         set dyn_notch_count = 2


### PR DESCRIPTION
Tweaks to the gyro filter, TPA and the master multiplier for my tunes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated FPV drone tuning presets for 3.4", 5", 6", and 7" models.
  * Adjusted TPA behavior: introduced/changed TPA mode, lowered TPA rate to 60, and reduced TPA breakpoint to 1250 for affected presets.
  * Enabled simplified gyro filtering and set gyro low-pass to 0 in performance and robust builds.
  * Tuned action camera multiplier for the 5" variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->