### PR TITLE
karate race whoop  tune for 2025:12

### DIFF
--- a/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
+++ b/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
@@ -9,7 +9,7 @@
 
 #$ DESCRIPTION:
 #$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174759844-ffd85f42-1f1c-42bf-9032-d9f96d4d9619.svg" width="90px" style="display: block; float: left; margin-right: 10px; margin-top: 20px"/>
-#$ DESCRIPTION: <h1>Karate Race 6S 5"</h1>
+#$ DESCRIPTION: <h1>Karate Race Whoop 65mm</h1>
 #$ DESCRIPTION: <br>
 #$ DESCRIPTION:
 #$ DESCRIPTION: This 1s whoop racing tune was developed using my custom Betafpv 5n1 build that weighs 15.6g [Air Brushless FC](https://betafpv.com/collections/brushless-flight-controller/products/air-brushless-flight-controller?variant=41142912745606) it is a slider tune allowing easy modification. 
@@ -24,7 +24,7 @@
 #$ DESCRIPTION: ## Things to note:
 #$ DESCRIPTION:
 #$ DESCRIPTION: - **YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!** Failure to do so might result in fire 🔥
-#$ DESCRIPTION: - Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc.
+#$ DESCRIPTION: - Also this should be applied to a clean flash after you've setup your rates, switches, vtx tables etc.
 #$ DESCRIPTION: - To test arm the quad with props on, it should **sound clean with no grinding**. If it passes that then hover test and check motor temps.
 #$ DESCRIPTION: - **If anything is off, don't fly it!!**
 #$ DESCRIPTION:   48khz firmware is recommended using 96khz will reduce the authority by a big margin and likely won’t fly very well.
@@ -34,7 +34,7 @@
 #$ DESCRIPTION: ## Radio links:
 #$ DESCRIPTION: 1. Make sure your radio firmware is up to date using either EdgeTX or OpenTX
 #$ DESCRIPTION: 2. Make sure your **ADC Filter is OFF** in the hardware page
-#$ DESCRIPTION: 3. @adio link rate is automatically detected and adjusted for with links above 150hz
+#$ DESCRIPTION: 3. Radio link rate is automatically detected and adjusted for with links above 150hz
 
 #$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/574
 

--- a/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
+++ b/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
@@ -1,0 +1,176 @@
+#$ TITLE: Karate RACE Whoop 2025.12
+#$ FIRMWARE_VERSION: 2025.12
+#$ CATEGORY: TUNE
+#$ STATUS: OFFICIAL 
+#$ KEYWORDS: karate, 1S, race, brushless, whoop, 65mm, sugarK, KarateBrot
+#$ AUTHOR: sugarK
+
+#$ PARSER: MARKED
+
+#$ DESCRIPTION:
+#$ DESCRIPTION: <img src="https://user-images.githubusercontent.com/19867640/174759844-ffd85f42-1f1c-42bf-9032-d9f96d4d9619.svg" width="90px" style="display: block; float: left; margin-right: 10px; margin-top: 20px"/>
+#$ DESCRIPTION: <h1>Karate Race 6S 5"</h1>
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This 1s whoop racing tune was developed using my custom Betafpv 5n1 build that weighs 15.6g [Air Brushless FC](https://betafpv.com/collections/brushless-flight-controller/products/air-brushless-flight-controller?variant=41142912745606) it is a slider tune allowing easy modification. 
+#$ DESCRIPTION: Has been tested on the mob6 hdz and NBD rs builds. For indoor flying/racing turn off air mode for the best performance. If your into acro flying in a big space put it on a switch.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: This tune should work well on any BRUSHLESS powered quality whoop build in the sub 20g range. It shouldn't be used on a brushed whoop.
+#$ DESCRIPTION: 
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Things to note:
+#$ DESCRIPTION:
+#$ DESCRIPTION: - **YOU HAVE TO USE RPM FILTERING WITH THIS TUNE!** Failure to do so might result in fire 🔥
+#$ DESCRIPTION: - Also this should be applied to a clean flash after you've setup your rates, swtiches, vtx tables etc.
+#$ DESCRIPTION: - To test arm the quad with props on, it should **sound clean with no grinding**. If it passes that then hover test and check motor temps.
+#$ DESCRIPTION: - **If anything is off, don't fly it!!**
+#$ DESCRIPTION:   48khz firmware is recommended using 96khz will reduce the authority by a big margin and likely won’t fly very well.
+#$ DESCRIPTION:
+#$ DESCRIPTION: <br>
+#$ DESCRIPTION:
+#$ DESCRIPTION: ## Radio links:
+#$ DESCRIPTION: 1. Make sure your radio firmware is up to date using either EdgeTX or OpenTX
+#$ DESCRIPTION: 2. Make sure your **ADC Filter is OFF** in the hardware page
+#$ DESCRIPTION: 3. @adio link rate is automatically detected and adjusted for with links above 150hz
+
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/574
+
+#$ INCLUDE_WARNING: misc/warnings/en/rpm_filters.txt
+#$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+# --DSHOT --
+set motor_pwm_protocol = Dshot300
+
+# -- Gyro lowpass filters --
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 0
+set gyro_lpf1_static_hz = 0
+
+# -- Gyro Dynamic Notches --
+set dyn_notch_count = 0
+
+# -- Dterm filtering --
+set dterm_lpf1_dyn_expo = 7
+
+# -- RPM filtering --
+set motor_poles = 12
+set dshot_bidir = ON
+set rpm_filter_fade_range_hz = 120
+set rpm_filter_harmonics = 1
+
+# -- iTerm  --
+set iterm_relax_cutoff = 45
+
+# -- Misc --
+set thrust_linear = 20
+set vbat_max_cell_voltage = 445
+set cpu_late_limit_permille = 15
+
+#$ OPTION_GROUP BEGIN: Dynamic Idle
+
+    #$ OPTION BEGIN (CHECKED): 12k race 15-18g whoop ( recommended )
+        set dyn_idle_min_rpm = 120
+        set dyn_idle_p_gain = 35
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): 18k FS 18g+ whoop
+        set dyn_idle_min_rpm = 150
+        set dyn_idle_p_gain = 35
+    #$ OPTION END
+    
+#$ OPTION_GROUP END
+
+#$ OPTION BEGIN (CHECKED): Vbat sag compensation ( recommended )
+    set vbat_sag_compensation = 100
+#$ OPTION END
+
+#$ OPTION BEGIN (UNCHECKED): Airmode OFF
+    feature -AIRMODE
+#$ OPTION END
+    
+#$ OPTION BEGIN (UNCHECKED): New crash flip mode
+    set crashflip_rate = 20
+    set crashflip_auto_rearm = ON 
+#$ OPTION END
+
+# -- PID values --
+set simplified_pids_mode = RP
+set simplified_i_gain = 110
+set simplified_d_gain = 80
+set simplified_pi_gain = 95
+set simplified_d_max_gain = 90
+set simplified_feedforward_gain = 115
+set simplified_pitch_d_gain = 105
+set simplified_dterm_filter_multiplier = 90
+set d_max_gain = 0
+set d_max_advance = 37
+set feedforward_boost = 18
+set feedforward_max_rate_limit = 100
+simplified_tuning apply
+
+#$ OPTION_GROUP BEGIN (EXCLUSIVE): Radio links
+    #Note you have to build the firmware with Ghost or SBUS to use them
+    #$ OPTION BEGIN (CHECKED): CRSF/ELRS
+        feature RX_SERIAL
+        set serialrx_provider = CRSF
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ghost 
+        feature RX_SERIAL
+        set serialrx_provider = GHST
+
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): SBUS
+        feature RX_SERIAL
+        set serialrx_provider = SBUS
+
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): Set RX to SPI ELRS 
+        set rx_spi_protocol = EXPRESSLRS   
+        
+    #$ OPTION END
+
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN (EXCLUSIVE): Stick feel aka Jitter reduction
+    #$ OPTION BEGIN (UNCHECKED): Standard feel 
+        set feedforward_jitter_factor = 7
+        
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (CHECKED): Racy feel 
+        set feedforward_jitter_factor = 3
+        
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): Sharpest feel 
+        set feedforward_jitter_factor = 0
+        
+    #$ OPTION END
+    
+#$ OPTION_GROUP END
+
+#$ OPTION_GROUP BEGIN: Optional rates
+    #$ OPTION BEGIN (UNCHECKED): sugarK's rates
+        #$ INCLUDE: presets/4.3/rates/SugarK_whoop.txt
+        
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): throttle expo for 30% hover throttle
+        set thr_mid = 30
+        set thr_expo = 65
+    #$ OPTION END
+    
+    #$ OPTION BEGIN (UNCHECKED): throttle expo for 45% hover throttle
+        set thr_mid = 45
+        set thr_expo = 65
+    #$ OPTION END
+    
+#$ OPTION_GROUP END


### PR DESCRIPTION
new tune for racing sub 20g 65mm race whoops that uses new features and tuning ideas from the new current release 2025:12

it leans into new FF smoothing and Dmin/max in boosting changes in 2025:12 and adopts new tuning ideas to suit the new release.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Karate RACE Whoop (2025.12)" preset for 1S whoop: DShot300 bidirectional, tuned gyro/D-term filtering and RPM filtering, iTerm relaxation and other tuning refinements. Includes selectable option groups: Dynamic Idle, vBat sag compensation, Airmode OFF, crash-flip modes, exclusive radio-link choices, stick-feel/jitter adjustments, optional rate variants, and simplified PID tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->