### PR TITLE
Add Impetus 2 preset for Betaflight 2026.6

### DIFF
--- a/presets/2026.6/tune/Funkolius_Impetus_Frame.txt
+++ b/presets/2026.6/tune/Funkolius_Impetus_Frame.txt
@@ -1,0 +1,69 @@
+#$ TITLE: Funkolius - Impetus 2 Frame
+#$ FIRMWARE_VERSION: 2026.6
+#$ CATEGORY: TUNE
+#$ STATUS: EXPERIMENTAL
+#$ KEYWORDS: freestyle, impetus 2, impetus, micro, 2 inch, 2 in, 2", 2.2 inch prop, frame, Funkolius
+#$ AUTHOR: Funkolius
+#$ PARSER: MARKED
+#$ DESCRIPTION: <img src="https://raw.githubusercontent.com/Funkolius/firmware-presets/master/assets/funkolius-productions-preset-logo.png" alt="Funkolius Productions" width="160px" style="display: block; margin-left: auto; margin-right: auto;"/>
+#$ DESCRIPTION: Tune for the Impetus 2 frame by Funkolius.
+#$ DESCRIPTION: Bidirectional DShot is required. Make sure your ESCs are 32-bit or flashed with BlueJay for 8-bit.
+#$ DESCRIPTION: Back up your current configuration before applying this preset, then test carefully and check motor temperatures.
+#$ FORCE_OPTIONS_REVIEW: false
+
+# Use PID profile 0 so the defaults include resets the same profile the tune uses.
+profile 0
+
+#$ INCLUDE: presets/2026.6/tune/defaults.txt
+
+# -- Simplified tuning baseline --
+set simplified_master_multiplier = 120
+set simplified_i_gain = 75
+set simplified_d_gain = 120
+set simplified_pi_gain = 70
+set simplified_d_max_gain = 0
+set simplified_feedforward_gain = 60
+set simplified_pitch_d_gain = 110
+set simplified_dterm_filter = OFF
+set simplified_dterm_filter_multiplier = 100
+
+simplified_tuning apply
+
+# -- PID tuning --
+set iterm_rotation = ON
+set iterm_relax = RPY
+set iterm_relax_type = GYRO
+set iterm_relax_cutoff = 13
+set d_max_gain = 35
+set d_max_advance = 55
+
+# -- Filters --
+#$ OPTION BEGIN (CHECKED): FILTERS RECOMMENDED FOR CLEAN BUILD
+    #$ INCLUDE: presets/4.5/filters/defaults.txt
+    set gyro_lpf1_static_hz = 0
+    set gyro_lpf2_static_hz = 700
+    set dyn_notch_count = 1
+    set dyn_notch_q = 750
+    set dyn_notch_min_hz = 115
+    set gyro_lpf1_dyn_min_hz = 0
+    set simplified_gyro_filter = OFF
+
+    set dterm_lpf1_dyn_min_hz = 80
+    set dterm_lpf1_dyn_max_hz = 120
+    set dterm_lpf1_type = BIQUAD
+    set dterm_lpf2_static_hz = 0
+    # Keep disabled D-term slider state sane if the user later re-enables the slider.
+    set simplified_dterm_filter = OFF
+    set simplified_dterm_filter_multiplier = 100
+#$ OPTION END
+
+# -- Launch control (optional) --
+#$ OPTION BEGIN (UNCHECKED): LAUNCH CONTROL (PITCHONLY)
+    set launch_control_mode = PITCHONLY
+    set launch_trigger_throttle_percent = 35
+    set launch_angle_limit = 80
+    set launch_control_gain = 40
+#$ OPTION END
+
+# -- Other Requirements --
+set dshot_bidir = ON


### PR DESCRIPTION
Adds a fresh 2026.6 port for the Funkolius Impetus 2 frame.

- Preserves the 31 authored setting values from the merged 2025.12 Impetus preset
- Uses the 2026.6 tune defaults, with the shared 4.5 filter defaults inside the checked Filters option
- Validated with `npm run index`, `npm run verify`, a 2026.6.1 settings-name audit, and `git diff --check`

No authored tune-value changes are introduced in this version port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Betaflight tuning preset for the Funkolius Impetus 2 frame.
  * Includes recommended PID, filter, feedforward and launch-control settings.
  * Enables bidirectional DShot as a required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->