### PR TITLE
Allow fork PR checkout in pull_request_target build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true  # checkout@v5 fork-checkout gate; job is contents:read, no secrets
 
       - name: Setup node
         uses: actions/setup-node@v5


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Fixes checkout failure: `Refusing to check out fork pull request code from a 'pull_request_target' workflow`
- Adds `allow-unsafe-pr-checkout: true` to the `actions/checkout@v5` step in the `build` job
- Build job runs with `contents: read` only, no secrets exposed, so opting in is safe per actions/checkout@v5 guidance (https://gh.io/securely-using-pull_request_target)

## Test plan
- [ ] Confirm workflow run on a fork PR now checks out fork head SHA successfully
- [ ] Confirm `deploy` job (with secrets) still never checks out PR fork code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to support an additional pull request checkout path.
  * Existing read-only permissions and deployment behaviour remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->