### PR TITLE
fix hover points for 25:12 preset

### DIFF
--- a/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
+++ b/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
@@ -69,6 +69,7 @@ set iterm_relax_cutoff = 45
 set thrust_linear = 20
 set vbat_max_cell_voltage = 445
 set cpu_late_limit_permille = 15
+set vbat_max_cell_voltage = 445
 
 #$ OPTION_GROUP BEGIN: Dynamic Idle
 
@@ -165,11 +166,13 @@ simplified_tuning apply
     
     #$ OPTION BEGIN (UNCHECKED): throttle expo for 30% hover throttle
         set thr_mid = 30
+        set thr_hover = 30
         set thr_expo = 65
     #$ OPTION END
     
     #$ OPTION BEGIN (UNCHECKED): throttle expo for 45% hover throttle
         set thr_mid = 45
+        set thr_hover = 45
         set thr_expo = 65
     #$ OPTION END
     

--- a/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
+++ b/presets/2025.12/tune/karate/karate_whoop_2025_12.txt
@@ -69,7 +69,6 @@ set iterm_relax_cutoff = 45
 set thrust_linear = 20
 set vbat_max_cell_voltage = 445
 set cpu_late_limit_permille = 15
-set vbat_max_cell_voltage = 445
 
 #$ OPTION_GROUP BEGIN: Dynamic Idle
 


### PR DESCRIPTION
fix hover points for 25:12 preset
add add battery settings to suit HV packs as most whoop packs are HV now



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Karate Whoop 2025.12 preset configuration with new throttle hover settings for throttle response tuning options.
  * Added hover throttle parameters to throttle expo configurations.
  * Updated battery voltage settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->