### PR TITLE
Include 4.5 filter defaults in Supafly 2025.12 tunes

### DIFF
--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_3_4_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_3_4_Inch_EasyTune.txt
@@ -39,6 +39,7 @@
 #$ DESCRIPTION: 
 
 #$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
 
 # ---- Base Setup -------
 

--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_5_Inch_EasyTune.txt
@@ -39,6 +39,7 @@
 #$ DESCRIPTION: 
 
 #$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
 
 # ---- Base Setup -------
 

--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_6_and_EasyTune.txt
@@ -39,6 +39,7 @@
 #$ DESCRIPTION: 
 
 #$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
 
 # ---- Base Setup -------
 

--- a/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
+++ b/presets/2025.12/tune/supafly_fpv/SupaflyFPV_Freestyle_7_Inch_EasyTune.txt
@@ -39,6 +39,7 @@
 #$ DESCRIPTION: 
 
 #$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
 
 # ---- Base Setup -------
 


### PR DESCRIPTION
Filter default Includes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated SupaflyFPV Freestyle drone presets (3.4", 5", 6", and 7" models) with expanded filter configuration defaults, providing users with additional tuning options for enhanced customization and performance optimization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->