### PR TITLE
Update openracer preset from 4.5 to 2025.12

### DIFF
--- a/presets/2025.12/tune/openracer_jazzmutant_tune.txt
+++ b/presets/2025.12/tune/openracer_jazzmutant_tune.txt
@@ -1,0 +1,101 @@
+#$ TITLE: OpenRacer 5" 6S by JazzMutant
+#$ FIRMWARE_VERSION: 2025.12
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: openracer, race, 5 Inch, 5 In, 5", JazzMutant
+#$ AUTHOR: JazzMutant
+#$ PARSER: MARKED
+#$ DESCRIPTION: This tune was specially developed by **@JazzMutant** for 6S [OpenRacer](https://github.com/OpenRacer/OpenRacer/tree/master) with 1900-2100kv motors.
+#$ DESCRIPTION: 
+#$ DESCRIPTION: ## Important notes:
+#$ DESCRIPTION: - Be sure you're using ESC with bidirectional DShot support (BLHeli32, AM32, BlueJay, OX32)
+#$ DESCRIPTION: - Select "Clean builds" filters option only if your build is perfect and props are always not very damaged.
+#$ DESCRIPTION: - For a typical racing quad "Normal" filters option is the best choice.
+#$ DESCRIPTION: - Test your quad after applying preset by flying slow for 30 seconds. Motors should stay cool or slightly warm. Quad should sound clean
+#$ DESCRIPTION: - **If anything is off, don't fly it!**
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/460
+#$ FORCE_OPTIONS_REVIEW: TRUE
+
+# Apply defaults
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+set motor_pwm_protocol = DSHOT600
+set dshot_bidir = ON
+
+set simplified_master_multiplier = 85
+set simplified_i_gain = 90
+set simplified_d_gain = 100
+set simplified_pi_gain = 115
+set simplified_d_max_gain = 0
+set simplified_feedforward_gain = 100
+set simplified_pitch_d_gain = 85
+set simplified_pitch_pi_gain = 85
+set simplified_gyro_filter = ON
+set thrust_linear = 20
+
+set gyro_lpf2_static_hz = 0
+
+set tpa_mode = D
+set tpa_rate = 65
+set tpa_breakpoint = 1650
+
+#$ OPTION BEGIN (UNCHECKED): DShot300 (instead of DShot600)
+    set motor_pwm_protocol = Dshot300
+#$ OPTION END
+
+#$ OPTION_GROUP BEGIN: Tuning Options
+    #$ OPTION BEGIN (CHECKED): Set Dynamic Idle to 35
+        set dyn_idle_min_rpm = 35
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Disable Throttle Boost
+        set throttle_boost = 0
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Enable full Battery Sag Compensation
+        set vbat_sag_compensation = 100
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Filters (select one)
+    #$ OPTION BEGIN (CHECKED): Normal builds 
+        set dyn_notch_count = 2
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 800
+        set simplified_gyro_filter_multiplier = 130
+        set rpm_filter_harmonics = 3
+        set rpm_filter_weights = 100,50,50
+        set simplified_dterm_filter_multiplier = 110
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Clean builds (be careful)
+        set dyn_notch_count = 1
+        set dyn_notch_q = 500
+        set dyn_notch_min_hz = 150
+        set dyn_notch_max_hz = 600
+        set simplified_gyro_filter_multiplier = 200
+        set rpm_filter_harmonics = 3
+        set rpm_filter_weights = 100,50,50
+        set simplified_dterm_filter_multiplier = 130
+        set dterm_lpf1_dyn_expo = 7
+    #$ OPTION END
+#$ OPTION_GROUP END
+
+simplified_tuning apply
+
+#$ OPTION BEGIN (UNCHECKED): 533 rates (Actual)
+    #$ INCLUDE: presets/2025.12/rates/defaults.txt
+    set rates_type = ACTUAL
+    set roll_rc_rate = 16
+    set pitch_rc_rate = 16
+    set yaw_rc_rate = 16
+    set roll_expo = 56
+    set pitch_expo = 56
+    set yaw_expo = 56
+    set roll_srate = 53
+    set pitch_srate = 53
+    set yaw_srate = 53
+#$ OPTION END


### PR DESCRIPTION
Updated command for d max slider and updated references in include commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tuning preset for OpenRacer JazzMutant 5" 6S, including pre-configured settings for motor performance, filtering, dynamic idle, battery compensation, and control rates to optimize flight characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->