### PR TITLE
UAVtech 2025.12 Update for 8-9in

### DIFF
--- a/presets/2025.12/tune/uav_tech/UAV_tech_8-9in.txt
+++ b/presets/2025.12/tune/uav_tech/UAV_tech_8-9in.txt
@@ -1,0 +1,134 @@
+#$ TITLE: UAV Tech - 8"/9" (1000-1400 AUW)
+#$ FIRMWARE_VERSION: 2025.12
+#$ CATEGORY: TUNE
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: 4S, 6S, 8in, 9in, 8", 9", freestyle, long range
+#$ AUTHOR: UAV Tech (Mark Spatz)
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION: I am a Betaflight contributor, YouTube content creator, and professional tuner [www.theuavtech.com](https://www.theuavtech.com)
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [Preset Overview Video](https://youtu.be/dEuNa-V6pys)
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: Preset for this class of quadcopters:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: <img src="https://theuavtech.com/wp-content/uploads/2020/10/10in-Long-Range-Header-scaled.jpg" width="350px"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Description:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: Base tune for a 8-9in quad with HD camera, approximate weight from 1,000 to 1,400 grams.  This tune is good for 4S or 6S batteries. The base preset assume you have your ESC set to 24K PWM (default).  If you are on 48K+, click the option above. Also, if you would like to use with RPM filtering or Dynamic Idle, click the option above. If you don't know what these features mean, click the links below for videos on each topic.
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: Recommended MINIMUM motor sizes:
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: 9″/10" is 28xx+  |  for HEAVIER builds ==> 31xx
+#$ DESCRIPTION:
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://i0.wp.com/theuavtech.com/wp-content/uploads/2020/10/icon-150x150-1.png" width="100px" style="margin-left: auto; margin-right: auto; display: block;"/>
+#$ DESCRIPTION:
+#$ DESCRIPTION: Options (click for video):
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [What is ESC PWM Frequency?](https://youtu.be/v3806Incpvo)
+#$ DESCRIPTION: - [HIGH vs. low PWM Frequency](https://youtu.be/ibMbsi09vVo)
+#$ DESCRIPTION:
+#$ DESCRIPTION:   (Recommendation: 16k or 24k | make sure to adjust in ESC settings)
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [What is the RPM Filter?](https://youtu.be/Y_fIJ7-c0_A)
+#$ DESCRIPTION: - [RPM vs. Dynamic Notch ONLY](https://youtu.be/ve_TNB0D87U)
+#$ DESCRIPTION:
+#$ DESCRIPTION: - [What is Dynamic Idle?](https://youtu.be/ynHsoQXifdU)
+#$ DESCRIPTION:
+#$ DESCRIPTION: Need more HELP?
+#$ DESCRIPTION: -----------
+#$ DESCRIPTION: - [UAV Tech Discord](https://discordapp.com/invite/rCCzgeT)
+#$ DESCRIPTION: - [Take it to the NEXT LEVEL!](https://theuavtech.com/tuning)
+#$ DESCRIPTION:
+#$ WARNING: Prior to selecting the "RPM Filter" or "Dynamic Idle" options, Bi-Directional DSHOT must be setup for your quad.  If you have not setup yet, click "CANCEL" and setup first (PROPS OFF to test).  If you have NOT selected the "RPM Filter" or "Dynamic Idle" options, YOU CAN IGNORE THIS MESSAGE.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/206
+#$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+# -- PID Settings --
+set simplified_d_gain = 140
+set simplified_pi_gain = 100
+set simplified_feedforward_gain = 140
+set simplified_d_max_gain = 0
+set simplified_i_gain = 50
+set simplified_pitch_d_gain = 120
+set simplified_pitch_pi_gain = 110
+set simplified_master_multiplier = 170
+
+set iterm_relax_cutoff = 10
+set anti_gravity_gain = 100
+set pidsum_limit = 1000
+set pidsum_limit_yaw = 1000
+
+#$ OPTION_GROUP BEGIN: Choose ONE Filter option (+ RPM filter if desired)
+  #$ OPTION BEGIN (UNCHECKED): low Build Quality
+  # -- ADDER: For HIGH gyro vibration builds --
+    set simplified_gyro_filter = ON
+    set simplified_gyro_filter_multiplier = 30
+    set simplified_dterm_filter = ON
+    set simplified_dterm_filter_multiplier = 80
+    set dyn_notch_count = 4
+    set dyn_notch_min_hz = 80
+    set dyn_notch_max_hz = 550
+    set yaw_lowpass_hz = 90
+  #$ OPTION END
+
+  #$ OPTION BEGIN (CHECKED): Medium Build Quality
+  # -- ADDER: For Medium gyro vibration builds --
+    set simplified_gyro_filter = ON
+    set simplified_gyro_filter_multiplier = 60
+    set simplified_dterm_filter = ON
+    set simplified_dterm_filter_multiplier = 100
+    set dyn_notch_count = 3
+    set dyn_notch_min_hz = 100
+    set dyn_notch_max_hz = 550
+    set yaw_lowpass_hz = 125
+  #$ OPTION END
+
+  #$ OPTION BEGIN (UNCHECKED): HIGH Build Quality
+  # -- ADDER: For low gyro vibration builds --
+    set simplified_gyro_filter = ON
+    set simplified_gyro_filter_multiplier = 100
+    set simplified_dterm_filter = ON
+    set simplified_dterm_filter_multiplier = 120
+    set dyn_notch_count = 2
+    set dyn_notch_min_hz = 125
+    set dyn_notch_max_hz = 550
+    set yaw_lowpass_hz = 0
+  #$ OPTION END
+
+  #$ OPTION BEGIN (UNCHECKED): ... + enable RPM filter (if supported)
+  # -- ADDER: Enabled RPM filtering --
+    set motor_pwm_protocol = DSHOT600
+    set dshot_bidir = ON
+    set rpm_filter_harmonics = 2
+    set dyn_notch_count = 2
+  #$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) ESC PWM Options ...
+  #$ OPTION BEGIN (CHECKED): 16 & 24k ESC PWM Settings
+  # -- ADDER: For 16 & 24k ESC PWM Settings --
+    set thrust_linear = 0
+  #$ OPTION END
+
+  #$ OPTION BEGIN (UNCHECKED): 48k+ ESC PWM Settings
+  # -- ADDER: For 48k+ ESC PWM Settings --
+    set thrust_linear = 20
+  #$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Prop Wash Performance Booster ...
+  #$ OPTION BEGIN (UNCHECKED): Dynamic Idle
+  # -- ADDER: Enabling Dynamic Idle --
+    set dyn_idle_min_rpm = 35
+  #$ OPTION END
+#$ OPTION_GROUP END
+
+simplified_tuning apply
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UAV Tech 8"/9" tuning preset optimized for 1000–1400 g aircraft with 4S/6S support
  * Multiple build-quality profiles (low/medium/high) with tailored gyro, D-term, notch and filter options
  * Optional RPM filtering and selectable ESC PWM frequency groups
  * Prop-wash performance booster (Dynamic Idle) and simplified preset-based tuning application

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->