### PR TITLE
Add Funkolius Impetus 2 preset

### DIFF
--- a/presets/2025.12/tune/Funkolius_Impetus_Frame.txt
+++ b/presets/2025.12/tune/Funkolius_Impetus_Frame.txt
@@ -2,7 +2,7 @@
 #$ FIRMWARE_VERSION: 2025.12
 #$ CATEGORY: TUNE
 #$ STATUS: EXPERIMENTAL
-#$ KEYWORDS: freestyle, impetus 2, impetus, micro, 2 inch, 2.2 inch prop, frame, Funkolius
+#$ KEYWORDS: freestyle, impetus 2, impetus, micro, 2 inch, 2 in, 2", 2.2 inch prop, frame, Funkolius
 #$ AUTHOR: Funkolius
 #$ PARSER: MARKED
 #$ DESCRIPTION: Tune for the Impetus 2 frame by Funkolius.
@@ -15,7 +15,6 @@
 profile 0
 
 #$ INCLUDE: presets/2025.12/tune/defaults.txt
-#$ INCLUDE: presets/4.5/filters/defaults.txt
 
 # -- Simplified tuning baseline --
 set simplified_master_multiplier = 120
@@ -35,24 +34,12 @@ set iterm_rotation = ON
 set iterm_relax = RPY
 set iterm_relax_type = GYRO
 set iterm_relax_cutoff = 13
-set p_pitch = 39
-set i_pitch = 52
-set d_pitch = 53
-set f_pitch = 89
-set p_roll = 37
-set i_roll = 50
-set d_roll = 43
-set f_roll = 86
-set p_yaw = 37
-set i_yaw = 50
-set f_yaw = 86
-set d_max_roll = 43
-set d_max_pitch = 53
 set d_max_gain = 35
 set d_max_advance = 55
 
 # -- Filters --
 #$ OPTION BEGIN (CHECKED): FILTERS RECOMMENDED FOR CLEAN BUILD
+#$ INCLUDE: presets/4.5/filters/defaults.txt
 set gyro_lpf1_static_hz = 0
 set gyro_lpf2_static_hz = 700
 set dyn_notch_count = 1
@@ -69,13 +56,6 @@ set dterm_lpf2_static_hz = 0
 set simplified_dterm_filter = OFF
 set simplified_dterm_filter_multiplier = 100
 #$ OPTION END
-
-# -- Launch control defaults reset --
-set launch_control_mode = PITCHONLY
-set launch_trigger_allow_reset = ON
-set launch_trigger_throttle_percent = 20
-set launch_angle_limit = 0
-set launch_control_gain = 40
 
 # -- Launch control (optional) --
 #$ OPTION BEGIN (UNCHECKED): LAUNCH CONTROL (PITCHONLY)

--- a/presets/2025.12/tune/Funkolius_Impetus_Frame.txt
+++ b/presets/2025.12/tune/Funkolius_Impetus_Frame.txt
@@ -1,0 +1,88 @@
+#$ TITLE: Funkolius - Impetus 2 Frame
+#$ FIRMWARE_VERSION: 2025.12
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: freestyle, impetus 2, impetus, micro, 2 inch, 2.2 inch prop, frame, Funkolius
+#$ AUTHOR: Funkolius
+#$ PARSER: MARKED
+#$ DESCRIPTION: Tune for the Impetus 2 frame by Funkolius.
+#$ DESCRIPTION: Bidirectional DShot is required. Make sure your ESCs are 32-bit or flashed with BlueJay for 8-bit.
+#$ DESCRIPTION: Back up your current configuration before applying this preset, then test carefully and check motor temperatures.
+#$ FORCE_OPTIONS_REVIEW: false
+
+# Use PID profile 0 so the defaults include resets the same profile the tune uses.
+profile 0
+
+#$ INCLUDE: presets/2025.12/tune/defaults.txt
+#$ INCLUDE: presets/4.5/filters/defaults.txt
+
+# -- Simplified tuning baseline --
+set simplified_master_multiplier = 120
+set simplified_i_gain = 75
+set simplified_d_gain = 120
+set simplified_pi_gain = 70
+set simplified_d_max_gain = 0
+set simplified_feedforward_gain = 60
+set simplified_pitch_d_gain = 110
+set simplified_dterm_filter = OFF
+set simplified_dterm_filter_multiplier = 100
+
+simplified_tuning apply
+
+# -- PID tuning --
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_type = GYRO
+set iterm_relax_cutoff = 13
+set p_pitch = 39
+set i_pitch = 52
+set d_pitch = 53
+set f_pitch = 89
+set p_roll = 37
+set i_roll = 50
+set d_roll = 43
+set f_roll = 86
+set p_yaw = 37
+set i_yaw = 50
+set f_yaw = 86
+set d_max_roll = 43
+set d_max_pitch = 53
+set d_max_gain = 35
+set d_max_advance = 55
+
+# -- Filters --
+#$ OPTION BEGIN (CHECKED): FILTERS RECOMMENDED FOR CLEAN BUILD
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 700
+set dyn_notch_count = 1
+set dyn_notch_q = 750
+set dyn_notch_min_hz = 115
+set gyro_lpf1_dyn_min_hz = 0
+set simplified_gyro_filter = OFF
+
+set dterm_lpf1_dyn_min_hz = 80
+set dterm_lpf1_dyn_max_hz = 120
+set dterm_lpf1_type = BIQUAD
+set dterm_lpf2_static_hz = 0
+# Keep disabled D-term slider state sane if the user later re-enables the slider.
+set simplified_dterm_filter = OFF
+set simplified_dterm_filter_multiplier = 100
+#$ OPTION END
+
+# -- Launch control defaults reset --
+set launch_control_mode = PITCHONLY
+set launch_trigger_allow_reset = ON
+set launch_trigger_throttle_percent = 20
+set launch_angle_limit = 0
+set launch_control_gain = 40
+
+# -- Launch control (optional) --
+#$ OPTION BEGIN (UNCHECKED): LAUNCH CONTROL (PITCHONLY)
+set launch_control_mode = PITCHONLY
+set launch_trigger_throttle_percent = 35
+set launch_angle_limit = 80
+set launch_control_gain = 40
+#$ OPTION END
+
+# -- Other Requirements --
+set dshot_bidir = ON

--- a/presets/2025.12/tune/Funkolius_Impetus_Frame.txt
+++ b/presets/2025.12/tune/Funkolius_Impetus_Frame.txt
@@ -8,6 +8,7 @@
 #$ DESCRIPTION: Tune for the Impetus 2 frame by Funkolius.
 #$ DESCRIPTION: Bidirectional DShot is required. Make sure your ESCs are 32-bit or flashed with BlueJay for 8-bit.
 #$ DESCRIPTION: Back up your current configuration before applying this preset, then test carefully and check motor temperatures.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/588
 #$ FORCE_OPTIONS_REVIEW: false
 
 # Use PID profile 0 so the defaults include resets the same profile the tune uses.


### PR DESCRIPTION
Summary:
- Adds the Funkolius Impetus 2 frame tune preset for Betaflight 2025.12.
- Author is Funkolius.
- This PR is intentionally limited to Impetus 2 only.

Preset details:
- Product/frame: Impetus 2
- Firmware version: 2025.12
- Category: Tune
- Status: Experimental
- Requires bidirectional DShot / RPM filtering.
- Selects profile 0 before applying defaults so the reset and tune target the same PID profile.
- Includes version-matched tune defaults and official filter defaults before applying custom tune/filter values.

Validation performed:
- Ran npm run verify: OK
- Ran targeted Impetus-only audit to confirm no MOTUS, Omerta, Basher X, or Funkolius Productions references are present.
- Confirmed Author remains Funkolius.
- Confirmed profile/default includes appear before custom PID/filter values.
- Confirmed no bad simplified_dterm_filter_multiplier = 10 line is present.

Request:
Please review for official firmware-presets inclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tuning Preset Updates**
  * Updated the experimental “Funkolius - Impetus 2 Frame” tune preset for firmware 2025.12, including expanded prop-format keywords.
  * Revised how recommended filter defaults are applied to better support clean builds.
  * Refined PID tuning to adjust rotation/relax behaviour and D-term limits; removed the launch-control defaults reset while keeping the optional pitch-only configuration.
  * Keeps bidirectional DShot enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->