### PR TITLE
Add Impetus 2 preset for Betaflight 4.5

### DIFF
--- a/presets/4.5/tune/Funkolius_Impetus_Frame.txt
+++ b/presets/4.5/tune/Funkolius_Impetus_Frame.txt
@@ -1,0 +1,76 @@
+#$ TITLE: Funkolius - Impetus 2 Frame
+#$ FIRMWARE_VERSION: 4.5
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: freestyle, impetus 2, impetus, micro, 2 inch, 2 in, 2\", 2.2 inch prop, frame, Funkolius
+#$ AUTHOR: Funkolius
+#$ PARSER: MARKED
+#$ DESCRIPTION: Tune for the Impetus 2 frame by Funkolius.
+#$ DESCRIPTION: Bidirectional DShot is required. Make sure your ESCs are 32-bit or flashed with BlueJay for 8-bit.
+#$ DESCRIPTION: Back up your current configuration before applying this preset, then test carefully and check motor temperatures.
+#$ DISCUSSION: https://github.com/betaflight/firmware-presets/pull/588
+#$ FORCE_OPTIONS_REVIEW: false
+
+# Use PID profile 0 so the defaults include resets the same profile the tune uses.
+profile 0
+
+#$ INCLUDE: presets/4.5/tune/defaults.txt
+
+# -- Simplified tuning baseline --
+set simplified_master_multiplier = 120
+set simplified_i_gain = 75
+set simplified_d_gain = 120
+set simplified_pi_gain = 70
+set simplified_dmax_gain = 0
+set simplified_feedforward_gain = 60
+set simplified_pitch_d_gain = 110
+set simplified_dterm_filter = OFF
+set simplified_dterm_filter_multiplier = 100
+
+simplified_tuning apply
+
+# -- PID tuning --
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_type = GYRO
+set iterm_relax_cutoff = 13
+set d_max_gain = 35
+set d_max_advance = 55
+
+# -- Filters --
+#$ OPTION BEGIN (CHECKED): FILTERS RECOMMENDED FOR CLEAN BUILD
+    #$ INCLUDE: presets/4.5/filters/defaults.txt
+    set gyro_lpf1_static_hz = 0
+    set gyro_lpf2_static_hz = 700
+    set dyn_notch_count = 1
+    set dyn_notch_q = 750
+    set dyn_notch_min_hz = 115
+    set gyro_lpf1_dyn_min_hz = 0
+    set simplified_gyro_filter = OFF
+
+    set dterm_lpf1_dyn_min_hz = 80
+    set dterm_lpf1_dyn_max_hz = 120
+    set dterm_lpf1_type = BIQUAD
+    set dterm_lpf2_static_hz = 0
+    # Keep disabled D-term slider state sane if the user later re-enables the slider.
+    set simplified_dterm_filter = OFF
+    set simplified_dterm_filter_multiplier = 100
+#$ OPTION END
+
+# -- Launch control defaults reset --
+set launch_control_mode = NORMAL
+set launch_trigger_allow_reset = ON
+set launch_trigger_throttle_percent = 20
+set launch_angle_limit = 0
+set launch_control_gain = 40
+
+# -- Launch control (optional) --
+#$ OPTION BEGIN (UNCHECKED): LAUNCH CONTROL (PITCHONLY)
+    set launch_control_mode = PITCHONLY
+    set launch_trigger_throttle_percent = 35
+    set launch_angle_limit = 80
+    set launch_control_gain = 40
+#$ OPTION END
+
+# -- Other Requirements --
+set dshot_bidir = ON


### PR DESCRIPTION
## Summary

- Add the Funkolius Impetus 2 tune preset for Betaflight 4.5.
- Use the current merged official Impetus 2 2025.12 preset as the parameter source; do not restore the earlier toned-down values.
- Translate only the firmware-specific 4.5 names and reset behavior:
  - `presets/4.5/tune/defaults.txt`
  - `presets/4.5/filters/defaults.txt`
  - `simplified_dmax_gain`
  - explicit 4.5 launch-control defaults reset before the optional block
- Keep the existing official 2025.12 Impetus preset unchanged.

## Validation

- `npm run index` completed; unrelated generated index churn was discarded to keep this official PR focused.
- `npm run verify` → `OK`
- Targeted audit passed for:
  - `profile 0` before defaults and custom tune
  - current approved 2025.12 authored values preserved
  - 4.5-specific parameter names
  - `simplified_dterm_filter_multiplier = 100`
  - no unrelated Funkolius products or terminology
  - explicit launch-control reset
- `git diff --check` → `OK`
- Remote branch verified from `raw.githubusercontent.com` after push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Funkolius Impetus 2 frame tuning preset for Betaflight 4.5.
  * Includes ready-to-use PID, filter, launch-control and tuning settings.
  * Provides an optional pitch-only launch-control configuration.
  * Includes guidance for bidirectional DShot requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->