### PR TITLE
Create oxbt_champ2_factory.txt

### DIFF
--- a/presets/2025.12/tune/oxbt_champ2_factory.txt
+++ b/presets/2025.12/tune/oxbt_champ2_factory.txt
@@ -21,7 +21,7 @@
 #$ DESCRIPTION: - Battery: 1480mAh-1550mAh, any brand/C-rating
 #$ DESCRIPTION:
 #$ DESCRIPTION: These are recommendations only. Every pilot has their own preferences — feel free to experiment.
-#$ DISCUSSION: https://github.com/gyyy414/firmware-presets
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/584
 
 # OXBT CHAMP2 Factory Preset
 #

--- a/presets/2025.12/tune/oxbt_champ2_factory.txt
+++ b/presets/2025.12/tune/oxbt_champ2_factory.txt
@@ -1,0 +1,121 @@
+#$ TITLE: OXBT CHAMP2 Factory Preset
+#$ FIRMWARE_VERSION: 2025.12
+#$ CATEGORY: TUNE
+#$ STATUS: COMMUNITY
+#$ KEYWORDS: oxbt, champ2, champ, factory, pid, tune
+#$ AUTHOR: Michael-GGG
+#$ DESCRIPTION: Factory preset for the OXBT CHAMP2 flight controller.
+#$ DESCRIPTION: Two PID tune options: Standard (smooth, stable, all-round) and Ultra (aggressive, racing, disables accelerometer and Airmode).
+#$ DESCRIPTION: Standard is the default and recommended for most pilots.
+#$ DESCRIPTION:
+#$ DESCRIPTION: RPM filtering (Bidirectional DSHOT) is REQUIRED for this tune.
+#$ DESCRIPTION:
+#$ DESCRIPTION: Recommended setup for Ultra:
+#$ DESCRIPTION: - Motor KV: 2150-2200
+#$ DESCRIPTION: - Props: GF5129, HQProp R29, HQProp R28 MCK, or other low-pitch props
+#$ DESCRIPTION: - Battery: 1500mAh or lighter, any brand/C-rating, to unlock Ultra's full potential
+#$ DESCRIPTION:
+#$ DESCRIPTION: Recommended setup for Standard:
+#$ DESCRIPTION: - Motor KV: 1950-2020
+#$ DESCRIPTION: - Props: GF5129, GF51377, GF51466, or other medium-pitch props
+#$ DESCRIPTION: - Battery: 1480mAh-1550mAh, any brand/C-rating
+#$ DESCRIPTION:
+#$ DESCRIPTION: These are recommendations only. Every pilot has their own preferences — feel free to experiment.
+#$ DISCUSSION: https://github.com/gyyy414/firmware-presets
+
+# OXBT CHAMP2 Factory Preset
+#
+# Two PID tune options:
+# - Standard: Smooth, stable, suitable for most pilots
+# - Ultra: Aggressive, requires a clean/low-noise build, and disables Airmode by default
+
+# ---- Common Settings ----
+
+# Features
+feature TELEMETRY
+feature LED_STRIP
+feature OSD
+
+# Hardware
+set mag_hardware = NONE
+set baro_hardware = NONE
+
+# Gyro Filters
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 0
+set dyn_notch_count = 2
+set dyn_notch_q = 550
+set gyro_lpf1_dyn_min_hz = 0
+set gyro_lpf1_dyn_max_hz = 550
+set simplified_gyro_filter_multiplier = 110
+
+# Blackbox
+set blackbox_sample_rate = 1/8
+
+# Motor
+set yaw_motors_reversed = ON
+
+# Common PID Settings
+set vbat_sag_compensation = 100
+set feedforward_jitter_factor = 3
+set feedforward_boost = 18
+set feedforward_max_rate_limit = 100
+set dyn_idle_min_rpm = 35
+set simplified_pids_mode = OFF
+set simplified_dterm_filter = OFF
+set simplified_dterm_filter_multiplier = 120
+set tpa_breakpoint = 1300
+
+profile 0
+
+#$ OPTION_GROUP BEGIN: (EXCLUSIVE) PID Tune Selection
+    #$ OPTION BEGIN (CHECKED): Standard PIDs — Smooth, stable, all-round flight
+        set dterm_lpf1_dyn_min_hz = 65
+        set dterm_lpf1_dyn_max_hz = 135
+        set dterm_lpf1_static_hz = 0
+        set dterm_lpf2_static_hz = 130
+        set anti_gravity_gain = 60
+        set throttle_boost = 0
+        set p_pitch = 32
+        set i_pitch = 115
+        set d_pitch = 25
+        set f_pitch = 105
+        set p_roll = 33
+        set i_roll = 112
+        set d_roll = 24
+        set f_roll = 110
+        set p_yaw = 34
+        set i_yaw = 110
+        set f_yaw = 105
+        set d_max_roll = 32
+        set d_max_pitch = 34
+        set tpa_rate = 60
+        set small_angle = 180
+    #$ OPTION END
+
+    #$ OPTION BEGIN (UNCHECKED): Ultra PIDs — Aggressive, requires a clean/low-noise build, and disables Airmode by default
+        feature -AIRMODE
+        set acc_hardware = NONE
+        set dterm_lpf1_dyn_min_hz = 85
+        set dterm_lpf1_dyn_max_hz = 185
+        set dterm_lpf1_static_hz = 0
+        set dterm_lpf2_static_hz = 185
+        set anti_gravity_gain = 55
+        set throttle_boost = 8
+        set p_pitch = 42
+        set i_pitch = 115
+        set d_pitch = 28
+        set f_pitch = 125
+        set p_roll = 43
+        set i_roll = 112
+        set d_roll = 27
+        set f_roll = 130
+        set p_yaw = 40
+        set i_yaw = 110
+        set f_yaw = 125
+        set d_max_roll = 36
+        set d_max_pitch = 37
+        set tpa_rate = 70
+        set small_angle = 180
+    #$ OPTION END
+#$ OPTION_GROUP END


### PR DESCRIPTION
Tune preset for OXBT CHAMP2 flight controller with Standard and Ultra PID options.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new firmware preset for the OXBT CHAMP2 flight controller in the 2025.12 TUNE range.
  * Included ready-to-use tuning guidance with shared settings and two selectable PID profiles: **Standard** (default) and **Ultra**.
  * Added notes and links, including a reminder that Bidirectional DSHOT RPM filtering is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->