### PR TITLE
Add TBS Unify Pro32 DP VTX table

### DIFF
--- a/presets/4.3/vtx/Unify_Pro32_DP_SA2_1.txt
+++ b/presets/4.3/vtx/Unify_Pro32_DP_SA2_1.txt
@@ -1,0 +1,29 @@
+#$ TITLE: TBS Unify Pro32 DP SA 2.1
+#$ FIRMWARE_VERSION: 4.2
+#$ FIRMWARE_VERSION: 4.3
+#$ FIRMWARE_VERSION: 4.4
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: VTX
+#$ STATUS: COMMUNITY
+#$ KEYWORDS:  vtx, vtx table, tbs, unify , pro32, DP, SA 2.1
+#$ AUTHOR: andybrwr
+#$ DESCRIPTION: VTX table for TBS Unify Pro32 DP SA 2.1. NOTE 1. Max power set to 65dB as it will force the VTX to output max power. NOTE 2. This table is as provided by the manufacturer.
+#$ DESCRIPTION: !!! Make sure to use the correct broad band antenna to avoid damaging the VTX !!!
+#$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
+#$ DESCRIPTION: ----------
+#$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+#$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
+
+# vtxtable
+vtxtable bands 6
+vtxtable channels 8
+vtxtable band 1 BOSCAM_A A FACTORY 5865 5845 5825 5805 5785 5765 5745 5725
+vtxtable band 2 BOSCAM_B B FACTORY 5733 5752 5771 5790 5809 5828 5847 5866
+vtxtable band 3 BOSCAM_E E FACTORY 5705 5685 5665 5645 5885 5905 5925 5945
+vtxtable band 4 FATSHARK F FACTORY 5740 5760 5780 5800 5820 5840 5860 5880
+vtxtable band 5 RACEBAND R FACTORY 5658 5695 5732 5769 5806 5843 5880 5917
+vtxtable band 6 RACE_LOW L FACTORY 5362 5399 5436 5473 5510 5547 5584 5621
+
+vtxtable powerlevels 8
+vtxtable powervalues 10 14 20 23 26 27 30 65
+vtxtable powerlabels 10 25 100 200 400 500 999 3k

--- a/presets/4.3/vtx/Unify_Pro32_DP_SA2_1.txt
+++ b/presets/4.3/vtx/Unify_Pro32_DP_SA2_1.txt
@@ -12,6 +12,7 @@
 #$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
 #$ DESCRIPTION: ----------
 #$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/583
 #$ INCLUDE_DISCLAIMER: misc/disclaimer/en/vtxtable.txt
 
 # vtxtable

--- a/presets/4.3/vtx/Unify_Pro32_DP_SA2_1.txt
+++ b/presets/4.3/vtx/Unify_Pro32_DP_SA2_1.txt
@@ -3,12 +3,14 @@
 #$ FIRMWARE_VERSION: 4.3
 #$ FIRMWARE_VERSION: 4.4
 #$ FIRMWARE_VERSION: 4.5
+#$ FIRMWARE_VERSION: 2025.12
+#$ FIRMWARE_VERSION: 2026.6
 #$ CATEGORY: VTX
 #$ STATUS: COMMUNITY
 #$ KEYWORDS:  vtx, vtx table, tbs, unify , pro32, DP, SA 2.1
 #$ AUTHOR: andybrwr
 #$ DESCRIPTION: VTX table for TBS Unify Pro32 DP SA 2.1. NOTE 1. Max power set to 65dB as it will force the VTX to output max power. NOTE 2. This table is as provided by the manufacturer.
-#$ DESCRIPTION: !!! Make sure to use the correct broad band antenna to avoid damaging the VTX !!!
+#$ DESCRIPTION: !!! Make sure to use the correct broadband antenna to avoid damaging the VTX !!!
 #$ DESCRIPTION: The information provided on this preset is for educational and entertainment purposes only. Betaflight makes no representations as to the safety or legality of the use of any information provided herein. End users assume all responsibility and liability for ensuring they are complying with all relevant laws and regulations.
 #$ DESCRIPTION: ----------
 #$ DESCRIPTION: Using the VTX tables as provided may be in breach of your local RF laws. It is up to the end user to research and comply with local regulations and in using these presets the user assumes all liability associated with breaching local regulations.


### PR DESCRIPTION
Adds a preset for the [TBS Unify Pro32 DP](https://www.team-blacksheep.com/products/prod:pro32_dp) according to provided VTX table at https://www.team-blacksheep.com/media/files/vtx-table-for-betaflight.txt.
Doesn't currently include the "all bands" option - I wasn't able to get this working at all in Betaflight, but maybe I was doing something wrong?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new VTX preset for the TBS Unify Pro32 DP SA 2.1.
  * Included complete band, channel, and power level information, available for multiple firmware versions.
  * Expanded the power label range to support a higher top-end setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->