### PR TITLE
Add CADDX Protos preset

### DIFF
--- a/presets/4.5/tune/caddx/CADDX_Protos.txt
+++ b/presets/4.5/tune/caddx/CADDX_Protos.txt
@@ -13,7 +13,7 @@
 #$ DESCRIPTION: - MCU: STM32F405
 #$ DESCRIPTION: - Battery: 2S LiPo
 #$ DESCRIPTION: - Optimized for responsive freestyle and general FPV flying
-#$ DESCRIPTION: - This preset is ONLY intended for Betaflight 4.5 firmware.
+#$ DESCRIPTION: - Intended for Betaflight 4.5 firmware due to simplified tuning behavior.
 #$ DESCRIPTION:
 
 profile 0


### PR DESCRIPTION
This is a tune preset made for the CADDX Protos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental factory performance tuning profile for CADDX Protos F4 (Betaflight 4.5, STM32F405), optimized for 2S LiPo.
  * Includes tuned gyro filtering, dynamic notch and RPM filtering, separated PID/FF adjustments, master multiplier and simplified tuning parameters for responsive freestyle FPV flying.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->