### PR TITLE
Add Betaflight 2026.6 TUNE defaults

### DIFF
--- a/presets/2026.6/tune/defaults.txt
+++ b/presets/2026.6/tune/defaults.txt
@@ -1,0 +1,131 @@
+#$ TITLE: Betaflight 2026.6 TUNE defaults
+#$ FIRMWARE_VERSION: 2026.6
+#$ CATEGORY: TUNE
+#$ STATUS: OFFICIAL
+#$ KEYWORDS: defaults, reset, tune, pid, basic, default
+#$ AUTHOR: Betaflight
+#$ DESCRIPTION: Resets all Basic 2026.6 Tune category parameters to defaults
+#$ DESCRIPTION: WARNING: Overwrites all settings mentioned below to defaults.  The User cannot retain their previous values.
+#$ DESCRIPTION: WARNING: Tune authors must explicitly set these values to something other than default if needed for the tune.
+#$ DESCRIPTION: DOES NOT reset rates, filters, rc_smoothing, and many other parameters.
+#$ PRIORITY: 0
+
+# THE FOLLOWING PARAMETERS ARE CONTROLLED
+# ALL WILL BE RESET TO DEFAULTS WHEN THIS DEFAULT IS RUN
+# ALL USER PREFERENCES FOR THESE VALUES WILL BE OVER-WRITTEN
+# IF THE AUTHOR WANTS A NON-DEFAULT VALUE, THEIR TUNE MUST SET IT
+# BOTH CHECKED AND UNCHECKED OPTIONS CAN BE USED FOR THESE PARAMETERS
+
+set yaw_spin_recovery = AUTO
+
+set motor_idle = 550
+
+set mixer_type = LEGACY
+
+set gyro_cal_on_first_arm = OFF
+
+set pid_at_min_throttle = ON
+set anti_gravity_gain = 80
+set anti_gravity_cutoff_hz = 5
+set anti_gravity_p_gain = 100
+set acc_limit_yaw = 0
+set acc_limit = 0
+
+set crash_dthreshold = 50
+set crash_gthreshold = 400
+set crash_setpoint_threshold = 350
+set crash_time = 500
+set crash_delay = 0
+set crash_recovery_angle = 10
+set crash_recovery_rate = 100
+set crash_limit_yaw = 200
+set crash_recovery = OFF
+
+set iterm_rotation = OFF
+set iterm_relax = RP
+set iterm_relax_type = SETPOINT
+set iterm_relax_cutoff = 15
+set iterm_windup = 80
+set pidsum_limit = 500
+set pidsum_limit_yaw = 400
+
+set throttle_boost = 5
+set throttle_boost_cutoff = 15
+set acro_trainer_angle_limit = 20
+set acro_trainer_lookahead_ms = 50
+set acro_trainer_debug_axis = ROLL
+set acro_trainer_gain = 75
+
+set p_pitch = 47
+set i_pitch = 84
+set d_pitch = 34
+set f_pitch = 125
+set p_roll = 45
+set i_roll = 80
+set d_roll = 30
+set f_roll = 120
+set p_yaw = 45
+set i_yaw = 80
+set d_yaw = 0
+set f_yaw = 120
+set angle_p_gain = 50
+set angle_feedforward = 50
+set angle_feedforward_smoothing_ms = 80
+set angle_limit = 60
+set angle_earth_ref = 100
+set horizon_level_strength = 75
+set horizon_limit_sticks = 75
+set horizon_limit_degrees = 135
+set horizon_ignore_sticks = OFF
+set horizon_delay_ms = 500
+set use_integrated_yaw = OFF
+set integrated_yaw_relax = 200
+set d_max_roll = 40
+set d_max_pitch = 46
+set d_max_yaw = 0
+set d_max_gain = 0
+set d_max_advance = 35
+
+set thrust_linear = 0
+set feedforward_transition = 0
+set auto_profile_cell_count = 0
+set vbat_sag_compensation = 0
+set motor_output_limit = 100
+set level_race_mode = OFF
+
+set launch_control_mode = PITCHONLY
+set launch_trigger_allow_reset = ON
+set launch_trigger_throttle_percent = 20
+set launch_angle_limit = 0
+set launch_control_gain = 40
+
+set feedforward_max_rate_limit = 90
+set feedforward_yaw_hold_gain = 15
+set feedforward_yaw_hold_time = 100
+
+set dyn_idle_min_rpm = 0
+set dyn_idle_p_gain = 50
+set dyn_idle_i_gain = 50
+set dyn_idle_d_gain = 50
+set dyn_idle_max_increase = 150
+
+set simplified_pids_mode = RPY
+set simplified_master_multiplier = 100
+set simplified_i_gain = 100
+set simplified_d_gain = 100
+set simplified_pi_gain = 100
+set simplified_d_max_gain = 100
+set simplified_feedforward_gain = 100
+set simplified_pitch_d_gain = 100
+set simplified_pitch_pi_gain = 100
+
+set tpa_mode = D
+set tpa_rate = 65
+set tpa_breakpoint = 1350
+set tpa_low_rate = 20
+set tpa_low_breakpoint = 1050
+set tpa_low_always = OFF
+
+set ez_landing_threshold = 25
+set ez_landing_limit = 15
+set ez_landing_speed = 50


### PR DESCRIPTION
Raised off the back of the discussion in #592, where @limonspb asked whether the 2026 tune/filter defaults need updating. They do.

`presets/2025.12/tune/defaults.txt` is included by **43 tunes across 8 authors** — aos_rc (21), uav_tech (12), supafly_fpv (4), karate (2), plus openracer, blackbird, basher and Funkolius — and it is not correct on 2026.6.

### What differs

Diffing `resetPidProfile()` between the `2025.12.5` and `2026.6.1` tags gives seven differences.

**Removed in 2026.6** — applying these reports CLI errors:

| parameter |
|---|
| `abs_control_gain` |
| `abs_control_limit` |
| `abs_control_error_limit` |
| `abs_control_cutoff` |
| `transient_throttle_limit` |

`transient_throttle_limit` is gone from the source entirely; `abs_control_gain` survives only as MSP padding (`sbufWriteU8(dst, 0); // was abs_control_gain`).

**Default value changed** — the 2025.12 values are no longer the defaults:

| parameter | 2025.12 | 2026.6 |
|---|---|---|
| `d_max_gain` | 37 | 0 |
| `d_max_advance` | 20 | 35 |

### Why a new file rather than adding `2026.6` to the existing one

That second pair is the reason. Declaring `FIRMWARE_VERSION: 2026.6` on the current file would leave a preset whose stated purpose is *"Resets all Basic Tune category parameters to defaults"* silently writing two values that are not defaults on that release. That is worse than the five CLI errors, because nothing reports it.

`INCLUDE` paths carry no version conditional and metaproperties of included presets are ignored, so no single file can be correct for both releases. This follows the existing convention instead — one `defaults.txt` per version folder, as 4.3, 4.4, 4.5 and 2025.12 already do.

`presets/2025.12/tune/defaults.txt` is left untouched. It is correct for 2025.12, and removing the `abs_control_*` resets there would stop it resetting parameters that still exist on that release.

### Verification

- All 103 parameters checked against the 823 CLI names in `settings.c` plus the `PARAM_NAME_*` macros in `fc/parameter_names.h` at `2026.6.1`. Only the five above are invalid.
- Every changed struct-field default across `src/main` compared between the two tags, and the whole of `resetPidProfile()` diffed. Those seven are the complete set — the other 96 parameters and their values are unchanged.
- `node indexer/check.js` passes.
- `index.json` / `index_hash.txt` untouched, since CI regenerates them.

### What this does and does not do

It adds a correct file. It does **not** repoint any existing tune at it — every tune declaring 2026.6 still includes the 2025.12 defaults, so nothing changes for users until you decide whether tunes on 2026.6 should reset to 2026.6 defaults.

That is a call for the maintainers, and it is not free: a tune covering both 2025.12 and 2026.6 can only carry one `INCLUDE`, so adopting this would mean splitting those tunes per version, the same way they already split at 4.5 → 2025.12 for the renamed `d_min_*` / `dshot_idle_value` / `simplified_dmax_gain` parameters.

Happy to do that follow-up for my own presets, and to help with the rest if the other authors are willing. Flagging the cost rather than assuming it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the official Betaflight 2026.6 TUNE defaults preset.
  * Provides updated default settings for flight behaviour, PID tuning, motor control, arming, crash recovery, launch control, and landing assistance.
  * Includes reset warnings and preset metadata for safer configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->