### PR TITLE
Add explicit permissions blocks for read-default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "30 4 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: 'Check and close stale issues'


### PR DESCRIPTION
The org default GITHUB_TOKEN permission is now read. These workflows write with GITHUB_TOKEN (stale labelling/closing, PR comment actions) and need explicit permissions to keep working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated issue and pull request maintenance permissions to support the existing stale-item workflow.
  * No changes were made to scheduling, configuration, or workflow behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->